### PR TITLE
fix(v0.50.0): sanitize public docs + add missing jsonschema dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,447 +4,55 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
-### Round-2 remediation (2026-04-11) — research team review PR #49 (follow-up)
-
-Addresses the 1 new BLOCKER (RO2-6) + 3 new MAJORs (RO2-1, RO2-3, RO2-4)
-+ 2 MINORs (RO2-2, RO2-5) raised in the Round-2 research team review on
-private PR #49. Operator directive: *"maintain our algorithm,
-implementation rigour and business value while solving the points raised
-by the research team."* All mechanism preserved. Algorithm integrity
-verified: 9/9 classify_concern precedence cases pass after the fixes.
-
-**RO2-6 (BLOCKER, now closed) — TCG seed reachability 25/67 → 67/67**
-- The Round-1 expansion added 37 new TCGTool nodes but wired only a
-  few MATCHES_INTENT edges, leaving 42/67 tools orphaned (unreachable
-  from any intent or workflow pattern). Research team's programmatic
-  graph-reachability audit caught this.
-- Added 8 new TCGIntent nodes: `intent_visual_audit`,
-  `intent_browser_automation`, `intent_production_deploy_check`,
-  `intent_dependency_management`, `intent_autonomous_task`,
-  `intent_knowledge_lookup`, `intent_review_pr`, `intent_trace_reasoning`.
-- Added 3 new graduated TCGWorkflowPattern nodes:
-  `workflow_visual_audit`, `workflow_autonomous_task`,
-  `workflow_review_pr`.
-- Added 57 new MATCHES_INTENT edges wiring every previously-orphan
-  tool into at least one intent.
-- Also backfilled core dev tools (`graq_edit`, `graq_bash`,
-  `graq_git_log`) into their existing intents.
-- **Reachability now 67/67 tools (100%)**, verified by the post-Round-2
-  orphan audit script.
-
-**RO2-4 (MAJOR, now closed) — banned-phrase guard self-defeat**
-- The Round-1 `_BANNED_PROMPT_PHRASES` frozenset stored the literal
-  patent-leaking sentences as plaintext strings in the shipped source.
-  A competitor grepping the PyPI wheel could trivially discover the
-  exact phrases the guard was meant to suppress.
-- Replaced with `_BANNED_PHRASE_HASHES: frozenset[str]` — a set of
-  SHA-1[:16] hex digests. The plaintext phrases never appear in
-  shipped source.
-- `_assert_no_banned_phrases` now computes a sliding window of 1..8
-  word n-grams over each prompt, SHA-1 hashes each window, and
-  compares against the hash set. Any match is a regression.
-- Regression-tested: the guard still fires on `"Apply rule order
-  strictly: safety > prerequisite > cost > ambiguity"` and on each
-  legacy persona token (PROPOSER/ADVERSARY/ARBITER) even though none
-  of these phrases appear as plaintext in the source.
-- Added `test_banned_phrase_hashes_size` (shape check) +
-  `test_banned_hash_guard_catches_strict_ordering_regression` +
-  `test_banned_hash_guard_catches_persona_regression`.
-
-**RO2-3 (MAJOR, now closed) — precedence comment leaks in debate.py**
-- Scrubbed 3 locations where the English precedence chain
-  ("safety comes first and wins over prerequisite > cost > ambiguity")
-  was leaked in comments / docstrings:
-  - `debate.py:209-213` — the `_CATEGORY_SIGNALS` comment. Replaced
-    with generic "iteration order is the tie-breaker" language that
-    does not state the specific ordering.
-  - `debate.py:~299` — docstring inside `classify_concern`. Replaced
-    with "is picked per the internal precedence policy".
-  - Module docstring "Safety-first precedence with four categories" →
-    "Four concern categories with a fixed internal ordering".
-- All three scrubs preserve the documentation intent while removing
-  the verbatim English chain.
-
-**RO2-1 (MAJOR, now closed) — dead strict reader wired into TCG**
-- Round-1 added `settings_loader.require_novelty_lift_min` but
-  `tool_capability_graph.graduate_pattern` still read the module
-  constant `PROBATION_NOVELTY_LIFT_MIN` directly, making the strict
-  reader dead code.
-- `ToolCapabilityGraph.__init__` now accepts an optional
-  `settings: dict | None` parameter and stores the resolved threshold
-  in `self._novelty_lift_min`. If `settings` is provided, the value is
-  pulled via `settings_loader.load_novelty_lift_min`; otherwise the
-  public default (0.2, intentionally non-operational) is used.
-- `graduate_pattern` now reads `self._novelty_lift_min` on every call.
-- `load_novelty_lift_min` + `require_novelty_lift_min` are now
-  actually called in the hot path.
-
-**RO2-2 (MINOR, now closed) — persona kwarg renamed to role**
-- `ReasonFn` protocol: `persona: str` → `role: str`.
-- All internal call sites updated.
-- Docstring reference scrubbed.
-- "Persona" was flagged as semantic cousin of the scrubbed vocabulary
-  (core multi-agent debate terminology). Renaming to the neutral
-  "role" label completes the vocabulary scrub.
-
-**RO2-5 (MINOR, now closed) — phantom_screenshot tier adjusted**
-- `graq_phantom_screenshot` governance tier GREEN → YELLOW.
-- Side effect `read` → `net`.
-- Rationale added to description: JS execution via remote page makes
-  this a governed operation.
-
-**Algorithm integrity verified (9/9 cases pass after fixes)**
-- Safety precedence: `"destructive AND expensive AND slow"` → BLOCK
-- Prerequisite > cost: `"missing prerequisite also expensive"` → REFINE
-- Cost alone: `"this is expensive, high-latency"` → REFINE
-- Ambiguity alone: `"ambiguous — unclear"` → REFINE
-- Explicit none: `"CONCERN: none"` → PROCEED
-- Affirmative safe: `"This action is non-destructive and safe."` → PROCEED
-- Credentials rewrite: `"Uses credentials env-var name"` → PROCEED
-- Safety alone: `"data loss ahead"` → BLOCK
-- Irreversible: `"this is irreversible"` → BLOCK
-
-**Mechanism preserved (non-negotiable per operator directive)**
-- 3 parallel role calls via `asyncio.gather`
-- Deterministic in-code override of the judge verdict
-- 4-category internal ordering (enforced in `_CATEGORY_SIGNALS` list
-  order)
-- Round-refinement feedback loop
-- `MAX_CHECK_ROUNDS = 2` hard ceiling
-- `ReasonFn` protocol surface (kwarg name changed, semantics unchanged)
-
-**Reachability verification**
-- Pre-Round-1: 30 tools, 12 intents, 5 workflows, no orphans by
-  construction
-- Post-Round-1: 67 tools, 12 intents, 5 workflows — **42 orphans**
-  (RO2-6 finding)
-- Post-Round-2: **67 tools, 20 intents, 8 graduated workflows, 0
-  orphans** — all tools reachable via at least one MATCHES_INTENT edge
-  or workflow_pattern membership
-
-**Tests:** `tests/test_chat/` 236 → **239 passing** (+3 new Round-2
-regression tests). Hotfix suites (test_base_serialization.py,
-test_continuation.py, test_areason_batch.py, test_aggregation.py)
-unchanged at 9+19+9+7 = 44 passing. Zero regressions.
-
-**Post-impl `graq_review` on debate.py with security focus:** **APPROVED
-at 93% confidence**. All comments are INFO-level hygiene notes. No
-OWASP Top 10 sinks, no secret exposure paths, no unsafe subprocess
-calls. Hash-based guard ships without plaintext sensitive phrases.
-
 ---
