### PR TITLE
hotfix(sdk): v0.46.9 — OT-060/061/062 (NEO4J_DISABLED, MCP gates, S3 dedupe)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## [0.46.9] — 2026-04-10
+
+### Fixed
+- **OT-060: NEO4J_DISABLED env var gate** in `graqle/core/graph.py` — `Graqle.from_neo4j()` and `Graqle.to_neo4j()` now respect the `NEO4J_DISABLED` env var (truthy: `1`, `true`, `yes`, `on`). When set, both methods raise `RuntimeError` BEFORE importing `Neo4jConnector` or dialing `bolt://`. Zero dials, zero retries. Existing caller `try/except → JSON fallback` contract preserved. Unblocks VS Code MCP server, CI jobs, and Lambda hosts that cannot tolerate slow bolt handshakes. **Neo4j remains a first-class power-user feature** — this is a per-process override, not a feature removal. Once-per-process WARNING via module-level sentinel. 6 new tests in `TestNeo4jDisabledEnvVar`.
+- **OT-062: Session-scoped MCP gate bypasses for graqle-vscode** in `graqle/plugins/mcp_dev_server.py` — the `initialize` JSON-RPC handler now reads `clientInfo.name` and, when it equals `"graqle-vscode"`, sets per-instance `_cg01_bypass`, `_cg02_bypass`, `_cg03_bypass` flags. The CG-01 (session_started), CG-02 (plan_active), and CG-03 (edit_enforcement) gates honor these flags. State is naturally session-scoped because each `KogniDevServer` instance is one MCP stdio process; concurrent non-graqle-vscode clients run in their own instances and are unaffected. **Fail-closed default**: missing or unrecognized `clientInfo` → gates remain ON. 5 new tests in `TestInitializeClientInfoBypass`.
+- **OT-061: S3 AccessDenied dedupe** in `graqle/core/kg_sync.py` — added `_is_access_denied()`, `_log_s3_error()`, `_reset_access_denied_dedupe()` helpers and a module-level `_access_denied_logged` sentinel. AccessDenied errors are now logged ONCE per process at WARNING; non-AccessDenied S3 errors continue to log at ERROR per occurrence. Replaces 3 noisy `logger.warning` sites in `pull_if_newer` and `_push_worker`. 5 new tests in `TestAccessDeniedDedupe`, including the headline test "10 AccessDenied errors → 1 log line".
+
+### Notes
+- 16 new tests added across `test_graph.py`, `test_mcp_dev_server.py`, and `test_kg_sync.py`. All 91 pre-existing tests continue to pass (107 total green, zero regressions).
+
+---
+
 ## [0.46.0] — 2026-04-07
 
 ### Added

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.46.8"
+__version__ = "0.46.9"

