### PR TITLE
fix(ci): governance-gate empty-files count bash bug

### DIFF
--- a/.github/workflows/governance-gate.yml
+++ b/.github/workflows/governance-gate.yml
@@ -47,7 +47,15 @@ jobs:
           echo "files<<EOF" >> "$GITHUB_OUTPUT"
           echo "$FILES" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
-          echo "count=$(echo "$FILES" | grep -c . || echo 0)" >> "$GITHUB_OUTPUT"
+          # Handle the empty-files case cleanly. The previous
+          # `grep -c . || echo 0` idiom produced "Invalid format '0'"
+          # because grep exits non-zero on no match AND still prints 0,
+          # so the `|| echo 0` fallback fired and appended a stray 0.
+          if [ -z "$FILES" ]; then
+            echo "count=0" >> "$GITHUB_OUTPUT"
+          else
+            echo "count=$(printf '%s\n' "$FILES" | sed '/^$/d' | wc -l)" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Run governance gate on changed files
         id: gate


### PR DESCRIPTION
## Summary

CI infrastructure fix for `.github/workflows/governance-gate.yml`. Unblocks PR #91 and any future PR that modifies only non-Python files.

### Root cause

Line 50 of `governance-gate.yml`:

```bash
echo "count=$(echo "$FILES" | grep -c . || echo 0)" >> "$GITHUB_OUTPUT"
```

When `$FILES` is empty (i.e. the PR touches 0 Python files):

- `echo "" | grep -c .` prints `0` AND exits with code 1
- The `|| echo 0` fallback then also fires and prints another `0`
- The shell substitution captures `0\n0`
- GitHub Actions rejects the resulting `count=0\n0` line with:

  ```
  ##[error]Unable to process file command 'output' successfully.
  ##[error]Invalid format '0'
  ```

Any PR that modifies only TOML / YAML / Markdown / docs hits this deterministically. Observed today on PR #91 which is a single-line `pyproject.toml` packaging fix to unblock the v0.50.0 PyPI publish.

### Fix

Explicitly branch on empty vs non-empty `$FILES`:

```bash
if [ -z "$FILES" ]; then
  echo "count=0" >> "$GITHUB_OUTPUT"
else
  echo "count=$(printf '%s\n' "$FILES" | sed '/^$/d' | wc -l)" >> "$GITHUB_OUTPUT"
fi
```

- `printf` + `sed '/^$/d'` + `wc -l` handles the count cleanly in all cases
- No more `grep -c . || echo 0` which has the exit-1-with-0-output trap
- When empty, writes `count=0` directly and the downstream `if: steps.changed.outputs.count != '0'` correctly skips the gate loop

### Verification plan

- **This PR itself** modifies only `.github/workflows/governance-gate.yml` (a YAML file, zero Python files changed) — it exercises the exact empty-files path that fails today
- If the fix works, the Governance Gate check on this PR should **PASS** (exit 0 with `count=0` and skip the actual gate loop)
- After merge, re-running CI on PR #91 picks up this workflow version and the Governance Gate check there turns green, unblocking the v0.50.0 publish retry

### Test plan

- [ ] CI test matrix (3.10 / 3.11 / 3.12) passes (unchanged by this diff — just a workflow YAML)
- [ ] **Governance Gate check on this PR** passes (the critical test)
- [ ] Smoke tests (Ubuntu + Windows) pass
- [ ] ip-protection-gate + pip-audit + PR Guardian all pass

### Context

- Related to PR #91 (packaging fix, blocked on this bug)
- Related to v0.50.0 PyPI publish (blocked on PR #91)
- Failed Governance Gate run on PR #91: [run 24290735570](https://github.com/quantamixsol/graqle/actions/runs/24290735570)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