-
-### Round-1 remediation (2026-04-11) — research team review PR #49
-
-Addresses the 2 BLOCKERs + 3 MAJORs raised in the research team review
-on private PR #49. Operator waived BLOCKER-R1 conditional on scrubbing
-patent-specific language from the debate subsystem while preserving
-mechanism, algorithm, quality, and the core edge/moat. BLOCKER-R2 and
-MAJOR-R1/R2/R3 are fully fixed.
-
-**BLOCKER-R1 (waived + scrubbed) — debate.py language scrub**
-- Renamed persona roles: `PROPOSER → CANDIDATE`, `ADVERSARY → CRITIC`,
-  `ARBITER → JUDGE`. No verbatim "PROPOSER/ADVERSARY/ARBITER" strings
-  appear anywhere in `graqle/chat/`.
-- Rewrote all three role prompts. No prompt contains the banned
-  sentence `"safety > prerequisite > cost > ambiguity"` — precedence
-  now lives only in code (`classify_concern`), not in prompt text.
-- Renamed constants: `_RULE_KEYWORDS → _CATEGORY_SIGNALS`,
-  `MAX_DEBATE_ROUNDS → MAX_CHECK_ROUNDS`.
-- Renamed functions: `deterministic_arbiter() → classify_concern()`,
-  `run_debate() → resolve_concern()`.
-- Renamed dataclasses: `DebateRecord → ConcernCheckRecord`,
-  `DebateRound → ConcernCheckRound`, `PersonaResponse → RoleResponse`.
-- Renamed RCAG node type: `NODE_TYPE_DEBATE_ROUND →
-  NODE_TYPE_CHECK_ROUND` with backward-compat alias for in-session
-  callers.
-- Added `_BANNED_PROMPT_PHRASES` frozenset + `_assert_no_banned_phrases`
-  import-time + runtime guard that fails fast on any regression
-  reintroducing the scrubbed phrasing. Test suite re-asserts the guard.
-- `backend_router.py` docstring scrubbed.
-- **Mechanism preserved** (operator waiver condition): 3 parallel role
-  calls via `asyncio.gather`, deterministic in-code override of the
-  judge verdict, safety-first precedence with four categories
-  (safety > prerequisite > cost > ambiguity in code), round-refinement
-  feedback loop, `MAX_CHECK_ROUNDS = 2` hard ceiling.
-
-**BLOCKER-R2 — TS-3 activation-threshold collision on 0.15**
-- Changed public default of `PROBATION_NOVELTY_LIFT_MIN` from `0.15`
-  to `0.2` in `graqle/chat/tool_capability_graph.py`. The old value
-  collided exactly with the unpublished PSE `similarity_threshold`
-  per research TS-3 finding.
-- Updated seed JSON `_meta.schema_notes.probation_thresholds.novelty_lift_min`
-  from `0.15` to `0.2` with an explicit annotation that the public
-  default is non-operational and operators must override via
-  `.graqle/settings.json`.
-- Added `settings_loader.load_novelty_lift_min(settings)` strict
-  reader and `settings_loader.require_novelty_lift_min(settings)`
-  fail-loud variant. The strict reader returns `None` on missing key
-  so the caller can fall back to the public default; the fail-loud
-  variant raises `ValueError` if the key is absent. Pattern per
-  `lesson_20260402T210613`: `config.get(KEY, default)` with a
-  numerical default IS a hardcoded threshold disguised as config.
-- Test docstring in `test_tool_capability_graph.py` updated to
-  reflect the new default.
-
-**MAJOR-R1 — TCG seed coverage expanded from 30 → 67 tools**
-- Added 37 new `TCGTool` nodes covering: 4 governance (`graq_gov_gate`,
-  `graq_safety_check`, `graq_audit`, `graq_runtime`), 8 phantom
-  (`graq_phantom_browse / _click / _type / _screenshot / _audit /
-  _session / _discover / _flow`), 13 scorch (`graq_scorch_audit /
-  _report / _a11y / _perf / _seo / _mobile / _i18n / _security /
-  _conversion / _brand / _auth_flow / _behavioral / _diff`), 6
-  lifecycle + workflow (`graq_lifecycle`, `graq_drace`,
-  `graq_workflow`, `graq_auto`, `graq_route`, `graq_correct`), and 6
-  accessory (`graq_profile`, `graq_web_search`, `graq_plan`,
-  `graq_github_pr`, `graq_github_diff`, `graq_todo`). Plus
-  `graq_reload` under destructive tier.
-- Wired 6 new `MATCHES_INTENT` edges so `intent_audit` now surfaces
-  `graq_gov_gate`, `graq_safety_check`, `graq_audit`, `graq_runtime`;
-  `intent_governed_refactor` surfaces `graq_gov_gate`; and
-  `intent_review` surfaces `graq_safety_check`.
-- Restores the "governance pre-disclosure" property promised in PR #49
-  body and unblocks the R18 GETC trace-capture flow.
-
-**MAJOR-R1b — auto-create probationary unknowns in reinforce_sequence**
-- Added `ToolCapabilityGraph._auto_create_probationary_tool(tool_id)`
-  helper that creates a YELLOW probationary `TCGTool` node with
-  `governance_tier=YELLOW`, `safe_for_prediction=False`,
-  `probation=True`, `auto_created=True`.
-- Updated `reinforce_sequence` to auto-create probationary nodes for
-  unseen `tool_*`-prefixed ids instead of silently skipping them. Non-
-  tool_ prefixed ids are still silently ignored (intents, workflows,
-  lessons).
-- Predicted missing edges never surface auto-created tools because
-  `predict_missing_edges` filters by `safe_for_prediction=True`.
-- Keeps BLOCKER-2 valid: no `KogniDevServer.list_tools()` runtime
-  bootstrap — learning still comes exclusively from observed usage.
-- The docstring claim *"UNKNOWN until reinforce_sequence learns them"*
-  is now factually correct.
-
-**MAJOR-R2 — prediction bias toward seeded tools** — automatically
-reduced by MAJOR-R1 expansion (67 tools vs 30 before) + auto-create
-fallback. No separate code fix.
-
-**MAJOR-R3 — arbiter substring matching is brittle**
-- Replaced substring matching with a `_CATEGORY_SIGNALS` list of
-  compiled regex patterns using word boundaries (`\bdestructive\b`,
-  `\bunsafe\b`, etc.).
-- Added `_has_negation` helper with a 20-char look-back window that
-  checks for negation tokens (`not `, `no `, `non-`, `never `,
-  `without `).
-- Added `_has_affirmative_safety` fallback that recognises benign
-  markers (`is safe`, `read-only`, `idempotent`, `no side effects`,
-  `credentials env-var name` — the `lesson_patent_scrub` safe rewrite
-  phrase).
-- Four-way fallback decision:
-  (1) explicit NONE → PROCEED,
-  (2) negation-guarded safety match → BLOCK,
-  (3) non-safety signal → REFINE,
-  (4) no signal + affirmative marker → PROCEED,
-  (5) no signal + no affirmative marker → REFINE (conservative default).
-- All 4 false-positive phrases from the research review
-  (`non-destructive`, `credentials env-var name`, `unsafe pattern we
-  already fixed`, `ambiguous but safe`) now pass their regression
-  tests.
-
-**MINOR-R1** — documented (TB-F8 `mcp_dev_server.py` wiring is still a
-v0.50.1 follow-up; snippet remains in
-`.gcc/CHATAGENTLOOP-V4-COMPLETE.md`).
-
-**MINOR-R4** — `graq_reason_batch` migration tracked as v0.50.1
-optimization; no functional change.
-
-**Security invariants added to debate.py**
-- `tests/test_chat/test_debate.py` now asserts the module source
-  contains no `import subprocess`, no `os.system`, no `os.environ`,
-  no `os.getenv`, no legacy persona names at caps, and that every
-  shipped prompt passes the banned-phrase guard.
-- Added a secret-leakage test: a synthetic SECRET-like value in the
-  question never appears in the streamed role outputs.
-
-**Tests**
-- `tests/test_chat/`: 214 → **236 passing** (added 22 new Round-1
-  regression tests: 15 new debate.py cases, 7 new TCG cases)
-- All 236 tests green in 1.28s
 
 ---
 
 ## v0.50.0 — 2026-04-11
 
