### PR TITLE
fix(v0.50.1): restore public pyproject.toml hotfixes lost in squash (follow-up to #93)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ classifiers = [
 ]
 
 dependencies = [
+    "jsonschema>=4.0",
     "networkx>=3.0",
     "numpy>=1.24",
     "pydantic>=2.0",
@@ -152,8 +153,12 @@ packages = ["graqle"]
 exclude = ["graqle/benchmarks/data/*"]
 
 [tool.hatch.build.targets.wheel.force-include]
+# NOTE: graqle/data/claude_gate is covered by packages=["graqle"] above.
+# Adding a force-include for a path already under the packages tree
+# creates duplicate local-header entries in the wheel ZIP and causes
+# PyPI to reject the upload with HTTP 400 "Duplicate filename in
+# local headers". Only force-include paths OUTSIDE the packages tree.
 "examples" = "graqle/examples"
-"graqle/data/claude_gate" = "graqle/data/claude_gate"
 
 [tool.ruff]
 target-version = "py310"


### PR DESCRIPTION
## Summary
Follow-up to #93. Public CI run [24294926454](https://github.com/quantamixsol/graqle/actions/runs/24294926454) failed on `test (3.11)` because the squash commit `c79d4829` took `pyproject.toml` whole-file from private master and silently dropped two public-only hotfixes.

## Root cause
| Dropped hotfix | Effect |
|---|---|
| `cb8ad3a0` — `fix(v0.50.0): ... add missing jsonschema dep` | Without `jsonschema>=4.0` declared as a runtime dependency, a clean Python 3.11 venv (CI matrix) has no `jsonschema`. The eager import in `graqle/chat/settings_loader.py` falls through to `Draft202012Validator = None` via its defensive `except ImportError` block. All 9 tests in `tests/test_chat/test_settings_loader.py` then raise `TypeError: NoneType object is not callable` at line 218. |
| `9669b4c1` — `fix(pkg): remove duplicate force-include causing PyPI HTTP 400 upload reject` | Re-adding `"graqle/data/claude_gate" = "graqle/data/claude_gate"` alongside `packages = ["graqle"]` creates duplicate local-header entries in the wheel ZIP. PyPI would reject the tag-triggered publish with HTTP 400 "Duplicate filename in local headers". |

Both lines were reintroduced by #93's squash because private master never backported them.

## Fix
**1 file, 6 insertions / 1 deletion:**
- Add `"jsonschema>=4.0"` back to `[project].dependencies` (first entry, alphabetical)
- Remove `"graqle/data/claude_gate" = "graqle/data/claude_gate"` from `[tool.hatch.build.targets.wheel.force-include]`
- Restore the 5-line `NOTE` comment explaining why the force-include was removed (defends against the same regression happening again on a future merge)

Version stays at `0.50.1`. No code changes, no test changes.

## Test plan
- [x] `pytest tests/test_chat/test_settings_loader.py tests/test_public_api tests/test_distribution` → **26/26 pass locally**
- [x] `tomli` parse of the updated `pyproject.toml` confirms: `jsonschema` in deps, `force-include` keys == `["examples"]`, version == `"0.50.1"`
- [x] `graq_reason` independent pass on the fix: **96% confidence safe**
- [x] GraQle governance gate **ACTIVE** throughout
- [ ] Operator approval on this PR
- [ ] Re-run public CI on merge commit — `test (3.11)` must go green
- [ ] Tag `v0.50.1` after CI green
- [ ] CI publishes via Trusted Publishing
- [ ] Post-publish smoke in `.tmp_dogfood_venv`

## Governance gap logged
The squash-from-private workflow needs a **3-way merge step for `pyproject.toml`** (and any other file both branches edit independently). A whole-file `git checkout private/master -- pyproject.toml` is unsafe when the two branches have diverged on the same file. Logging as `CG-SQUASH-MERGE-01` in `.gcc/OPEN-TRACKER-CAPABILITY-GAPS.md` so future hotfix ships run a pre-squash compare:

```sh
git diff origin/master...private/master -- pyproject.toml  # inspect BEFORE checkout
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
