### PR TITLE
hotfix(v0.51.6): skip TestMigrateJsonToNeo4j when neo4j driver not installed

### DIFF
--- a/tests/test_connectors/test_upgrade.py
+++ b/tests/test_connectors/test_upgrade.py
@@ -8,10 +8,18 @@
 # ── /graqle:intelligence ──
 
 
+import importlib.util
 import json
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+# CI fix (2026-04-16): the TestMigrateJsonToNeo4j class exercises code that
+# imports `graqle.connectors.neo4j`, which in turn imports the third-party
+# `neo4j` driver at module-load time. The driver is an optional extra
+# (`pip install graqle[api]`), not installed on the default CI matrix. Skip
+# the whole class when the driver is unavailable so CI stays green.
+_NEO4J_AVAILABLE = importlib.util.find_spec("neo4j") is not None
 
 from graqle.connectors.upgrade import (
     NODE_THRESHOLD,
@@ -154,6 +162,10 @@ class TestSanitiseForNeo4jProps:
         assert out["versions"] == ["1.0", "2.0"]
 
 
+@pytest.mark.skipif(
+    not _NEO4J_AVAILABLE,
+    reason="neo4j driver not installed (optional extra); run `pip install graqle[api]` to enable",
+)
 class TestMigrateJsonToNeo4j:
     """Hot-fix 2026-04-16: chunks must become :Chunk nodes, not scalar props.
 


### PR DESCRIPTION
## Summary - PR #107 (v0.51.6) added 4 tests in tests/test_connectors/test_upgrade.py::TestMigrateJsonToNeo4j that import graqle.connectors.neo4j (which imports the optional 'neo4j' driver at module load). - Default CI matrix does not install the graqle[api] extra, so the import fails with ModuleNotFoundError and all 4 tests report as failures. - publish job on ci.yml has needs: [test, audit] - so v0.51.6 tag push did not reach PyPI. ## Fix Add a class-level @pytest.mark.skipif keyed on importlib.util.find_spec('neo4j'). Tests skip cleanly with a 'pip install graqle[api]' hint when the driver is missing; run normally when it is present (local dev, CI matrices with the api extra). No logic changes. ## Test plan - [x] Diff is 12 insertions, pure pytest gate - [x] Local regression unchanged (693/693 where graqle[api] is installed) - [ ] CI matrix (3.10/3.11/3.12) green after merge - [ ] v0.51.6 tag re-cut on the merge commit triggers a clean publish job