### PR TITLE
fix(tests): complete graq_generate mocks for OT-054 + Senior reviewed

### DIFF
--- a/tests/test_generation/test_graq_generate.py
+++ b/tests/test_generation/test_graq_generate.py
@@ -60,6 +60,11 @@ def _build_mock_graph() -> MagicMock:
     mock_backend.name = "mock"
     mock_backend.cost_per_1k_tokens = 0.0
     graph._get_backend_for_node = MagicMock(return_value=mock_backend)
+    # _activate_subgraph returns a list of node IDs (strings)
+    graph._activate_subgraph = MagicMock(return_value=["SyncEngine"])
+    # config.activation.strategy used in _activate_subgraph call
+    graph.config = MagicMock()
+    graph.config.activation.strategy = "chunk"
     return graph
 
 

--- a/tests/test_generation/test_graq_generate_streaming.py
+++ b/tests/test_generation/test_graq_generate_streaming.py
@@ -68,6 +68,11 @@ def _build_mock_server():
     mock_backend.cost_per_1k_tokens = 0.0
     mock_graph._get_backend_for_node = MagicMock(return_value=mock_backend)
 
+    # _activate_subgraph returns a list of node IDs
+    mock_graph._activate_subgraph = MagicMock(return_value=["FooModule"])
+    mock_graph.config = MagicMock()
+    mock_graph.config.activation.strategy = "chunk"
+
     server._graph = mock_graph
 
     return server
@@ -98,8 +103,9 @@ async def test_stream_false_returns_no_chunks(server):
 
 
 @pytest.mark.asyncio
-async def test_stream_true_populates_chunks(server):
-    """stream=True → metadata.chunks contains the streamed text pieces."""
+async def test_stream_true_ignored_after_ot054(server):
+    """OT-054: stream=True is now ignored — single-shot backend call.
+    metadata.chunks is empty and stream flag is False."""
     with patch("graqle.plugins.mcp_dev_server.KogniDevServer._handle_preflight",
                new=AsyncMock(return_value='{"risk_level":"low","warnings":[]}')), \
          patch("graqle.plugins.mcp_dev_server.KogniDevServer._handle_safety_check",
@@ -112,13 +118,13 @@ async def test_stream_true_populates_chunks(server):
     if "error" not in data:
         chunks = data["metadata"]["chunks"]
         assert isinstance(chunks, list)
-        assert len(chunks) >= 1
-        assert data["metadata"]["stream"] is True
+        # OT-054: streaming disabled, chunks are empty
+        assert chunks == []
 
 
 @pytest.mark.asyncio
-async def test_stream_true_chunks_join_to_non_empty(server):
-    """stream=True → joining chunks produces non-empty text."""
+async def test_stream_true_still_returns_patches(server):
+    """OT-054: even with stream=True, patches are returned via single-shot."""
     with patch("graqle.plugins.mcp_dev_server.KogniDevServer._handle_preflight",
                new=AsyncMock(return_value='{"risk_level":"low","warnings":[]}')), \
          patch("graqle.plugins.mcp_dev_server.KogniDevServer._handle_safety_check",
@@ -129,8 +135,7 @@ async def test_stream_true_chunks_join_to_non_empty(server):
 
     data = json.loads(raw)
     if "error" not in data:
-        chunks = data["metadata"]["chunks"]
-        assert "".join(chunks).strip() != ""
+        assert "patches" in data
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Complete fix for CI failures in graq_generate tests:
- `_activate_subgraph` mock returns proper node ID list
- `graph.config.activation.strategy` mocked as "chunk" string
- Streaming tests updated: OT-054 made streaming single-shot, assertions reflect new behavior
- **Senior reviewed at 87% confidence** — findings addressed

## Root cause

OT-054 (private commit) changed `_handle_generate` from multi-agent `areason` to direct `backend.generate()`. The test mocks weren't updated for the new code path. This surfaced when 25 private commits were squash-merged to public in PR #53.

## Verified locally

14/14 generate tests pass. 232 workflow tests pass.

## Test plan

- [ ] CI green on all 3 Python versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)