### PR TITLE
fix: v0.43.1 — think-tag fallback for reasoning models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## v0.43.1 — 2026-04-05
+
+### Fixed
+- **Think-tag fallback for reasoning models** — Models like DeepSeek-R1 and Gemma4 that wrap entire output in `<think>...</think>` tags no longer produce empty responses. When stripping think tags produces empty text, falls back to the last think block's content. Zero regression for models that produce content outside tags.
+
+---
+
 ## v0.43.0 — 2026-04-05
 
 ### Added — GNIE (GraQle-Native Inference Enhancement)

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.43.0"
+__version__ = "0.43.1"

--- a/graqle/backends/api.py
+++ b/graqle/backends/api.py
@@ -579,12 +579,20 @@ class OllamaBackend(BaseBackend):
                 response.raise_for_status()
                 data = response.json()
                 text = data.get("response", "")
-                # Strip <think>...</think> tags from reasoning models (DeepSeek-R1)
+                # Strip <think>...</think> tags from reasoning models (DeepSeek-R1, Gemma4)
+                # Fallback: if stripping produces empty, use last think block content
                 if "<think>" in text:
                     import re
-                    text = re.sub(
-                        r"<think>.*?</think>\s*", "", text, flags=re.DOTALL
+                    think_blocks = re.findall(
+                        r"<think>(.*?)</think>", text, flags=re.DOTALL
                     )
+                    stripped = re.sub(
+                        r"<think>.*?</think>\s*", "", text, flags=re.DOTALL
+                    ).strip()
+                    if stripped:
+                        text = stripped
+                    elif think_blocks:
+                        text = think_blocks[-1].strip()
                 # OT-028: Capture done_reason for truncation detection
                 done_reason = data.get("done_reason", "") or ""
                 truncated = done_reason == "length"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.43.0"
+version = "0.43.1"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Proprietary — see LICENSE"}


### PR DESCRIPTION
## Summary
- DeepSeek-R1 and Gemma4 models wrap entire output in `<think>...</think>` tags
- After stripping, output was empty (0 chars) — breaking reasoning pipeline
- Fix: fall back to last think block content when stripping produces empty
- Zero regression for models with content outside tags

## Origin
- Private PR #23 (research-development-graqle) — merged to R15-clean
- Sanitized squash to public per ADR-149

## Version
- `0.43.0` -> `0.43.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)