### PR TITLE
chore: bump to v0.40.4 — R15 Multi-Backend Debate

### DIFF
--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.40.3"
+__version__ = "0.40.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.40.3"
+version = "0.40.4"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Proprietary — see LICENSE"}


### PR DESCRIPTION
## Summary
- Version bump from 0.40.3 to 0.40.4
- R15 Multi-Backend Debate merged via PR #19 (3-round research team review)
- All 3,181 tests passing, 588 research component tests verified, zero regressions

## Test plan
- [x] Full test suite: 3,181 passed, 0 regressions
- [x] Research components R2-R11+R15: 588 tests, 0 failures
- [x] Critical invariants: governance.py, mcp_server.py, licensing, ip_gate.yml all verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)