-**ChatAgentLoop v4 — Claude-Code-equivalent interactive chat layer (ADR-152).**
-
-This is a feature jump (0.47.3 → 0.50.0) that ships the entire chat
-agent loop the VS Code extension v0.6.0 will host: a three-graph
-runtime architecture (GRAQ.md / TCG / RCAG), an LLM tool-use loop
-that ranks over a TCG-activated subgraph instead of cold-picking from
-~134 tools, durable pause/resume with CAS-locked state machine,
-session-scoped permission caching, adversarial debate, polyglot
-backend routing, hard-error continuation, and convention inference
-as a first-class product feature. SDK-HF-01 (graq_generate missing
-from generate-intent DAG) is structurally resolved — the extension's
-dag.ts + intent.ts are deleted; tool selection moves to the SDK.
+**Structured chat agent layer with architectural awareness, durable pause/resume, and governed tool selection.**
 
 ### Added
-- **`graqle/chat/`** — new package, 8 SDK modules + 2 templates (~6500 LOC).
-  - **`streaming.py`** (TB-F1) — ChatEvent envelope, ChatEventBuffer with
-    monotonic per-turn sequencing, long-poll cursor helper.
-  - **`turn_ledger.py`** (TB-F1) — append-only audit log at
-    `.graqle/chat/ledger/turn_<id>.jsonl`.
-  - **`settings_loader.py`** (TB-F1) — `.graqle/settings.json` policy
-    loader with fail-closed jsonschema validation.
-  - **`graq_md_loader.py`** (TB-F1) — multi-root GRAQ.md loader walking
-    cwd UP to filesystem root, most-specific-wins conflict merge,
-    user-content sandbox escaping.
-  - **`templates/GRAQ_default.md`** (TB-F1) — built-in floor with 7
-    scenario playbooks (codegen / debug / refactor / audit / review /
-    write-new-artifact / convention-inference) + tool catalog.
-  - **`tool_capability_graph.py`** (TB-F2) — `ToolCapabilityGraph`
-    IS-A `Graqle` subclass with enrichment bypass, 30-tool/12-intent/
-    5-workflow/20-lesson seed, intent classification + activation,
-    edge reinforcement with [0.0, 10.0] clamp, probationary pattern
-    mining (3 obs / 2 holdouts / 0.15 lift), 2-hop missing-edge
-    prediction with destructive-edge safety filter, atomic save with
-    .bak rollback.
-  - **`templates/tcg_default.json`** (TB-F2) — canonical seed: 30 tools
-    with governance tiers (GREEN/YELLOW/RED), 12 intents with keyword
-    + preferred_sequence, 5 graduated workflow patterns including the
-    `convention_inference` workflow that wires `graq_glob → graq_read
-    → graq_write` for the `write-new-artifact` intent, 20 lessons,
-    108 typed edges (MATCHES_INTENT / USED_AFTER / PART_OF /
-    CAUSED_BY).
-  - **`rcag.py`** (TB-F3) — `RuntimeChatActionGraph` IS-A `Graqle`,
-    7 ephemeral node types (ToolCall, ToolResult, AssistantReasoning,
-    GovernanceCheckpoint, DebateRound, ErrorNode, AttachmentContext),
-    query augmentation with rolling 3-turn summary + partial
-    reasoning, deterministic token-overlap activation fallback for
-    unit tests (production wires through `_activate_subgraph(strategy
-    ='chunk')`).
-  - **`permission_manager.py`** (TB-F4) — `TurnState` enum, `TurnStore`
-    with CAS state transitions under `asyncio.Lock`, idempotent
-    resume via `tool_result_cache`, crash recovery via terminal
-    tombstoning, `PermissionManager` with session-scoped cache keyed
-    by `(tool_name, resource_scope, session_id)` plus revocation.
-  - **`debate.py`** (TB-F5) — PROPOSER/ADVERSARY/ARBITER personas via
-    `asyncio.gather` of three reason calls (will migrate to native
-    `graq_reason_batch` now that CG-REASON-01 is fixed in v0.47.3),
-    deterministic arbiter rule order safety > prerequisite > cost >
-    ambiguity, max 2 rounds, debate chip streaming.
-  - **`backend_router.py`** (TB-F6) — `BackendProfile`, `BackendRouter`,
-    family detection by name prefix, 6 chat task types (chat_triage /
-    chat_reasoning / chat_debate_proposer / chat_debate_adversary /
-    chat_debate_arbiter / chat_format), family separation enforced
-    only when 2+ families configured, minimal-polyglot degradation
-    when only one backend is available.
-  - **`agent_loop.py`** (TB-F7) — `ChatAgentLoop` integration point,
-    10-step turn flow from ADR-152 §Decision, adaptive budget with
-    burst override (25 → 100 ceiling), hard-error continuation via
-    ErrorNode + synthetic tool_result, governance parallelism,
-    pause/resume/cancel state transitions, CGI-compatible event
-    emission shape (ADR-153 seed) so the future project-self-memory
-    graph can fold turn events in via a classification pass.
-  - **`mcp_handlers.py`** (TB-F8) — four chat handler functions
-    (`handle_chat_turn`, `handle_chat_poll`, `handle_chat_resume`,
-    `handle_chat_cancel`) that the MCP server will dispatch the
-    `graq_chat_*` tools to. Kept in a separate module to minimize
-    the hub-file edit surface in `mcp_dev_server.py` per
-    CG-DIF-01/CG-DIF-02 — TB-N tracks the small registration block
-    that wires them in.
 
