### PR TITLE
fix: AGREEMENT_THRESHOLD import os + default 0.0→1.0

### DIFF
--- a/graqle/plugins/mcp_server.py
+++ b/graqle/plugins/mcp_server.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import re
 import uuid
 from dataclasses import dataclass, field
@@ -1094,7 +1095,7 @@ class MCPServer:
 
         pairs_total = 0
         pairs_agreed = 0
-        AGREEMENT_THRESHOLD = float(os.environ.get("GRAQLE_AGREEMENT_THRESHOLD", "0.0"))
+        AGREEMENT_THRESHOLD = float(os.environ.get("GRAQLE_AGREEMENT_THRESHOLD", "1.0"))
 
         for i in range(len(node_ids)):
             for j in range(i + 1, len(node_ids)):


### PR DESCRIPTION
## Summary
- Added missing `import os` to mcp_server.py (NameError fix)
- Changed AGREEMENT_THRESHOLD default from 0.0 to 1.0 (pass-through when unconfigured)
- 37 mcp_predict tests now pass (was 2 failures)

## Test plan
- [x] `pytest tests/test_plugins/test_mcp_predict.py` — 37 passed
- [ ] Full CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)