### PR TITLE
fix(v0.51.0): restore CORS if-guard in app.py collapsed by sanitization

### DIFF
--- a/graqle/server/app.py
+++ b/graqle/server/app.py
@@ -153,7 +153,8 @@ def create_app(
     from starlette.middleware.gzip import GZipMiddleware
     app.add_middleware(GZipMiddleware, minimum_size=1000)
 
-    # CORS middleware — skip on Lambda where Function URL handles CORS if not os.environ.get("AWS_LAMBDA_FUNCTION_NAME"):
+    # CORS middleware — skip on Lambda where Function URL handles CORS
+    if not os.environ.get("AWS_LAMBDA_FUNCTION_NAME"):
         app.add_middleware(
             CORSMiddleware,
             allow_origins=["*"],


### PR DESCRIPTION
1 file, 2 ins / 1 del. The ADR-N regex strip collapsed an if-statement into a comment at app.py:156, causing unexpected indent on Lambda deploy. 392/392 .py files AST-clean after fix.