-### Tests
-- **`tests/test_chat/`** — new directory, 214 tests passing in 1.29s.
-  - test_streaming.py (TB-F1)
-  - test_turn_ledger.py (TB-F1)
-  - test_settings_loader.py (TB-F1)
-  - test_graq_md_loader.py (TB-F1)
-  - test_isolation.py (TB-F1; updated to allow the four shared core
-    modules graqle.core.{graph,node,edge,types,message,state} for
-    TB-F2 onward — everything else in graqle.core stays forbidden)
-  - test_tool_capability_graph.py (TB-F2, 43 cases covering BLOCKER-1
-    enrichment bypass / BLOCKER-2 single source of truth / MAJOR-2
-    destructive-edge filter / MAJOR-3 probationary filter /
-    MAJOR-4 atomic save rollback / MAJOR-5 negative paths /
-    MINOR-1 weight clamp / MINOR-2 probation thresholds)
-  - test_rcag.py (TB-F3, 19 cases)
-  - test_permission_manager.py (TB-F4, 22 async cases)
-  - test_debate.py (TB-F5, 15 cases including the deterministic rule
-    order verification)
-  - test_backend_router.py (TB-F6, 14 cases)
-  - test_agent_loop.py (TB-F7, 11 async cases including the
-    SDK-HF-01 structural regression guard
-    `test_sdk_hf_01_codegen_picks_graq_generate` that asserts a
-    codegen turn produces a tool_planned event for graq_generate
-    AND the final turn_complete text contains a fenced python block)
-  - test_mcp_handlers.py (TB-F8, 9 async cases)
+- **Structured chat agent** — your AI coding assistant now runs a chat loop that picks the right tool for every task based on your project's history and the specific intent of your question. No cold-picking from a long tool list.
+- **Durable pause/resume** — long-running tasks can pause for operator approval and resume exactly where they left off. Nothing lost if the session is closed.
+- **Structured second-opinion check** — for sensitive actions, a quick internal check flags safety concerns, missing prerequisites, or ambiguity before anything is touched.
+- **Bring-your-own-backend polyglot routing** — mix and match LLM providers for different task types (triage, reasoning, formatting). Works with a single backend or multiple families, with graceful degradation.
+- **Hard-error continuation** — when a tool fails, the assistant adapts and keeps going instead of freezing.
+- **Convention inference** — when you ask the assistant to write a new artifact (an ADR, a test file, a tracker entry), it finds existing examples in your project, matches the style, and writes in the right location. No clarifying questions.
+- **Session-scoped permissions** — approve a tool once for a scope; subsequent same-scope calls auto-proceed. Revocable mid-session.
+- **Append-only audit log** — every turn is recorded for historical transcript inspection.
+- **Project-specific instructions via `GRAQ.md`** — drop a `GRAQ.md` at your project root to customize how the assistant behaves for your codebase, similar to `CLAUDE.md`.
 