--- a/graqle/core/graph.py
+++ b/graqle/core/graph.py
@@ -33,6 +33,45 @@ from graqle.core.types import (
 logger = logging.getLogger("graqle")
 
 
+# OT-060: Process-scoped Neo4j escape hatch via NEO4J_DISABLED env var.
+# Purpose: let hosts with tight handshake deadlines (VS Code MCP server,
+# CI jobs, Lambda) tell graQle to skip bolt:// dials entirely for this
+# process. Neo4j remains a first-class power-user storage + reasoning
+# backend — this is a per-process override, not a feature removal.
+_neo4j_disabled_warned: bool = False
+
+
+def _neo4j_disabled() -> bool:
+    """Return True iff the NEO4J_DISABLED env var is set to a truthy value.
+
+    Truthy values: "1", "true", "yes", "on" (case-insensitive, whitespace-trimmed).
+    All other values (unset, empty, "0", "false", "no", "off", etc.) return False.
+
+    Evaluated on every call — not cached — so tests can monkeypatch the env
+    var between assertions and the SDK honors runtime env changes.
+    """
+    import os
+    return os.environ.get("NEO4J_DISABLED", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _emit_neo4j_disabled_warning() -> None:
+    """Log a single WARNING per process when the NEO4J_DISABLED gate fires.
+
+    Best-effort single-emission semantics using a module-level bool. In CPython
+    the GIL makes the check-and-set atomic enough for a logging purpose; we
+    accept the theoretical possibility of a duplicate warning under extreme
+    concurrent first-fire conditions.
+    """
+    global _neo4j_disabled_warned
+    if not _neo4j_disabled_warned:
+        logger.warning(
+            "Neo4j backend disabled for this process via NEO4J_DISABLED=true. "
+            "Graph loaded from JSON fallback. This is a process-scoped override; "
+            "Neo4j remains fully supported. See `graq upgrade neo4j`."
+        )
+        _neo4j_disabled_warned = True
+
+
 def _acquire_lock(lock_path: str):
     """Acquire a cross-platform file lock. Returns the lock file descriptor.
 
@@ -526,6 +565,21 @@ class Graqle:
         Loads nodes and edges via Cypher, attaches chunks as node properties,
         and stores the connector for runtime Cypher vector search.
         """
+        # OT-060: Process-scoped escape hatch. When NEO4J_DISABLED=true,
+        # raise before importing Neo4jConnector or dialing bolt://.
+        # Zero dials, zero retries. Callers already wrap this in try/except
+        # and fall back to JSON, so the existing graceful-degradation
+        # contract is preserved.
+        if _neo4j_disabled():
+            _emit_neo4j_disabled_warning()
+            raise RuntimeError(
+                "Neo4j backend is disabled for this process (NEO4J_DISABLED=true). "
+                "Your graph is still available via the local graqle.json file. "
+                "To re-enable Neo4j, unset NEO4J_DISABLED in your environment. "
+                "Neo4j remains fully supported for users who want a local graph DB — "
+                "see `graq upgrade neo4j`."
+            )
+
         from graqle.connectors.neo4j import Neo4jConnector
 
         cfg = config or GraqleConfig.default()
@@ -598,6 +652,19 @@ class Graqle:
             embed_fn: Optional callable(text) -> list[float] for chunk embeddings.
                       If None, chunks are written without embeddings.
         """
+        # OT-060: Process-scoped escape hatch. When NEO4J_DISABLED=true,
+        # raise before importing Neo4jConnector or dialing bolt://.
+        # Use Graqle.to_json() to export locally instead.
+        if _neo4j_disabled():
+            _emit_neo4j_disabled_warning()
+            raise RuntimeError(
+                "Neo4j backend is disabled for this process (NEO4J_DISABLED=true). "
+                "Your graph is still available via the local graqle.json file. "
+                "To re-enable Neo4j, unset NEO4J_DISABLED in your environment. "
+                "Use Graqle.to_json() to export locally, or see `graq upgrade neo4j` "
+                "to set up a local Neo4j instance."
+            )
+
         from graqle.connectors.neo4j import Neo4jConnector
 
         connector = Neo4jConnector(

--- a/graqle/core/kg_sync.py
+++ b/graqle/core/kg_sync.py
@@ -41,6 +41,47 @@ PUSH_DEBOUNCE_SECS: float = 5.0   # max one push per path per N seconds
 PULL_TIMEOUT_SECS: float = 3.0    # max seconds to wait for S3 on startup
 S3_BUCKET = "graqle-graphs-eu"
 
+# OT-061: Session-scoped AccessDenied dedupe.
+# Goal: log AccessDenied ONCE per process at WARNING, not per occurrence.
+# Other S3 errors continue to be logged at ERROR per occurrence.
+_access_denied_logged: bool = False
+
+
+def _is_access_denied(exc: BaseException) -> bool:
+    """Return True iff exc is a botocore ClientError with AccessDenied code."""
+    try:
+        import botocore.exceptions
+        if not isinstance(exc, botocore.exceptions.ClientError):
+            return False
+        code = exc.response.get("Error", {}).get("Code", "")
+        return code in ("AccessDenied", "AccessDeniedException", "403")
+    except Exception:
+        return False
+
+
+def _log_s3_error(operation: str, exc: BaseException) -> None:
+    """Log an S3 error with AccessDenied dedupe.
+
+    AccessDenied: WARNING once per process, then silenced.
+    Other errors: ERROR per occurrence.
+    """
+    global _access_denied_logged
+    if _is_access_denied(exc):
+        if not _access_denied_logged:
+            logger.warning(
+                "KG %s: S3 AccessDenied. Check IAM permissions for bucket %s. Further AccessDenied warnings suppressed for this process. Error: %s",
+                operation, S3_BUCKET, exc,
+            )
+            _access_denied_logged = True
+    else:
+        logger.error("KG %s failed: %s", operation, exc)
+
+
+def _reset_access_denied_dedupe() -> None:
+    """Reset the dedupe sentinel. For tests only."""
+    global _access_denied_logged
+    _access_denied_logged = False
+
 
 # ---------------------------------------------------------------------------
 # Data classes
@@ -253,7 +294,8 @@ def pull_if_newer(
     except ImportError:
         return PullResult(reason="boto3 not available")
     except Exception as exc:
-        logger.warning("KG pull failed (non-fatal): %s", exc)
+        # OT-061: dedupe AccessDenied at WARNING, log other errors at ERROR
+        _log_s3_error("pull", exc)
         return PullResult(reason=f"error: {exc}")
 
 
@@ -333,12 +375,13 @@ def _push_worker(local_path: Path, project: str | None, retry_on_error: bool = T
         except ImportError:
             return  # boto3 not available — skip silently
         except Exception as exc:
+            # OT-061: dedupe AccessDenied at WARNING, log other errors at ERROR
             if attempt == 1 and retry_on_error:
-                logger.warning("KG push attempt 1 failed: %s — retrying", exc)
+                _log_s3_error("push (retrying)", exc)
                 time.sleep(1.0)
             else:
-                logger.warning("KG push failed%s: %s",
-                               " after 2 attempts" if retry_on_error else "", exc)
+                _suffix = " after 2 attempts" if retry_on_error else ""
+                _log_s3_error("push" + _suffix, exc)
 
 
 # ---------------------------------------------------------------------------

--- a/graqle/plugins/mcp_dev_server.py
+++ b/graqle/plugins/mcp_dev_server.py
@@ -2203,6 +2203,16 @@ class KogniDevServer:
         # CG-01/02: Protocol enforcement state
         self._session_started: bool = False  # Set True by graq_lifecycle(session_start)
         self._plan_active: bool = False      # Set True by graq_plan
+        # OT-062: Per-MCP-session gate bypasses for VS Code extension.
+        # Set by the initialize handler when clientInfo.name == "graqle-vscode".
+        # Fail-closed default: bypasses are False. Each KogniDevServer instance
+        # is one MCP session (one stdio process), so this state is naturally
+        # session-scoped — concurrent non-graqle-vscode clients run in their
+        # own KogniDevServer instances and are unaffected.
+        self._mcp_client_name: str | None = None
+        self._cg01_bypass: bool = False  # Skip session_started check
+        self._cg02_bypass: bool = False  # Skip plan_active check
+        self._cg03_bypass: bool = False  # Skip edit_enforcement on .py files
         # v0.46.4: graq_todo session state
         self._todos: list[dict[str, Any]] = []
         # B4: Session cache for cross-tool context reuse (v0.42.2 hotfix)
@@ -2986,7 +2996,8 @@ class KogniDevServer:
             # Exempt: graq_lifecycle (needed to start session), graq_inspect (read-only diagnostics)
             _CG01_EXEMPT = {"graq_lifecycle", "kogni_lifecycle", "graq_inspect", "kogni_inspect"}
             if getattr(_governance, "session_gate_enabled", False):
-                if not getattr(self, "_session_started", False) and name not in _CG01_EXEMPT:
+                # OT-062: graqle-vscode bypass — skip if initialize handler set _cg01_bypass
+                if not getattr(self, "_session_started", False) and name not in _CG01_EXEMPT and not getattr(self, "_cg01_bypass", False):
                     logger.warning("CG-01 BLOCKED: '%s' before session_start", name)
                     err = json.dumps({
                         "error": "CG-01_SESSION_GATE",
@@ -3006,7 +3017,8 @@ class KogniDevServer:
                 "graq_lifecycle", "kogni_lifecycle",
             }
             if getattr(_governance, "plan_mandatory", False):
-                if name in _WRITE_TOOLS and name not in _CG02_EXEMPT and not getattr(self, "_plan_active", False):
+                # OT-062: graqle-vscode bypass — skip if initialize handler set _cg02_bypass
+                if name in _WRITE_TOOLS and name not in _CG02_EXEMPT and not getattr(self, "_plan_active", False) and not getattr(self, "_cg02_bypass", False):
                     logger.warning("CG-02 BLOCKED: write tool '%s' without prior graq_plan", name)
                     err = json.dumps({
                         "error": "CG-02_PLAN_GATE",
@@ -3023,7 +3035,8 @@ class KogniDevServer:
             # When enabled, graq_write is blocked for .py/.ts/.js/.tsx files (code files).
             # Use graq_edit instead — it runs preflight + governance + diff application.
             if getattr(_governance, "edit_enforcement", False):
-                if name in ("graq_write", "kogni_write"):
+                # OT-062: graqle-vscode bypass — skip if initialize handler set _cg03_bypass
+                if name in ("graq_write", "kogni_write") and not getattr(self, "_cg03_bypass", False):
                     _target = arguments.get("file_path", "")
                     _CODE_EXTS = {".py", ".ts", ".js", ".tsx", ".jsx", ".go", ".rs", ".java"}
                     if any(_target.endswith(ext) for ext in _CODE_EXTS):
@@ -8289,6 +8302,32 @@ class KogniDevServer:
         # ---- MCP lifecycle methods ------------------------------------
 
         if method == "initialize":
+            # OT-062: Detect graqle-vscode client and set per-session gate bypasses.
+            # The VS Code extension manages its own governance flow and needs to
+            # bypass CG-01 (session_started), CG-02 (plan_active), and CG-03
+            # (edit_enforcement) to deliver a smooth UX without round-tripping
+            # graq_lifecycle/graq_plan from the extension layer.
+            # Fail-closed: missing or unrecognized clientInfo → gates ON.
+            try:
+                _client_info = params.get("clientInfo", {}) if isinstance(params, dict) else {}
+                _client_name = _client_info.get("name", "") if isinstance(_client_info, dict) else ""
+                self._mcp_client_name = _client_name or None
+                if _client_name == "graqle-vscode":
+                    self._cg01_bypass = True
+                    self._cg02_bypass = True
+                    self._cg03_bypass = True
+                    logger.info("OT-062: graqle-vscode clientInfo detected — CG-01/02/03 gates bypassed for this MCP session")
+                else:
+                    # Fail-closed default for any other client (or missing clientInfo)
+                    self._cg01_bypass = False
+                    self._cg02_bypass = False
+                    self._cg03_bypass = False
+            except Exception as _e:
+                logger.warning("OT-062: failed to parse clientInfo: %s — gates remain ON", _e)
+                self._cg01_bypass = False
+                self._cg02_bypass = False
+                self._cg03_bypass = False
+
             # v0.46.8: Start background KG loading — do NOT block the handshake.
             # The 534 MB graph loads in a daemon thread; tool calls wait if needed.
             self._start_kg_load_background()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.46.8"
+version = "0.46.9"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Proprietary — see LICENSE"}

--- a/tests/test_cloud/test_kg_sync.py
+++ b/tests/test_cloud/test_kg_sync.py
@@ -690,3 +690,113 @@ class TestOfflineModeNoErrors:
         monkeypatch.setenv("GRAQLE_OFFLINE", "1")
         success, _, _ = download_graph(tmp_path / "g.json", "proj", "hash")
         assert success is False  # graceful failure, no exception
+
+
+class TestAccessDeniedDedupe:
+    """OT-061: AccessDenied dedupe — logged ONCE per process at WARNING.
+
+    Non-AccessDenied S3 errors continue to be logged at ERROR per occurrence.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_dedupe(self):
+        """Reset the module-level dedupe sentinel before AND after each test."""
+        from graqle.core.kg_sync import _reset_access_denied_dedupe
+        _reset_access_denied_dedupe()
+        yield
+        _reset_access_denied_dedupe()
+
+    def _make_access_denied_error(self):
+        """Build a botocore ClientError with AccessDenied code."""
+        try:
+            import botocore.exceptions
+        except ImportError:
+            pytest.skip("botocore not installed")
+        return botocore.exceptions.ClientError(
+            error_response={"Error": {"Code": "AccessDenied", "Message": "denied"}},
+            operation_name="PutObject",
+        )
+
+    def _make_other_error(self):
+        """Build a botocore ClientError with a non-AccessDenied code."""
+        try:
+            import botocore.exceptions
+        except ImportError:
+            pytest.skip("botocore not installed")
+        return botocore.exceptions.ClientError(
+            error_response={"Error": {"Code": "InternalError", "Message": "boom"}},
+            operation_name="PutObject",
+        )
+
+    def test_is_access_denied_recognizes_AccessDenied_code(self):
+        """_is_access_denied returns True for ClientError with AccessDenied code."""
+        from graqle.core.kg_sync import _is_access_denied
+        assert _is_access_denied(self._make_access_denied_error()) is True
+
+    def test_is_access_denied_returns_False_for_other_codes(self):
+        """_is_access_denied returns False for non-AccessDenied ClientError and other exceptions."""
+        from graqle.core.kg_sync import _is_access_denied
+        assert _is_access_denied(self._make_other_error()) is False
+        assert _is_access_denied(ValueError("boom")) is False
+        assert _is_access_denied(RuntimeError("nope")) is False
+
+    def test_ten_access_denied_errors_produce_one_log_line(self, caplog):
+        """Session prompt requirement: 10 synthetic AccessDenied errors → 1 log line total."""
+        import logging
+        from graqle.core.kg_sync import _log_s3_error
+        err = self._make_access_denied_error()
+
+        with caplog.at_level(logging.WARNING, logger="graqle.core.kg_sync"):
+            for _ in range(10):
+                _log_s3_error("push", err)
+
+        warning_records = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "AccessDenied" in r.getMessage()
+        ]
+        assert len(warning_records) == 1, (
+            f"Expected exactly 1 warning across 10 AccessDenied errors, "
+            f"got {len(warning_records)}"
+        )
+
+    def test_non_access_denied_errors_logged_per_occurrence_at_error(self, caplog):
+        """Non-AccessDenied errors fire ERROR every time, not deduped."""
+        import logging
+        from graqle.core.kg_sync import _log_s3_error
+        err = self._make_other_error()
+
+        with caplog.at_level(logging.ERROR, logger="graqle.core.kg_sync"):
+            for _ in range(5):
+                _log_s3_error("push", err)
+
+        error_records = [
+            r for r in caplog.records
+            if r.levelno == logging.ERROR
+            and "InternalError" in r.getMessage()
+        ]
+        assert len(error_records) == 5, (
+            f"Expected 5 error logs (one per occurrence), got {len(error_records)}"
+        )
+
+    def test_dedupe_state_is_reset_by_helper(self, caplog):
+        """After _reset_access_denied_dedupe(), the next AccessDenied logs again."""
+        import logging
+        from graqle.core.kg_sync import _log_s3_error, _reset_access_denied_dedupe
+        err = self._make_access_denied_error()
+
+        with caplog.at_level(logging.WARNING, logger="graqle.core.kg_sync"):
+            _log_s3_error("push", err)
+            _log_s3_error("push", err)  # silenced (same process)
+            _reset_access_denied_dedupe()
+            _log_s3_error("push", err)  # logs again after reset
+
+        warning_records = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "AccessDenied" in r.getMessage()
+        ]
+        assert len(warning_records) == 2, (
+            f"Expected 2 warnings (one before reset, one after), got {len(warning_records)}"
+        )
+

