### PR TITLE
fix(tests): update tool count 120→122 in 2 missed test files

### DIFF
--- a/tests/test_plugins/test_mcp_dev_server_v015.py
+++ b/tests/test_plugins/test_mcp_dev_server_v015.py
@@ -86,7 +86,7 @@ def server():
 
 class TestToolDefinitionsV015:
     def test_tools_defined(self):
-        assert len(TOOL_DEFINITIONS) == 120  # +4: graq_github_pr/diff + kogni aliases (HFCI-001+002)
+        assert len(TOOL_DEFINITIONS) == 122  # +4: graq_github_pr/diff + kogni aliases (HFCI-001+002) +2: graq_auto + kogni_auto
 
     def test_reload_tool_exists(self):
         names = {t["name"] for t in TOOL_DEFINITIONS}

--- a/tests/test_plugins/test_phantom.py
+++ b/tests/test_plugins/test_phantom.py
@@ -608,7 +608,7 @@ class TestZeroRegression:
         # graq_reload + graq_audit are graq_* only (no kogni_* alias) → 49 graq + 49 kogni = 98
         assert len(graq_tools) >= 38, f"graq_* tools must not decrease, got {len(graq_tools)}"
         assert len(kogni_tools) >= 36, f"kogni_* tools must not decrease, got {len(kogni_tools)}"
-        assert len(TOOL_DEFINITIONS) == 120, f"Expected 120 total tools, got {len(TOOL_DEFINITIONS)}"  # +4: graq_github_pr/diff + kogni aliases (HFCI-001+002)
+        assert len(TOOL_DEFINITIONS) == 122, f"Expected 122 total tools, got {len(TOOL_DEFINITIONS)}"  # +4: graq_github_pr/diff + kogni aliases (HFCI-001+002)
 
     def test_existing_tool_schemas_unchanged(self):
         """Spot-check that existing tool schemas were not modified."""


### PR DESCRIPTION
## Summary
- `test_mcp_dev_server_v015.py` and `test_phantom.py` still asserted `== 120` tools
- Actual count is 122 after graq_auto + kogni_auto were added in v0.44.1
- CI Python 3.11 failed with `assert 122 == 120`

## Test plan
- [ ] CI passes (all 3 tool count assertions now say 122)

🤖 Generated with [Claude Code](https://claude.com/claude-code)