-### Hotfixes rolled into v0.50.0
-- **CG-REASON-02** (v0.47.1) — BaseBackend deepcopy/pickle safety via
-  `_TRANSIENT_BACKEND_ATTRS` drop on serialization, fixed the
-  `cannot pickle '_thread.RLock' object` crash that was hard-downing
-  every reasoning round on the openai backend.
-- **SDK-HF-02** (v0.47.2) — synthesis truncation regression fixed via
-  the new `generate_with_continuation` helper extracted from
-  `CogniNode.reason` into `graqle/core/node.py`. The
-  `Aggregator._weighted_synthesis` path now recovers from
-  `stop_reason=max_tokens` the same way per-node responses do.
-  CogniNode.reason() keeps its inline copy of the loop untouched
-  (deferred to CG-OT028-01 follow-up).
-- **CG-REASON-01** (v0.47.3) — `areason_batch` error fallback fixed via
-  the new module-level `_make_error_result(query, exc)` helper that
-  builds a valid `ReasoningResult` with all required fields plus
-  `backend_status="failed"` / `backend_error` / `reasoning_mode=
-  "error"`. Unblocks the native batch reasoning path for the
-  ChatAgentLoop debate subsystem.
+### Four new MCP tools (registration in v0.50.1)
+
+- `graq_chat_turn(message, ...)` — start a new structured chat turn
+- `graq_chat_poll(turn_id, since_seq, timeout)` — long-poll for events
+- `graq_chat_resume(turn_id, pending_id, decision)` — apply a permission decision and resume
+- `graq_chat_cancel(turn_id)` — cancel an in-flight turn
+
+### Fixed (critical bug fixes rolled in)
+
+- **Backend reliability** — fixes a crash that affected reasoning calls after the first round on some backends (ships as v0.47.1 fix rolled in).
+- **Long-response handling** — synthesis now correctly handles responses that hit the model's output token limit (ships as v0.47.2 fix rolled in).
+- **Batch reasoning** — the batch reasoning path now works correctly when a query fails inside a batch (ships as v0.47.3 fix rolled in).
+
+### Changed
+
+- **136 MCP tools** total (was 122)
+- **Version jump** 0.47.0 → 0.50.0 (feature jump reflecting the structured chat agent surface)
+
+### Governed by default
+
+- Three-tier governance (auto / review / approval) with tiers pre-disclosed upfront — no surprise-blocks mid-flow
+- Impact analysis and preflight checks on every change
+- Destructive operations always require explicit confirmation
 
 ### Notes
-- **SDK-HF-01 structurally resolved.** The extension's `dag.ts` +
-  `intent.ts` are obsoleted by the SDK-side TCG. The LLM picks tools
-  from a pre-activated TCG subgraph that puts `graq_generate` at
-  position #2 (score 1.635) for `write a Python function...` queries
-  on day one of the seed, before any user reinforcement. Verified
-  by the `test_sdk_hf_01_codegen_picks_graq_generate` regression
-  guard.
-- **Convention inference is a first-class product feature.** The TCG
-  ships with a `workflow_convention_inference` graduated workflow
-  pattern wiring `graq_glob → graq_read → graq_write` for the
-  `intent_write_new_artifact` intent. The built-in GRAQ.md template
-  has a `## Scenario: write-new-artifact` playbook encoding the
-  same behavior in natural language.
-- **CGI-compatible event emission shape (ADR-153 seed).** Every
-  ChatAgentLoop event carries the structural fields a future
-  Cognigraph Implementation Graph would need (turn_id, session_id,
-  parent_id, tool_name, status, latency_ms, debate_verdict,
-  debate_reason, governance_tier, governance_decision). The
-  ADR-153 design session (post-v0.50.0) can decide whether to fold
-  terminal turn events into a persistent project-self-memory graph
-  via a classification pass. No CGI node types or edge schemas are
-  implemented in v0.50.0 — ADR-153 ships in v0.51.0 as a separate
-  design wave.
-- **Source-level isolation rule narrowed.** `tests/test_chat/
-  test_isolation.py` now allows the chat package to import from
-  `graqle.core.{graph,node,edge,types,message,state}` (the
-  legitimate shared core); everything else in `graqle.core` /
-  `graqle.backends` / `graqle.orchestration` / `graqle.reasoning` /
-  `graqle.intelligence` / `graqle.plugins` / `graqle.connectors`
-  stays forbidden. Source-level scan pattern per
-  lesson_20260411T081005.
-- **Test counts at ship time:**
-  - tests/test_chat/: 214 passing in 1.29s (the v4 chat layer)
-  - tests/test_backends/test_base_serialization.py: 9 (CG-REASON-02)
-  - tests/test_core/test_continuation.py: 19 (SDK-HF-02 helper)
-  - tests/test_core/test_areason_batch.py: 9 (CG-REASON-01)
-  - tests/test_orchestration/test_aggregation.py: 7 (SDK-HF-02 wiring)
-- **TB-F8 hub-file wiring deferred.** The four `mcp_handlers.handle_chat_*`
-  functions are ready and tested standalone. The actual registration
-  block in `graqle/plugins/mcp_dev_server.py` (8609 lines, impact
-  radius 491) will be a small follow-up edit applied via
-  `graq_apply` per the CG-DIF-02 hub-file safety rule. See
-  `.gcc/CHATAGENTLOOP-V4-COMPLETE.md` for the registration snippet.
-- **PyPI publish + git tag pending operator approval.** The build is
-  staged at v0.50.0 but `python -m build && twine upload` is not
-  run automatically.
 
