### PR TITLE
chore(release): bump version to 0.52.0a2

### DIFF
--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.52.0a1"
+__version__ = "0.52.0a2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.52.0a1"
+version = "0.52.0a2"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Proprietary — see LICENSE"}


### PR DESCRIPTION
Version bump only. Ships CG-19 Routing Gate (PR #114 merged as d218f6e2 on master). Pre-publish wheel smoke: **446 entries / 446 unique / 0 dupes** (prevents repeat of v0.52.0a1 duplicate-filename 400). On merge: tag v0.52.0a2 → ci.yml publish job → OIDC → real PyPI. 🤖 Generated with [Claude Code](https://claude.com/claude-code)