### PR TITLE
fix(build): remove duplicate force-include causing PyPI 400 on v0.52.0a1 publish

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,6 @@ exclude = ["graqle/benchmarks/data/*"]
 # PyPI to reject the upload with HTTP 400 "Duplicate filename in
 # local headers". Only force-include paths OUTSIDE the packages tree.
 "examples" = "graqle/examples"
-"graqle/data/claude_gate" = "graqle/data/claude_gate"
 
 [tool.ruff]
 target-version = "py310"


### PR DESCRIPTION
## Summary

Hotfix for the v0.52.0a1 publish failure. Single-line removal.

**Root cause:** `pyproject.toml` had a `[tool.hatch.build.targets.wheel.force-include]` entry for `graqle/data/claude_gate` — a directory already covered by `packages = ["graqle"]`. Hatchling wrote each of the three files (`graqle-gate.py`, `graqle-gate.sh`, `settings.json`) **twice** into the wheel ZIP.

`twine check` passes the result (Python's `zipfile` tolerates duplicate entries). **PyPI's stricter upload-time check does not** — it rejected the upload with:

```
HTTP 400: Invalid distribution file. ZIP archive not accepted:
Duplicate filename in local headers.
```

The comment block immediately above the offending line **already documented this exact failure mode** ("Only force-include paths OUTSIDE the packages tree") — the fix is to delete the contradicting line.

## Test plan

- [x] Local rebuild after fix: **444 entries, 444 unique, 0 duplicates** (1,791,566 bytes — ~3 KB smaller than the rejected wheel)
- [x] No `UserWarning: Duplicate name:` during `python -m build`
- [ ] CI on this PR: full test matrix (reuses the same config as v0.52.0a1 tag-run which was green on all 6 gates — the only failure was the publish job itself)
- [ ] After merge: re-tag `v0.52.0a1` on new master HEAD → `ci.yml` publish job → OIDC → real PyPI
- [ ] Post-publish: `pip install --pre graqle==0.52.0a1` in fresh venv, confirm 0.52.0a1 listed on PyPI

## Why re-tag the same version (not bump to 0.52.0a2)

Nothing from v0.52.0a1 was ever uploaded to PyPI — the 400 rejection happened before any byte was stored server-side. The version number `0.52.0a1` is still available. The previous git tag will be deleted and re-pushed on the new master HEAD (containing this fix). No consumer has downloaded anything claiming to be 0.52.0a1.

## Related

- Failed publish run: [run 24696724247](https://github.com/quantamixsol/graqle/actions/runs/24696724247) — all 6 gate jobs green, publish job failed
- Wave 1 PR merged: #109 → commit `0d869a1c`
- Original Wave 1 commit: `d247adbe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