----
+- Four new MCP tools are wired at the SDK level; MCP server registration lands as a v0.50.1 hotfix to keep the v0.50.0 change surface focused.
+- Works with Anthropic, OpenAI, AWS Bedrock, Ollama (local), Gemini, Groq, DeepSeek, Together, Mistral, OpenRouter, Fireworks, Cohere, vLLM, and custom providers.
+- Fully offline capable with Ollama.
 
 ## v0.47.3 — 2026-04-11
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Your codebase is a graph. Every node reasons. Every change is governed.
 
-> **One command. 90 seconds. Your AI writes code with architectural awareness, governance gates, multi-agent reasoning, and a self-learning tool graph. Not a linter. Not a copilot. A knowledge graph where every module is an autonomous agent — now with a structured chat layer that picks tools from a learned subgraph instead of cold-picking from 130+.**
+> **One command. 90 seconds. Your AI writes code with architectural awareness, governance gates, and multi-agent reasoning. Not a linter. Not a copilot. A knowledge graph where every module is an autonomous agent — now with a structured chat layer that picks the right tool for every task.**
 
 **The world's first governance-led multi-agent reasoning system for code.**
 Scan any codebase into a persistent knowledge graph. Every module becomes a reasoning agent.
@@ -16,11 +16,10 @@ Every change is impact-analysed, gate-checked, and taught back — automatically
 [![PyPI](https://img.shields.io/pypi/v/graqle?color=%2306b6d4&label=PyPI)](https://pypi.org/project/graqle/)
 [![Downloads](https://img.shields.io/pypi/dw/graqle?color=%2306b6d4&label=downloads%2Fweek)](https://pypi.org/project/graqle/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-06b6d4.svg)](https://python.org)
-[![Tests: 4,430+](https://img.shields.io/badge/tests-4%2C430%2B%20passing-06b6d4.svg)]()
+[![Tests: 4,400+](https://img.shields.io/badge/tests-4%2C400%2B%20passing-06b6d4.svg)]()
 [![LLM Backends: 14](https://img.shields.io/badge/LLM%20backends-14-06b6d4.svg)]()
 [![MCP Tools: 136](https://img.shields.io/badge/MCP%20tools-136-06b6d4.svg)]()
 [![Model Agnostic](https://img.shields.io/badge/model-agnostic-06b6d4.svg)]()
-[![ChatAgentLoop v4](https://img.shields.io/badge/ChatAgentLoop-v4-06b6d4.svg)]()
 [![Governed Reasoning](https://img.shields.io/badge/governed-reasoning-06b6d4.svg)]()
 [![VS Code Extension](https://img.shields.io/badge/VS%20Code-Extension-06b6d4.svg)](https://marketplace.visualstudio.com/items?itemName=graqle.graqle-vscode)
 
@@ -58,78 +57,42 @@ That's it. Claude Code now routes every tool call through GraQle's governed equi
 
 ---
 
-## What's New in v0.50.0 — ChatAgentLoop v4
+## What's New in v0.50.0 — Structured Chat Agent
 
-> **The LLM becomes a ranker over a pre-activated tool subgraph, not a cold picker over 130+ options. Your codebase now runs a structured chat loop with learned tool selection, durable pause/resume, three-role concern checks, and hard-error continuation. This is Claude Code quality inside any MCP client — hosted by the SDK.**
+> **Your AI coding assistant now runs a structured chat loop with architectural awareness, durable pause/resume, and governed tool selection. The same quality you get from dedicated coding assistants — now inside any MCP client.**
 
-### ChatAgentLoop v4 — Structured Chat Agent Layer (ADR-152)
+### Structured chat agent layer
 
-A complete chat agent subsystem ships under `graqle/chat/`. The SDK is now the host AI tool — the VS Code extension becomes a thin webview. Three non-overlapping runtime graphs plus a durable state machine drive the loop:
+- **Smart tool selection** — the assistant picks the right tool for the job based on what your project already uses, your past successful workflows, and the specific intent of your question. No more cold-picking from a long tool list.
+- **Durable pause/resume** — long-running tasks can pause for your approval and resume exactly where they left off. No lost work if you close the session.
+- **Structured second-opinion check** — for sensitive actions, the assistant runs a quick internal check before touching anything, flagging safety concerns, missing prerequisites, or ambiguity.
+- **Bring-your-own-backend** — mix and match LLM providers for different task types (triage, reasoning, formatting). Works with a single backend or multiple families.
+- **Hard-error continuation** — when a tool fails, the assistant adapts and keeps going instead of freezing.
+- **Convention inference** — when you say *"write an ADR for this"* or *"add a test for that"*, the assistant finds existing examples in your project, matches the style, and writes in the right location — no clarifying questions.
 
-- **GRAQ.md** — static policy + multi-root walk-up loader + scenario playbooks. Walks cwd UP to filesystem root collecting every `GRAQ.md`, most-specific wins, additive for scenario playbooks, plus `~/.graqle/GRAQ.md` (user-global) and a built-in template floor. User content sandboxed inside `<user_project_instructions UNTRUSTED=true>`.
-- **TCG — Tool Capability Graph** — a `Graqle` IS-A subclass whose nodes are the 67 MCP tools themselves plus Intent, WorkflowPattern, and Lesson nodes. Ships with a canonical seed (`graqle/chat/templates/tcg_default.json`): **67 tools / 20 intents / 8 graduated workflows / 20 lessons / 171 typed edges**, every tool reachable via at least one MATCHES_INTENT edge. Each tool carries a `governance_tier` attribute (GREEN/YELLOW/RED) so governance is pre-disclosed upfront, never surprise-blocked mid-flow. Cross-session, self-learning: edge reinforcement on every successful turn, probationary workflow-pattern mining with holdout validation before graduation, missing-edge prediction with destructive-edge safety filter, and auto-create-probationary fallback for observed-but-unseeded tools. Atomic save with `.bak` rollback.
-- **RCAG — Runtime Chat Action Graph** — per-session ephemeral execution memory as a `Graqle` IS-A subclass with seven typed action node types (ToolCall, ToolResult, AssistantReasoning, GovernanceCheckpoint, CheckRound, ErrorNode, AttachmentContext). Replaces linear chat history with query-time activation so context size stays constant regardless of turn count. Rolling 3-turn summary augments activation queries.
-- **TurnLedger** — immutable append-only audit log at `.graqle/chat/ledger/turn_<id>.jsonl`, outside the three-graph editorial rule because historical metadata doesn't fit any graph cleanly.
+### Three new SDK capabilities
 
-### The 10-step turn flow
+- **Session-scoped permissions** — approve a tool once for a scope, subsequent same-scope calls auto-proceed. Revocable mid-session.
+- **Append-only audit log** — every turn is recorded at `.graqle/chat/ledger/turn_<id>.jsonl` for full historical transcript inspection.
+- **Project-specific instructions** — drop a `GRAQ.md` at your project root to customize how the assistant behaves for your codebase, similar to `CLAUDE.md`.
 
-1. `begin_turn` (RCAG) + `TurnStore.create` (CAS state machine) + ledger open
-2. TCG activation → ranked candidates with governance tiers pre-disclosed
-3. `governance_chip` events emitted upfront as a single consent
-4. LLM tool-use loop (the LLM RANKS over the activated subgraph, not cold-picks)
-5. Permission gate with session-scoped cache keyed by `(tool_name, resource_scope, session_id)` — pause & resume on prompt, deny on no
-6. Optional 3-role concern check (CANDIDATE / CRITIC / JUDGE) before HIGH/CRITICAL actions, with deterministic in-code override of the LLM judge verdict
-7. Tool execution with hard-error continuation — on exception the loop records an `ErrorNode`, feeds the LLM a synthetic result, and continues. Never freezes.
-8. Live reinforcement of TCG edges on success/failure
-9. Probationary workflow-pattern mining on turn completion
-10. `end_turn` + terminal state transition + rolling summary update
+### Governed by default
 
-### Four new MCP tools
+- Three-tier governance (auto / review / approval) with tiers pre-disclosed upfront — no surprise-blocks mid-flow
+- Impact analysis and preflight checks on every change
+- Destructive operations always require explicit confirmation
 
-- `graq_chat_turn(message, ...)` — start a new turn, return first event batch + cursor
-- `graq_chat_poll(turn_id, since_seq, timeout)` — long-poll events since a cursor
-- `graq_chat_resume(turn_id, pending_id, decision)` — apply a permission decision and resume
-- `graq_chat_cancel(turn_id)` — cancel an in-flight turn cleanly
+### Three critical bug fixes rolled in
 
-### Bring-your-own-backend polyglot routing
-
-Six new chat task types route against whatever backends you have configured in `graqle.yaml`: `chat_triage`, `chat_reasoning`, `chat_debate_proposer`, `chat_debate_adversary`, `chat_debate_arbiter`, `chat_format`. Family separation is enforced only when 2+ families are configured; otherwise the router degrades to a same-family warning chip. Minimal-polyglot mode kicks in when only one backend is available.
-
-### Durable pause/resume
-
-- `TurnCheckpoint` with CAS state transitions under a single `asyncio.Lock`
-- Idempotent resume via `tool_result_cache` keyed by `tool_call_id`
-- Crash recovery via terminal-state tombstoning (`active`/`paused` at crash → `abandoned` with `crash_recovery` reason)
-- Second `graq_chat_turn` while one is active returns `turn_busy` with a `graq_chat_cancel` escape hatch
-
-### Convention inference — a first-class product feature
-
-When you say *"write an ADR for this decision"* or *"add a new test for this"*, ChatAgentLoop v4 MUST infer conventions from existing artifacts rather than ask where files go. The TCG seeds a `workflow_convention_inference` graduated pattern wiring `graq_glob → graq_read → graq_write` for the `write-new-artifact` intent. The built-in GRAQ.md template has a `## Scenario: write-new-artifact` playbook encoding the same behavior.
-
-### 3 blocking hotfixes rolled in
-
-- **CG-REASON-02** (v0.47.1) — BaseBackend `__getstate__`/`__setstate__`/`__deepcopy__` drops transient runtime handles (HTTP clients, cloud SDK sessions, executors, threading primitives) so reasoning nodes can be deepcopied without the `cannot pickle '_thread.RLock'` crash. Fix-forward compatible with any backend.
-- **SDK-HF-02** (v0.47.2) — synthesis truncation recovery via the new `generate_with_continuation` helper extracted from `CogniNode.reason`. `Aggregator._weighted_synthesis` now recovers from `stop_reason=max_tokens` the same way per-node responses do.
-- **CG-REASON-01** (v0.47.3) — `areason_batch` error fallback via `_make_error_result(query, exc)` helper that builds a valid `ReasoningResult` with all required fields plus `backend_status="failed"` so the native batch reasoning path can be used by the chat concern-check subsystem.
+- **Backend reliability** — fixes a crash that affected reasoning calls after the first round on some backends
+- **Long-response handling** — synthesis now correctly handles responses that hit the model's output token limit
+- **Batch reasoning** — the batch reasoning path now works correctly when a query fails inside a batch
 
 ### Key numbers
 
-- **8 new SDK modules + 2 templates** (~6,500 LOC of new governed chat infrastructure)
-- **67 tools / 20 intents / 8 graduated workflows / 20 lessons / 171 typed edges** in the TCG seed
-- **239 new tests** in `tests/test_chat/` (all green in 1.4s)
-- **136 MCP tools** total (was 122)
-- **4,430+ total tests** (was 4,150+)
-- **3 blocking hotfixes** rolled in (CG-REASON-01 / CG-REASON-02 / SDK-HF-02)
-
-### Governance posture
-
-- **SDK-HF-01 structurally resolved** — the extension's old DAG builder is obsoleted; the LLM picks tools from a TCG-activated subgraph that puts `graq_generate` in the top 3 candidates for codegen intent on day one. No orchestration bug can recreate the broken path `graq_preflight → graq_context → graq_reason → graq_learn` because no component owns it anymore.
-- **Three-tier governance** (GREEN auto / YELLOW async chip / RED permission modal) with tiers embedded in the TCG tool nodes as attributes — pre-disclosed upfront as a single consent, never surprise-blocked mid-flow.
-- **Destructive-edge safety filter** blocks `graq_bash`, `graq_write`, `graq_git_commit`, `graq_ingest`, `graq_vendor`, `graq_reload` from ever surfacing in predicted missing edges, regardless of statistical support.
-
-### 14 LLM Backends. 136 MCP Tools. 4,430+ Tests.
-
-Works with Anthropic, OpenAI, AWS Bedrock, Ollama (local), Gemini, Groq, DeepSeek, Together, Mistral, OpenRouter, Fireworks, Cohere, vLLM, and custom providers.
+- **136 MCP tools** exposed to Claude Code, Cursor, and VS Code Copilot
+- **14 LLM backends** — Anthropic, OpenAI, AWS Bedrock, Ollama (local), Gemini, Groq, DeepSeek, Together, Mistral, OpenRouter, Fireworks, Cohere, vLLM, and custom providers
+- **Fully offline capable** with Ollama
 
 [Install VS Code Extension](https://marketplace.visualstudio.com/items?itemName=graqle.graqle-vscode) | [Full Changelog](https://github.com/quantamixsol/graqle/blob/master/CHANGELOG.md)
 

--- a/graqle/chat/settings_loader.py
+++ b/graqle/chat/settings_loader.py
@@ -37,8 +37,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-import jsonschema
-from jsonschema import Draft202012Validator
+try:
+    import jsonschema
+    from jsonschema import Draft202012Validator
+    _JSONSCHEMA_AVAILABLE = True
+except ImportError:  # pragma: no cover — defensive fallback
+    jsonschema = None  # type: ignore[assignment]
+    Draft202012Validator = None  # type: ignore[assignment,misc]
+    _JSONSCHEMA_AVAILABLE = False
 
 __all__ = [
     "ChatSettings",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "graqle"
 version = "0.50.0"
-description = "Claude-Code-equivalent structured chat agent for your codebase. LLM ranks over a learned 67-tool subgraph instead of cold-picking, with durable pause/resume, three-role concern checks, and governed reasoning. Build a knowledge graph from any codebase where every module is a reasoning agent. Impact analysis, preflight governance, multi-agent synthesis. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
+description = "Architecture-aware AI coding assistant for your codebase. Build a knowledge graph from any project where every module is a reasoning agent. Governed code generation, impact analysis, preflight checks, multi-agent synthesis. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Proprietary — see LICENSE"}
 requires-python = ">=3.10"
@@ -42,6 +42,7 @@ classifiers = [
 ]
 
 dependencies = [
+    "jsonschema>=4.0",
     "networkx>=3.0",
     "numpy>=1.24",
     "pydantic>=2.0",


### PR DESCRIPTION
## Summary

Two post-merge fixes for v0.50.0 (PR #89).

### 1. Add missing `jsonschema` runtime dependency

The settings loader imports `jsonschema` but it was not declared in `pyproject.toml`, causing CI test collection to fail across Python 3.10 / 3.11 / 3.12 with `ModuleNotFoundError: No module named 'jsonschema'`.

- Added `jsonschema>=4.0` to the runtime dependencies
- Made the import defensive (`try/except ImportError`) in `settings_loader.py` so the module remains importable in unusual environments

### 2. Sanitize public-facing documentation to high-level only

Cleaned `README.md`, `CHANGELOG.md`, and `pyproject.toml` description so the public-facing copy describes **what the feature does and the value it delivers**, not internal implementation details.

- Hero tagline softened
- "What's New in v0.50.0" rewritten as user-facing features + value statements
- CHANGELOG v0.50.0 entry rewritten as a standard high-level changelog block
- pyproject description sanitized to marketing copy
- Internal code names removed from badges

## Test plan

- [ ] CI test matrix (3.10 / 3.11 / 3.12) passes on the hotfix branch
- [ ] `pip install .` works in a clean venv and imports `graqle.chat.settings_loader` without error
- [ ] README renders cleanly with the new v0.50.0 block
- [ ] CHANGELOG parses as valid markdown

## Related

- PR #89 (merged at `7c973b92`) — the v0.50.0 feature PR these hotfixes apply to

🤖 Generated with [Claude Code](https://claude.com/claude-code)
