### PR TITLE
chore(release): v0.41.0 — PR Guardian MVP

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,21 @@ All PRs must pass `ruff check` and `ruff format --check` with zero errors.
 - **Documentation improvements** (README, docstrings, examples)
 - **New language support** (extractors for additional languages)
 
+## PR Guardian & Governance Checks
+
+All PRs to this repository are automatically analysed by PR Guardian.
+The governance engine checks for blast radius, secret exposure, and
+protected code patterns. Some outcomes to be aware of:
+
+- **Blocked PRs**: If your PR modifies trade-secret-protected patterns
+  (weight constants, scoring formulas, threshold derivations), it will
+  be unconditionally blocked. This is by design and cannot be overridden.
+  Contact the maintainers if you believe the block is in error.
+- **Advisory warnings**: PRs touching security, auth, or governance
+  modules may receive advisory warnings requiring senior review.
+- **Secret detection**: The governance engine scans diffs for
+  accidentally committed API keys, tokens, and credentials.
+
 ## What We Won't Accept
 
 - Changes that break existing tests

--- a/README.md
+++ b/README.md
@@ -321,6 +321,55 @@ Architecture-aware quality control that scales across teams without requiring ev
 
 ---
 
+## PR Guardian — governance checks on every pull request
+
+Automated blast radius analysis for PRs. PR Guardian analyses your diff
+against the project knowledge graph and reports **blast radius**,
+a **governance verdict**, and a **status badge** — directly on the PR.
+
+### GitHub Action
+
+```yaml
+# .github/workflows/graq-guardian.yml
+name: PR Guardian
+on: [pull_request]
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  guardian:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: graqle/pr-guardian@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### CLI
+
+```bash
+# Analyse a diff locally
+graq pr-guardian --diff <(git diff main...HEAD)
+
+# JSON output for CI integration
+graq pr-guardian --diff <(git diff main...HEAD) --output-format json
+```
+
+### What it shows
+
+- **Blast radius** — how many downstream modules are affected by the change
+- **Governance verdict** — pass or block, with actionable reasoning
+- **PR badge** — shields.io-compatible SVG posted as a PR comment
+- **SARIF output** — optional integration with GitHub Code Scanning
+
+PR Guardian runs the same analysis locally and in CI, so developers
+catch governance issues before review.
+
+---
+
 ## 74 MCP tools — your AI uses them automatically
 
 ```bash

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.40.7"
+__version__ = "0.41.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.40.7"
+version = "0.41.0"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Proprietary — see LICENSE"}


### PR DESCRIPTION
## v0.41.0 Release — PR Guardian MVP

Post-merge release commit for PR Guardian (merged via #30).

### Changes
- Version bump 0.40.7 -> 0.41.0
- README: PR Guardian section with GitHub Action + CLI examples (graq_review APPROVED 96%)
- CONTRIBUTING.md: TS-BLOCK governance behavior documented (graq_review APPROVED 98%)

### Verification
- 66 guardian + 206 governance = 272 tests pass, zero regression
- GraQle Senior Dev: PRODUCTION-READY at 95% confidence
- Tag v0.41.0 already pushed (will trigger CI/CD PyPI publish once this merges)
- All 8 post-merge steps completed and GraQle-verified

### No code changes
This is a release metadata commit only — version bump + documentation. No functional code changes.

Generated with [Claude Code](https://claude.com/claude-code)
