### PR TITLE
chore(release): v0.42.0 — GenerateResult, continuation loop, file visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## v0.42.0 — 2026-04-03
+
+### Added
+- **GenerateResult dataclass** — all 14 backends now return structured results with truncation detection (`truncated`, `stop_reason`, `tokens_used`, `model`). Full str backward-compat via 30+ proxied methods.
+- **Continuation loop** — `CogniNode.reason()` auto-continues truncated responses with configurable `max_continuations` (default 3) and seam deduplication.
+- **Format-aware validation** — advisory output validation for `graq_generate`: balanced delimiters, SUMMARY marker, diff hunk integrity. Non-blocking.
+- **Model output limits** — `model_limits.py` with 70+ model token limits, prefix matching, LRU cache.
+- **File visibility fixes** — `graq_edit` auto-syncs written files into KG (OT-031/ADR-134), `graq_review` resolves relative paths (OT-033), abbreviated diff detection (OT-034).
+- 60 new tests across 3 test modules.
+
+### Changed
+- **BREAKING:** `Aggregator.aggregate()` returns `tuple[str, dict]` instead of `str`. The dict contains `synthesis_truncated` and `synthesis_stop_reason`. Only 1 internal caller (Orchestrator).
+- `OrchestrationConfig` gains `max_continuations` (default 3) and `continuation_overlap_lines` (default 15).
+- `Message` dataclass gains `metadata: dict` field (default empty dict).
+
+### Fixed
+- OT-028: `graq_reason` responses no longer silently truncated at ~4000 chars.
+- OT-030: `graq_generate` produces complete output for files >300 lines via continuation.
+- OT-031: Newly edited files are auto-scanned into the KG (ADR-134).
+- OT-032: Correction cost reduced from $2.50/call to ~$0.05 via continuation loop.
+- OT-033: `graq_review` finds files regardless of working directory.
+- OT-034: `graq_review` warns on abbreviated diffs instead of producing false positives.
+- OT-035: Format validation catches structural incompleteness in generated code.
+
+---
+
+## v0.41.0 — 2026-04-02
+
+### Added
+- PR Guardian MVP — automated governance checks on pull requests.
+
+---
+
 ## v0.40.7 — 2026-04-02
 
 ### Fixed

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.41.0"
+__version__ = "0.42.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.41.0"
+version = "0.42.0"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Proprietary — see LICENSE"}


### PR DESCRIPTION
## Release v0.42.0

Version bump + CHANGELOG for 7 OTs shipped in PR #35 and #36.

### Changes
- Version: 0.41.0 -> 0.42.0
- CHANGELOG: Documents all 7 OTs, breaking change (aggregate return type), 60 new tests

### OTs Closed
OT-028, OT-030, OT-031, OT-032, OT-033, OT-034, OT-035

No code changes — version metadata only.