### PR TITLE
fix(tests): last tool count 120→122 in test_tools_defined

### DIFF
--- a/tests/test_plugins/test_mcp_dev_server.py
+++ b/tests/test_plugins/test_mcp_dev_server.py
@@ -120,7 +120,7 @@ def server(mock_graph):
 
 class TestToolDefinitions:
     def test_tools_defined(self):
-        assert len(TOOL_DEFINITIONS) == 120  # +4: graq_github_pr/diff + kogni aliases (HFCI-001+002)
+        assert len(TOOL_DEFINITIONS) == 122  # +4: graq_github_pr/diff + kogni aliases (HFCI-001+002) +2: graq_auto + kogni_auto
 
     def test_expected_tool_names(self):
         names = {t["name"] for t in TOOL_DEFINITIONS}


### PR DESCRIPTION
## Summary
- Last remaining `assert len(TOOL_DEFINITIONS) == 120` in `test_mcp_dev_server.py::TestToolDefinitions::test_tools_defined`
- Comprehensive scan confirms zero remaining `== 120` tool count assertions

## Self-correction
This is the 3rd fix for the same class of bug. Root cause: did not run `grep -rn "== 120" tests/` comprehensively before each prior fix commit. This pattern is now documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)