### PR TITLE
chore(release): v0.42.1 — content security architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## v0.42.1 — 2026-04-03
+
+### Added
+- **Content security architecture** — 5-layer detection pipeline (property-key matching, 200+ regex patterns, Shannon entropy analysis, AST credential detection, semantic placeholder) classifies every node with a sensitivity level before content enters reasoning.
+- **7 exit gates** — content redaction enforced at every path from KG to external APIs: LLM reasoning, chunk synthesis, description enrichment, embedding, code generation, code review/debug, and query reformulation.
+- **Cryptographic audit trail** — SHA-256 content hashes (pre/post redaction), append-only JSONL security audit log, dry-run mode for verification before sending.
+- **Sensitivity-aware embedding** — typed placeholders (e.g., `<API_KEY_VALUE>`) preserve vector quality while redacting actual values. SECRET content blocked from cloud embedding entirely.
+- **Shannon entropy detector** — catches novel/custom secret formats not matching known regex patterns.
+- `graqle/security/` package — sensitivity classifier, content gate, audit, entropy detector (932 lines).
+- `graqle/core/redaction.py` — property-level redaction utilities (145 lines).
+- 85 new tests (47 security architecture + 38 redaction).
+
+### Security
+- All 7 gates fail-CLOSED: if security module fails to load, content is NOT sent to external providers.
+- Deep-copy node isolation prevents concurrent reasoning calls from corrupting each other's state.
+- SECURITY.md updated with accurate description of content security architecture.
+- Send-time overhead: ~7ms (negligible against 500ms-5s LLM API latency).
+
+---
+
 ## v0.42.0 — 2026-04-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ Every change is impact-analysed, gate-checked, and taught back — automatically
 [![PyPI](https://img.shields.io/pypi/v/graqle?color=%2306b6d4&label=PyPI)](https://pypi.org/project/graqle/)
 [![Downloads](https://img.shields.io/pypi/dw/graqle?color=%2306b6d4&label=downloads%2Fweek)](https://pypi.org/project/graqle/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-06b6d4.svg)](https://python.org)
-[![Tests: 1,569+](https://img.shields.io/badge/tests-1%2C569%2B%20passing-06b6d4.svg)]()
+[![Tests: 3,320+](https://img.shields.io/badge/tests-3%2C320%2B%20passing-06b6d4.svg)]()
 [![LLM Backends: 14](https://img.shields.io/badge/LLM%20backends-14-06b6d4.svg)]()
 [![MCP Tools: 74](https://img.shields.io/badge/MCP%20tools-74-06b6d4.svg)]()
 [![Model Agnostic](https://img.shields.io/badge/model-agnostic-06b6d4.svg)]()
-[![VS Code Extension](https://img.shields.io/badge/VS%20Code-v0.3.0-06b6d4.svg)](https://marketplace.visualstudio.com/items?itemName=graqle.graqle-vscode)
+[![Content Security](https://img.shields.io/badge/content%20security-7%20gates-06b6d4.svg)]()
+[![VS Code Extension](https://img.shields.io/badge/VS%20Code-v0.3.5-06b6d4.svg)](https://marketplace.visualstudio.com/items?itemName=graqle.graqle-vscode)
 
 ```bash
 pip install graqle && graq scan repo . && graq run "find every security bug in this codebase"
@@ -35,19 +36,25 @@ pip install graqle && graq scan repo . && graq run "find every security bug in t
 
 ## What's New
 
-### SDK v0.40.7
+### SDK v0.42.1 — Content Security Architecture
 
-- **R15 Multi-Backend Debate** — optional multi-LLM debate mode: propose/challenge/synthesize across providers. 4 patent claims. Governance-first design.
-- **graq_review dogfooding** — GraQle's own code review tool found 4 BLOCKERs + 3 MAJORs in the debate module that unit tests missed. All fixed.
-- **OT-018 file reader fix** — `graq_read` no longer truncates files on Windows. Environment variable fallback for Windows Store Python.
-- **3 live OpenAI debates** — full evidence report demonstrating cross-provider reasoning with GPT-5.4 vs Claude Sonnet 4.6.
-- **14,959 node KG** — largest production graph to date.
+- **7 exit gates** — every path from your knowledge graph to external LLM/embedding providers is now gated with automatic content redaction. Credentials, API keys, tokens, and connection strings are caught and replaced before leaving your machine.
+- **5-layer detection** — property-key matching, 200+ regex patterns, Shannon entropy analysis, AST credential detection, and semantic classification. Catches secrets that static analysis misses.
+- **Cryptographic audit trail** — SHA-256 content hashes prove what was sent vs. what was redacted. Append-only JSONL audit log for compliance.
+- **Sensitivity-aware embedding** — typed placeholders preserve vector quality while redacting actual values. SECRET content never leaves your machine.
+- **3,320+ tests passing** across Python 3.10, 3.11, 3.12. 85 new security-specific tests.
 
-### VS Code Extension v0.3.0
+### SDK v0.42.0 — GenerateResult + Continuation Loop
 
-- **Credential Forwarding** — AWS, Anthropic, and OpenAI credentials forwarded securely via allowlist-only environment
-- **Project-Scoping** — each workspace loads its own knowledge graph; workspace changes restart MCP with correct config
-- **Error Surfacing** — backend errors surface as actionable messages instead of silent swallowing
+- **GenerateResult** — all 14 backends return structured results with truncation detection.
+- **Continuation loop** — auto-continues truncated LLM responses with seam deduplication.
+- **Format validation** — advisory output checks for `graq_generate`.
+- **File visibility** — `graq_edit` auto-syncs to KG, `graq_review` resolves paths correctly.
+
+### VS Code Extension v0.3.5
+
+- **Content security gates** active in all MCP tool calls
+- Credential forwarding, project scoping, error surfacing (from v0.3.0)
 - **Security Hardening** — `shell:false` on all subprocess spawns, CSP nonce on WebView, secret redaction in logs
 
 [Install VS Code Extension](https://marketplace.visualstudio.com/items?itemName=graqle.graqle-vscode) | See the full [Changelog](https://github.com/quantamixsol/graqle/blob/master/CHANGELOG.md)

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.42.0"
+__version__ = "0.42.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.42.0"
+version = "0.42.1"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Proprietary — see LICENSE"}


### PR DESCRIPTION
## Summary

Version bump to v0.42.1. Updates CHANGELOG and README with content security architecture details from PR #38.

- Bump `pyproject.toml` + `__version__.py` to 0.42.1
- CHANGELOG: security architecture entry (7 gates, 5-layer detection, audit trail)
- README: updated What's New, test count badge (3,320+), content security badge

## Test plan

- [x] 219 core tests pass after version bump
- [x] No code changes — version, docs, and badges only

🤖 Generated with [Claude Code](https://claude.com/claude-code)