### PR TITLE
fix(tests): JSON-serializable mock nodes for graq_generate

### DIFF
--- a/tests/test_generation/test_graq_generate.py
+++ b/tests/test_generation/test_graq_generate.py
@@ -35,10 +35,22 @@ class _MockReasoningResult:
         return len(self.active_nodes)
 
 
+class _MockNode:
+    """JSON-serializable mock node (MagicMock fails JSON serialization)."""
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        self.id = kwargs.get("label", "mock")
+        self.properties = {}
+        self.chunks = [{"content": kwargs.get("description", "")}]
+        self.file_path = None
+        self.start_line = None
+        self.end_line = None
+
+
 def _build_mock_graph() -> MagicMock:
     graph = MagicMock()
     graph.nodes = {
-        "SyncEngine": MagicMock(label="SyncEngine", entity_type="Class", description="Cloud sync"),
+        "SyncEngine": _MockNode(label="SyncEngine", entity_type="Class", description="Cloud sync"),
     }
     graph.edges = {}
     graph.areason = AsyncMock(return_value=_MockReasoningResult())

--- a/tests/test_generation/test_graq_generate_streaming.py
+++ b/tests/test_generation/test_graq_generate_streaming.py
@@ -25,6 +25,22 @@ def _build_mock_server():
     # Mock graph that supports both areason and areason_stream
     mock_graph = MagicMock()
 
+    # JSON-serializable mock node (MagicMock fails JSON serialization)
+    class _MockNode:
+        def __init__(self, **kw):
+            self.__dict__.update(kw)
+            self.id = kw.get("label", "mock")
+            self.properties = {}
+            self.chunks = [{"content": kw.get("description", "")}]
+            self.file_path = None
+            self.start_line = None
+            self.end_line = None
+
+    mock_graph.nodes = {
+        "FooModule": _MockNode(label="FooModule", entity_type="PythonModule", description="test module"),
+    }
+    mock_graph.edges = {}
+
     # areason returns a structured ReasoningResult-like object
     mock_result = MagicMock()
     mock_result.answer = "--- a/foo.py\n+++ b/foo.py\n@@ -1,1 +1,2 @@\n+# added\n SUMMARY: Added comment"


### PR DESCRIPTION
## Summary

Follow-up to PR #54. The generate test mocks use MagicMock for graph nodes, which fails `json.dumps()` serialization. Replace with `_MockNode` class that has proper string/dict attributes.

Fixes 6 remaining CI failures across Python 3.10/3.11/3.12.

## Test plan

- [ ] CI green on all 3 Python versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)