### PR TITLE
fix(OT-018): file reader truncation + Windows env var fallback

### DIFF
--- a/graqle/backends/api.py
+++ b/graqle/backends/api.py
@@ -28,6 +28,41 @@ logger = logging.getLogger("graqle.backends.api")
 
 # Retry configuration
 MAX_RETRIES = 3
+
+
+def _get_env_with_win_fallback(key: str) -> str:
+    """Read an environment variable with Windows registry fallback.
+
+    On Windows, env vars set via SetEnvironmentVariable('User') or
+    SetEnvironmentVariable('Machine') are only visible to processes
+    started AFTER the change.  IDE extensions (VS Code, Claude Code)
+    spawn shells before the user sets the key, so os.environ misses it.
+    This function checks the User and Machine registry as fallback.
+    """
+    value = os.environ.get(key, "")
+    if value:
+        return value
+    if os.name != "nt":
+        return ""
+    try:
+        import winreg
+        # Try User-level first, then Machine-level
+        for hive, path in [
+            (winreg.HKEY_CURRENT_USER, "Environment"),
+            (winreg.HKEY_LOCAL_MACHINE,
+             r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment"),
+        ]:
+            try:
+                with winreg.OpenKey(hive, path) as hkey:
+                    val, _ = winreg.QueryValueEx(hkey, key)
+                    if val:
+                        os.environ[key] = str(val)  # cache for future calls
+                        return str(val)
+            except (OSError, FileNotFoundError):
+                continue
+    except ImportError:
+        pass
+    return ""
 BASE_DELAY = 1.0  # seconds
 MAX_DELAY = 30.0
 
@@ -181,7 +216,7 @@ class OpenAIBackend(BaseBackend):
         max_retries: int = MAX_RETRIES,
     ) -> None:
         self._model = model
-        self._api_key = api_key or os.environ.get("OPENAI_API_KEY", "")
+        self._api_key = api_key or _get_env_with_win_fallback("OPENAI_API_KEY")
         self._client = None
         self._max_retries = max_retries
 

--- a/graqle/core/graph.py
+++ b/graqle/core/graph.py
@@ -688,7 +688,7 @@ class Graqle:
 
                 suffix = fp.suffix.lower()
                 if suffix in (".py", ".js", ".ts", ".tsx", ".jsx"):
-                    chunks = self._chunk_source_code(content, max_chunks=5)
+                    chunks = self._chunk_source_code(content)
                 else:
                     chunks = [{"text": content[:4000], "type": suffix.lstrip(".") or "text"}]
 
@@ -885,7 +885,7 @@ class Graqle:
                         if content.strip():
                             suffix = fp.suffix.lower()
                             if suffix in (".py", ".js", ".ts", ".tsx", ".jsx"):
-                                chunks = self._chunk_source_code(content, max_chunks=5)
+                                chunks = self._chunk_source_code(content)
                             else:
                                 chunks = [{"text": content[:4000], "type": suffix.lstrip(".") or "text"}]
                             if chunks:
@@ -926,11 +926,12 @@ class Graqle:
             )
 
     @staticmethod
-    def _chunk_source_code(content: str, max_chunks: int = 5) -> list[dict[str, str]]:
+    def _chunk_source_code(content: str, max_chunks: int = 15) -> list[dict[str, str]]:
         """Split source code into semantic chunks at function/class boundaries.
 
         Returns a list of ``{"text": ..., "type": ...}`` dicts, capped at
-        *max_chunks* to stay within token budgets.
+        *max_chunks* to stay within token budgets.  Raised from 5 to 15
+        (OT-018) so files up to ~600 lines are fully indexed.
         """
         import re as _re
 

--- a/graqle/plugins/mcp_dev_server.py
+++ b/graqle/plugins/mcp_dev_server.py
@@ -1400,7 +1400,7 @@ TOOL_DEFINITIONS: list[dict[str, Any]] = [
             "properties": {
                 "file_path": {"type": "string", "description": "Absolute or relative path to file"},
                 "offset": {"type": "integer", "description": "Start line (1-indexed, default 1)", "default": 1},
-                "limit": {"type": "integer", "description": "Max lines to return (default 200)", "default": 200},
+                "limit": {"type": "integer", "description": "Max lines to return (default 500)", "default": 500},
             },
             "required": ["file_path"],
         },
@@ -2023,9 +2023,9 @@ class KogniDevServer:
                     return
 
             elif backend_name == "openai":
-                from graqle.backends.api import OpenAIBackend
+                from graqle.backends.api import OpenAIBackend, _get_env_with_win_fallback
                 if not api_key:
-                    api_key = os.environ.get("OPENAI_API_KEY")
+                    api_key = _get_env_with_win_fallback("OPENAI_API_KEY")
                 if api_key:
                     graph.set_default_backend(OpenAIBackend(model=model_name, api_key=api_key))
                     logger.info("Backend: OpenAI (%s)", model_name)
@@ -4532,7 +4532,7 @@ class KogniDevServer:
             return json.dumps({"error": "Parameter 'file_path' is required."})
 
         offset = max(1, int(args.get("offset", 1)))
-        limit = min(max(1, int(args.get("limit", 200))), 2000)
+        limit = min(max(1, int(args.get("limit", 500))), 2000)
 
         fp = Path(file_path)
         if not fp.exists():


### PR DESCRIPTION
## Summary
- **OT-018 fix**: File reader default limit raised from 200 to 500 lines
- **OT-018 fix**: KG chunker max_chunks raised from 5 to 15 (~600 lines coverage)
- **NEW**: Windows registry fallback for env vars (OPENAI_API_KEY, etc.)

## Root Cause (OT-018)
graq_reason reported R15 debate modules as "absent" (0/6 components found) even though they were merged to master. Root cause: the MCP dev server's `graq_read` defaulted to 200 lines, and the graph chunker capped at 5 chunks (~200 lines). Files beyond 200 lines had their tail invisible to reasoning agents.

## Root Cause (Windows env var)
On Windows, `os.environ.get('OPENAI_API_KEY')` returns empty when the key was set via `SetEnvironmentVariable('User')` AFTER the IDE process started. The new `_get_env_with_win_fallback()` reads from the Windows registry (HKCU + HKLM) as fallback.

## Changes
| File | Change |
|------|--------|
| `mcp_dev_server.py` | `limit` default 200→500, tool description updated |
| `graph.py` | `max_chunks` default 5→15, removed hardcoded `max_chunks=5` from 2 call sites |
| `backends/api.py` | New `_get_env_with_win_fallback()`, applied to OpenAI backend |

## Test plan
- [x] 3,180 tests passed, 0 regressions
- [x] Registry fallback verified with ANTHROPIC_API_KEY (108 chars found via HKCU)
- [x] Bedrock backend unaffected (uses boto3 credential chain, not env vars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)