### PR TITLE
fix(pkg): remove duplicate force-include — unblocks v0.50.0 PyPI publish

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,8 +153,12 @@ packages = ["graqle"]
 exclude = ["graqle/benchmarks/data/*"]
 
 [tool.hatch.build.targets.wheel.force-include]
+# NOTE: graqle/data/claude_gate is covered by packages=["graqle"] above.
+# Adding a force-include for a path already under the packages tree
+# creates duplicate local-header entries in the wheel ZIP and causes
+# PyPI to reject the upload with HTTP 400 "Duplicate filename in
+# local headers". Only force-include paths OUTSIDE the packages tree.
 "examples" = "graqle/examples"
-"graqle/data/claude_gate" = "graqle/data/claude_gate"
 
 [tool.ruff]
 target-version = "py310"


### PR DESCRIPTION
## Summary

Single-line packaging fix that unblocks the v0.50.0 PyPI publish.

### Root cause

The v0.50.0 publish run ([24290499364](https://github.com/quantamixsol/graqle/actions/runs/24290499364)) failed at the final `pypa/gh-action-pypi-publish` step with:

```
HTTP 400 Bad Request
Invalid distribution file. ZIP archive not accepted:
Duplicate filename in local headers.
```

Test matrix / smoke / audit / attestation all passed — the wheel itself was rejected by PyPI's hardened upload handler because of duplicate entries in the ZIP central directory.

### Why it happened

`pyproject.toml` had:

```toml
[tool.hatch.build.targets.wheel]
packages = ["graqle"]

[tool.hatch.build.targets.wheel.force-include]
"examples" = "graqle/examples"
"graqle/data/claude_gate" = "graqle/data/claude_gate"   # ← duplicate
```

`packages = ["graqle"]` already includes the full `graqle/` tree, so `graqle/data/claude_gate/*` was packaged **twice** — once via the normal package walk, once via `force-include`. Hatchling's builder emits a `UserWarning: Duplicate name:` for each duplicate file and writes them both into the final wheel ZIP. PyPI rejects any ZIP with duplicate local headers.

### Fix

Remove the redundant `force-include` for `graqle/data/claude_gate`. Keep `"examples"` because that path is **outside** the `graqle/` package tree and genuinely needs `force-include` to ship. Added an inline comment documenting the rule for future contributors: only force-include paths outside the packages tree.

### Verification on this branch

- `python -m build` — zero `UserWarning` duplicate-name messages (was 3)
- `python -m twine check dist/*` — PASSED on both the wheel and the sdist
- Wheel inspection: **431 unique entries / 431 total / 0 duplicates** (was 434 with 3 dupes)
- `graqle/data/claude_gate/*` still present in the wheel via the normal package include path (graqle-gate.py, graqle-gate.sh, settings.json) — no loss of function

### Test plan

- [ ] CI test matrix (3.10 / 3.11 / 3.12) passes
- [ ] Smoke tests (Ubuntu + Windows) pass
- [ ] pip-audit clean
- [ ] After merge, re-tag `v0.50.0` on the new merge commit → publish job succeeds → `graqle 0.50.0` live on PyPI

## Context

The previous v0.50.0 tag has been deleted locally and on origin. After this PR merges, we'll re-tag `v0.50.0` on the new merge commit to trigger a fresh publish run.

## Related

- Failed publish run: https://github.com/quantamixsol/graqle/actions/runs/24290499364
- PR #89 (the v0.50.0 feature)
- PR #90 (sanitization + jsonschema dep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