--- a/tests/test_core/test_graph.py
+++ b/tests/test_core/test_graph.py
@@ -164,3 +164,148 @@ def test_cache_key_includes_model_name(sample_graph, tmp_path):
         "Repeated to_json calls must produce consistent embedding_model in _meta"
     )
     assert meta1.get("embedding_dim") == meta2.get("embedding_dim")
+
+
+class TestNeo4jDisabledEnvVar:
+    """OT-060: NEO4J_DISABLED env var process-scoped escape hatch.
+
+    Tests the gate added in graqle/core/graph.py:
+      - _neo4j_disabled() helper (truthy/falsey env var parsing)
+      - Graqle.from_neo4j() raises RuntimeError when env=true
+      - Graqle.to_neo4j() raises RuntimeError when env=true
+      - Backward compat when env unset (gate does NOT fire)
+      - Once-per-process WARNING sentinel
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_warning_sentinel(self):
+        """Reset the once-per-process sentinel before AND after each test."""
+        from graqle.core import graph as graph_module
+        graph_module._neo4j_disabled_warned = False
+        yield
+        graph_module._neo4j_disabled_warned = False
+
+    def test_from_neo4j_raises_when_NEO4J_DISABLED_set(self, monkeypatch):
+        """Gate fires: from_neo4j raises BEFORE any Neo4jConnector instantiation."""
+        monkeypatch.setenv("NEO4J_DISABLED", "true")
+
+        connector_calls = []
+
+        def _spy_init(self, *args, **kwargs):
+            connector_calls.append((args, kwargs))
+
+        try:
+            from graqle.connectors import neo4j as neo4j_mod
+            monkeypatch.setattr(neo4j_mod.Neo4jConnector, "__init__", _spy_init)
+        except ImportError:
+            pass
+
+        with pytest.raises(RuntimeError) as excinfo:
+            Graqle.from_neo4j(uri="bolt://should-never-be-dialed:7687")
+
+        assert "NEO4J_DISABLED" in str(excinfo.value)
+        assert "process" in str(excinfo.value).lower()
+        assert len(connector_calls) == 0, (
+            f"Neo4jConnector was instantiated {len(connector_calls)} times — "
+            "the gate did not fire BEFORE the connector"
+        )
+
+    def test_to_neo4j_raises_when_NEO4J_DISABLED_set(self, monkeypatch):
+        """Gate fires: to_neo4j raises BEFORE any Neo4jConnector instantiation."""
+        monkeypatch.setenv("NEO4J_DISABLED", "true")
+
+        connector_calls = []
+
+        def _spy_init(self, *args, **kwargs):
+            connector_calls.append((args, kwargs))
+
+        try:
+            from graqle.connectors import neo4j as neo4j_mod
+            monkeypatch.setattr(neo4j_mod.Neo4jConnector, "__init__", _spy_init)
+        except ImportError:
+            pass
+
+        g = Graqle.from_networkx(nx.Graph())
+        with pytest.raises(RuntimeError) as excinfo:
+            g.to_neo4j(uri="bolt://should-never-be-dialed:7687")
+
+        assert "NEO4J_DISABLED" in str(excinfo.value)
+        assert len(connector_calls) == 0, (
+            f"Neo4jConnector was instantiated {len(connector_calls)} times — "
+            "the gate did not fire BEFORE the connector"
+        )
+
+    def test_neo4j_path_untouched_when_NEO4J_DISABLED_absent(self, monkeypatch):
+        """Backward compat: with env unset, the real Neo4jConnector path IS reached."""
+        monkeypatch.delenv("NEO4J_DISABLED", raising=False)
+
+        connector_calls = []
+
+        def _spy_init(self, *args, **kwargs):
+            connector_calls.append((args, kwargs))
+            raise RuntimeError("MARKER_REAL_CONNECTOR_REACHED")
+
+        try:
+            from graqle.connectors import neo4j as neo4j_mod
+            monkeypatch.setattr(neo4j_mod.Neo4jConnector, "__init__", _spy_init)
+
+            with pytest.raises(RuntimeError) as excinfo:
+                Graqle.from_neo4j(uri="bolt://127.0.0.1:9")
+
+            assert len(connector_calls) == 1, (
+                f"Expected exactly 1 Neo4jConnector instantiation when env unset, "
+                f"got {len(connector_calls)}"
+            )
+            assert "MARKER_REAL_CONNECTOR_REACHED" in str(excinfo.value)
+            assert "NEO4J_DISABLED" not in str(excinfo.value)
+        except ImportError:
+            with pytest.raises(Exception) as excinfo:
+                Graqle.from_neo4j(uri="bolt://127.0.0.1:9")
+            assert "NEO4J_DISABLED" not in str(excinfo.value)
+
+    def test_neo4j_disabled_truthy_values(self, monkeypatch):
+        """All documented truthy values trigger the gate."""
+        from graqle.core.graph import _neo4j_disabled
+        truthy = [
+            "1", "true", "TRUE", "True",
+            "yes", "YES", "on", "ON",
+            "  true  ",
+            "\tYES\n",
+        ]
+        for val in truthy:
+            monkeypatch.setenv("NEO4J_DISABLED", val)
+            assert _neo4j_disabled() is True, f"{val!r} should be truthy"
+
+    def test_neo4j_disabled_falsey_values(self, monkeypatch):
+        """All non-truthy values leave the gate disabled."""
+        from graqle.core.graph import _neo4j_disabled
+        falsey = [
+            "", "0", "false", "FALSE",
+            "no", "off", "  ", "garbage",
+            " FaLsE ",
+        ]
+        for val in falsey:
+            monkeypatch.setenv("NEO4J_DISABLED", val)
+            assert _neo4j_disabled() is False, f"{val!r} should be falsey"
+        monkeypatch.delenv("NEO4J_DISABLED", raising=False)
+        assert _neo4j_disabled() is False
+
+    def test_warning_sentinel_emits_only_once_per_process(self, monkeypatch, caplog):
+        """Once-per-process WARNING fires exactly one time across multiple gate hits."""
+        import logging
+        monkeypatch.setenv("NEO4J_DISABLED", "true")
+
+        with caplog.at_level(logging.WARNING, logger="graqle"):
+            for _ in range(3):
+                with pytest.raises(RuntimeError):
+                    Graqle.from_neo4j(uri="bolt://should-never-be-dialed:7687")
+
+        warning_records = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "NEO4J_DISABLED=true" in r.getMessage()
+        ]
+        assert len(warning_records) == 1, (
+            f"Expected exactly 1 warning across 3 gate fires, got {len(warning_records)}"
+        )
+

--- a/tests/test_plugins/test_mcp_dev_server.py
+++ b/tests/test_plugins/test_mcp_dev_server.py
@@ -751,3 +751,120 @@ class TestReasonBatchPredictiveMode:
         statuses_returned = [r.get("prediction", {}).get("status") for r in data["results"]]
         assert "WRITTEN" in statuses_returned
         assert "SKIPPED_LOW_CONFIDENCE" in statuses_returned
+
+
+class TestInitializeClientInfoBypass:
+    """OT-062: Initialize handler detects clientInfo.name == "graqle-vscode"
+    and sets per-MCP-session bypass flags for CG-01/02/03 gates.
+    Default is fail-closed: missing or unrecognized clientInfo → gates ON.
+    """
+
+    def _make_server(self):
+        """Build a fresh KogniDevServer without invoking __init__ heavy load."""
+        from graqle.plugins.mcp_dev_server import KogniDevServer
+        srv = KogniDevServer.__new__(KogniDevServer)
+        srv._mcp_client_name = None
+        srv._cg01_bypass = False
+        srv._cg02_bypass = False
+        srv._cg03_bypass = False
+        srv._session_started = False
+        srv._plan_active = False
+        srv._start_kg_load_background = lambda: None
+        return srv
+
+    @pytest.mark.asyncio
+    async def test_initialize_with_graqle_vscode_client_sets_all_bypasses(self):
+        """When clientInfo.name == "graqle-vscode", all three CG bypasses are set."""
+        srv = self._make_server()
+        request = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "clientInfo": {"name": "graqle-vscode", "version": "0.1.0"},
+                "capabilities": {},
+            },
+        }
+        response = await srv._handle_jsonrpc(request)
+        assert response["result"]["protocolVersion"] == "2024-11-05"
+        assert srv._mcp_client_name == "graqle-vscode"
+        assert srv._cg01_bypass is True
+        assert srv._cg02_bypass is True
+        assert srv._cg03_bypass is True
+
+    @pytest.mark.asyncio
+    async def test_initialize_with_unknown_client_keeps_gates_on(self):
+        """Unknown clientInfo.name leaves all bypasses False (fail-closed)."""
+        srv = self._make_server()
+        request = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "clientInfo": {"name": "claude-code", "version": "2.0"},
+            },
+        }
+        await srv._handle_jsonrpc(request)
+        assert srv._mcp_client_name == "claude-code"
+        assert srv._cg01_bypass is False
+        assert srv._cg02_bypass is False
+        assert srv._cg03_bypass is False
+
+    @pytest.mark.asyncio
+    async def test_initialize_with_missing_clientInfo_keeps_gates_on(self):
+        """Missing clientInfo entirely → fail-closed (gates remain on)."""
+        srv = self._make_server()
+        request = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {},
+        }
+        await srv._handle_jsonrpc(request)
+        assert srv._mcp_client_name is None
+        assert srv._cg01_bypass is False
+        assert srv._cg02_bypass is False
+        assert srv._cg03_bypass is False
+
+    @pytest.mark.asyncio
+    async def test_initialize_with_malformed_clientInfo_keeps_gates_on(self):
+        """Malformed clientInfo (string instead of dict) → fail-closed."""
+        srv = self._make_server()
+        request = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"clientInfo": "not-a-dict"},
+        }
+        await srv._handle_jsonrpc(request)
+        assert srv._cg01_bypass is False
+        assert srv._cg02_bypass is False
+        assert srv._cg03_bypass is False
+
+    @pytest.mark.asyncio
+    async def test_two_independent_servers_have_independent_bypass_state(self):
+        """Two KogniDevServer instances on the same process have independent state.
+        Proves the bypass flags are session-scoped, not global.
+        """
+        srv_vscode = self._make_server()
+        srv_other = self._make_server()
+
+        vscode_req = {
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {"clientInfo": {"name": "graqle-vscode"}},
+        }
+        other_req = {
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {"clientInfo": {"name": "other-client"}},
+        }
+        await srv_vscode._handle_jsonrpc(vscode_req)
+        await srv_other._handle_jsonrpc(other_req)
+
+        assert srv_vscode._cg01_bypass is True
+        assert srv_vscode._cg02_bypass is True
+        assert srv_vscode._cg03_bypass is True
+        assert srv_other._cg01_bypass is False
+        assert srv_other._cg02_bypass is False
+        assert srv_other._cg03_bypass is False
+


### PR DESCRIPTION
## Summary

Hotfix v0.46.9 ships **3 fixes** that unblock the VS Code extension MCP handshake and reduce S3 log noise:

- **OT-060** — `NEO4J_DISABLED` env var gate in `graqle/core/graph.py`
- **OT-062** — Session-scoped MCP gate bypasses for `clientInfo.name == "graqle-vscode"` in `graqle/plugins/mcp_dev_server.py`
- **OT-061** — S3 AccessDenied dedupe in `graqle/core/kg_sync.py`

**Test results: 107 passed (91 existing + 16 new), zero regressions.**

---

## OT-060 — `NEO4J_DISABLED` env var gate

`Graqle.from_neo4j()` and `Graqle.to_neo4j()` now respect the `NEO4J_DISABLED` env var. When set to a truthy value (`1`, `true`, `yes`, `on` — case-insensitive, whitespace-trimmed), both methods raise `RuntimeError` **before** importing `Neo4jConnector` or dialing `bolt://`. Zero dials, zero retries.

The existing caller `try/except → JSON fallback` contract is preserved, so every existing caller in `cli/main.py`, `cli/commands/*.py`, `plugins/mcp_dev_server.py`, and `server/app.py` automatically falls back to JSON without code changes.

**Once-per-process WARNING** via a module-level sentinel — users see the message exactly once per session, then it's silenced.

**Backward compat:** when env unset → byte-identical legacy behavior. Verified by running `from_neo4j` against TCP discard port 9 and observing the real `neo4j.exceptions.ServiceUnavailable` from the actual connector — proving the gate did NOT fire when the env var was absent.

**Commercial framing:** Neo4j remains a first-class power-user feature. This is a per-process escape hatch, **not a feature removal**. The `RuntimeError` message intentionally references `graq upgrade neo4j` to preserve the conversion funnel for users who want to enable Neo4j.

**For VS Code extension users:** the extension can now set `NEO4J_DISABLED=true` in the child process environment when spawning the MCP server. This bypasses any stale `connector: neo4j` config in `graqle.yaml` that would otherwise hang the MCP `initialize` handshake on a slow `bolt://` dial.

---

## OT-062 — Session-scoped MCP gate bypasses for graqle-vscode

The MCP `initialize` JSON-RPC handler in `graqle/plugins/mcp_dev_server.py` now reads `params.clientInfo.name`. When it equals `"graqle-vscode"` (case-sensitive exact match), the handler sets per-instance `_cg01_bypass`, `_cg02_bypass`, `_cg03_bypass` flags on the `KogniDevServer` instance. The CG-01 (session_started), CG-02 (plan_active), and CG-03 (edit_enforcement) gate checks honor these flags.

**State is naturally session-scoped** because each `KogniDevServer` is one MCP stdio process. Concurrent non-graqle-vscode clients run in their own server instances and are unaffected.

**Fail-closed default:** missing or malformed `clientInfo` → all gates remain ON.

**For VS Code extension users:** send `clientInfo: {"name": "graqle-vscode", "version": "..."}` in the MCP `initialize` request. Once initialize returns, gates are bypassed for the lifetime of that server child process. The extension can call `graq_*` tools without first calling `graq_lifecycle(session_start)` or `graq_plan(...)`.

**Critical:** the bypass ONLY activates on EXACT case-sensitive match `"graqle-vscode"`. Spelling variants do NOT activate the bypass (intentional fail-closed behavior).

---

## OT-061 — S3 AccessDenied dedupe

Added `_is_access_denied(exc)`, `_log_s3_error(operation, exc)`, and `_reset_access_denied_dedupe()` (test-only) helpers + a module-level `_access_denied_logged` sentinel in `graqle/core/kg_sync.py`. Replaces 3 noisy `logger.warning` sites in `pull_if_newer` and `_push_worker`.

**Behavior:**
- AccessDenied → 1 WARNING per process, then silenced
- Non-AccessDenied S3 errors → ERROR per occurrence (unchanged escalation)

**Headline test:** 10 synthetic AccessDenied errors → exactly 1 log line. Eliminates the "VS Code MCP server runs forever and produces hundreds of identical AccessDenied warnings per day" failure mode for users without S3 write permissions.

---

## Test plan

| Test file | Existing | New | Total | Time |
|---|---|---|---|---|
| `tests/test_core/test_graph.py` | 12 | 6 | **18 passed** | 4.63s |
| `tests/test_plugins/test_mcp_dev_server.py` | 41 | 5 | **46 passed** | 0.29s |
| `tests/test_cloud/test_kg_sync.py` | 38 | 5 | **43 passed** | 32.24s |
| **Total** | **91** | **16** | **107 passed** | ~37s |

**Zero regressions.** All 91 pre-existing tests pass byte-identically after the changes.

Combined run on this branch: `pytest tests/test_core/test_graph.py tests/test_plugins/test_mcp_dev_server.py tests/test_cloud/test_kg_sync.py -x -q` → **107 passed in 41.81s**.

### Functional smoke tests (verified at runtime against the local edited file)

- [x] OT-060: `NEO4J_DISABLED=true` → `Graqle.from_neo4j()` raises `RuntimeError` with correct message
- [x] OT-060: `NEO4J_DISABLED=true` → `Graqle.to_neo4j()` raises `RuntimeError` with correct message
- [x] OT-060: env unset → real `Neo4jConnector` is reached (verified via marker exception spy)
- [x] OT-060: 17 truthy/falsey/whitespace/edge boundary values
- [x] OT-060: WARNING emitted exactly once across multiple gate fires
- [x] OT-062: `clientInfo.name == "graqle-vscode"` → all 3 bypass flags set
- [x] OT-062: unknown clientInfo → fail-closed (gates ON)
- [x] OT-062: missing/malformed clientInfo → fail-closed
- [x] OT-062: two independent KogniDevServer instances → independent state
- [x] OT-061: 10 AccessDenied errors → 1 log line
- [x] OT-061: 5 non-AccessDenied errors → 5 log lines (no dedupe for other errors)
- [x] OT-061: dedupe state can be reset by `_reset_access_denied_dedupe()`

---

## Files changed (9)

```
CHANGELOG.md                                | new [0.46.9] entry at top
graqle/__version__.py                       | 0.46.8 → 0.46.9
pyproject.toml                              | 0.46.8 → 0.46.9
graqle/core/graph.py                        | +67  -0
graqle/core/kg_sync.py                      | +47  -4
graqle/plugins/mcp_dev_server.py            | +42  -3
tests/test_core/test_graph.py               | +145 -0
tests/test_plugins/test_mcp_dev_server.py   | +117 -0
tests/test_cloud/test_kg_sync.py            | +110 -0
```

**Net:** 542 insertions, 9 deletions. The 9 deletions are 3 modified `if` conditions in `mcp_dev_server.py` (each line shown as 1 del + 1 add in unified diff format) plus 6 lines in `kg_sync.py` (3 noisy `logger.warning` sites replaced with calls to `_log_s3_error`).

---

## How this PR was prepared

This PR was cherry-picked from the corresponding private hotfix branch (`hotfix/sdk-v0469-ot060-061-062`), which was reviewed and merged on the internal research repo. The cherry-pick produced one expected merge conflict in `CHANGELOG.md` (different format conventions between the two branches), which was resolved by reformatting the new v0.46.9 entry to match this repo's `[x.y.z]` Keep-A-Changelog convention.

The cherry-pick followed the same proven pattern used for the recent `lazy-kg-load` hotfix:
1. Branch from `origin/master`
2. `git cherry-pick <private-commit-sha>`
3. Resolve the CHANGELOG format conflict
4. Run focused test suites to confirm zero regression
5. Push and open PR

The new commit on this branch has the same author, date, and message as the private original, with a different SHA (standard cherry-pick output).

---

## Release sequence

After this PR merges:
1. Tag `v0.46.9` on `origin/master` → triggers PyPI auto-publish workflow
2. Verify on PyPI: `pip index versions graqle` should list `0.46.9`
3. Verify install: `pip install graqle==0.46.9` then `graq doctor`
4. Update VS Code extension if it needs to consume the new `clientInfo` bypass behavior
5. Bump dependent project pins (Studio, etc.) to `graqle>=0.46.9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
