### PR TITLE
chore(release): bump version to v0.51.4

### DIFF
--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.51.3"
+__version__ = "0.51.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.51.3"
+version = "0.51.4"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Proprietary — see LICENSE"}


### PR DESCRIPTION
## Summary

Bumps `graqle/__version__.py` and `pyproject.toml` from `0.51.3` → `0.51.4`.

PR #104 (the v0.51.4 hotfix) merged the code changes but did not bump the version files. Without this bump the v0.51.4 git tag would point at a commit whose `pyproject.version` is still `0.51.3`, and the trusted-publisher CI would either reject (duplicate version) or accidentally publish as `0.51.3`.

This is a 2-line release housekeeping commit.

## Files

- `graqle/__version__.py`: `0.51.3` → `0.51.4`
- `pyproject.toml`: `0.51.3` → `0.51.4`

## After merge

1. `git tag v0.51.4 <merge-commit>`
2. `git push origin v0.51.4` → CI trusted-publisher → PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)