### PR TITLE
fix(cg-19): restore missing graq_route schema + regression tests + 0.52.0a3 (HOTFIX for 0.52.0a2)

### DIFF
--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.52.0a2"
+__version__ = "0.52.0a3"

--- a/graqle/plugins/mcp_dev_server.py
+++ b/graqle/plugins/mcp_dev_server.py
@@ -808,7 +808,9 @@ TOOL_DEFINITIONS: list[dict[str, Any]] = [
             "Smart query router — classifies your question and recommends "
             "whether to use GraQle tools or external tools (CloudWatch, grep, git). "
             "Call this BEFORE investigating to get the most efficient tool strategy. "
-            "Returns: category, recommended tools, confidence, and reasoning."
+            "Returns: category, recommended tools, confidence, and reasoning. "
+            "CG-19: pass available_tools (and optionally permission_tier) to pre-filter "
+            "the recommendation to tools the calling client can actually invoke."
         ),
         "inputSchema": {
             "type": "object",
@@ -816,6 +818,27 @@ TOOL_DEFINITIONS: list[dict[str, Any]] = [
                 "question": {
                     "type": "string",
                     "description": "The question or investigation topic to route",
+                },
+                "available_tools": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "CG-19 (advisory): list of tool names the calling client is permitted to invoke. "
+                        "When provided, the recommendation's graqle_tools is intersected with this set and "
+                        "filtered tools are surfaced separately. This is NOT a server-enforced auth boundary "
+                        "— the client owns real permission enforcement; this field only helps the router "
+                        "recommend tools the client can actually call."
+                    ),
+                },
+                "permission_tier": {
+                    "type": "string",
+                    "enum": ["ADVISORY", "ENFORCED"],
+                    "description": (
+                        "CG-19 (advisory): how to present the filter result. "
+                        "ADVISORY (default): keep full recommendation, annotate with filtered_tools. "
+                        "ENFORCED: replace graqle_tools with the filtered subset; if empty, downgrade the "
+                        "recommendation to external_only / blocked. Requires available_tools to take effect."
+                    ),
                 },
             },
             "required": ["question"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.52.0a2"
+version = "0.52.0a3"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Proprietary — see LICENSE"}

--- a/tests/test_plugins/test_cg19_routing_gate.py
+++ b/tests/test_plugins/test_cg19_routing_gate.py
@@ -245,3 +245,49 @@ def test_tier_without_available_tools_is_backcompat(server):
     payload = json.loads(raw)
     # Back-compat path: no cg19_applied key
     assert "cg19_applied" not in payload
+
+# ─── CG-19 tool-schema shape regression (would have caught the 0.52.0a2 bug) ─
+
+def test_graq_route_schema_has_cg19_params():
+    """The graq_route tool schema MUST expose available_tools and permission_tier.
+
+    This test would have caught the 0.52.0a2 bug where the handler contained
+    CG-19 validation logic but the schema block was never updated — so MCP
+    clients never saw the new parameters. Tests that only exercise the
+    handler directly bypass the schema entirely and miss this class of bug.
+    """
+    from graqle.plugins.mcp_dev_server import TOOL_DEFINITIONS
+    route = next((t for t in TOOL_DEFINITIONS if t["name"] == "graq_route"), None)
+    assert route is not None, "graq_route tool must be defined"
+    props = route["inputSchema"]["properties"]
+    assert "available_tools" in props, (
+        "CG-19: graq_route schema MUST expose 'available_tools'. "
+        "0.52.0a2 shipped without this; 0.52.0a3 restored it."
+    )
+    assert "permission_tier" in props, (
+        "CG-19: graq_route schema MUST expose 'permission_tier'."
+    )
+
+
+def test_available_tools_schema_is_array_of_strings():
+    from graqle.plugins.mcp_dev_server import TOOL_DEFINITIONS
+    route = next(t for t in TOOL_DEFINITIONS if t["name"] == "graq_route")
+    at = route["inputSchema"]["properties"]["available_tools"]
+    assert at["type"] == "array"
+    assert at["items"] == {"type": "string"}
+
+
+def test_permission_tier_schema_is_strict_enum():
+    from graqle.plugins.mcp_dev_server import TOOL_DEFINITIONS
+    route = next(t for t in TOOL_DEFINITIONS if t["name"] == "graq_route")
+    pt = route["inputSchema"]["properties"]["permission_tier"]
+    assert pt["type"] == "string"
+    assert set(pt["enum"]) == {"ADVISORY", "ENFORCED"}
+
+
+def test_question_still_the_only_required_field():
+    """CG-19 fields are optional — back-compat guarantee at the schema layer."""
+    from graqle.plugins.mcp_dev_server import TOOL_DEFINITIONS
+    route = next(t for t in TOOL_DEFINITIONS if t["name"] == "graq_route")
+    assert route["inputSchema"]["required"] == ["question"]
+


### PR DESCRIPTION
## Summary

**HOTFIX for v0.52.0a2.** Public-side mirror of private PR #65 (merged `33961c37` on 2026-04-21). CG-19 shipped half-implemented to real PyPI as `0.52.0a2`: handler had the validation + filter logic, but the tool schema was never updated — so MCP clients couldn't invoke the new `available_tools` / `permission_tier` parameters. This PR restores the schema, adds 4 regression tests that would have caught the original bug, and bumps to `0.52.0a3`.

## Root cause

- Original CG-19 implementation required two `graq_edit` calls (schema + handler). The schema call returned `success: true` / `confidence: 0.9` / `strategy_used: literal` — the success claim was false and the schema was never written to disk.
- The handler edit was caught and fixed via the Deterministic Insertion Pattern. The schema miss was invisible because all 17 tests called `_handle_route(args)` directly, bypassing `TOOL_DEFINITIONS`.
- Bug rode through: private PR #64 → public PR #114 → PR #115 → tag `v0.52.0a2` → CI OIDC → PyPI.
- Caught on post-publish dogfood: fresh `pip install --pre graqle==0.52.0a2` revealed `TOOL_DEFINITIONS["graq_route"]["inputSchema"]["properties"]` contained only `question`.

## Fixes (same 4 as private PR #65)

1. **Schema restored** via Deterministic Insertion Pattern (not `graq_edit` — root cause): `available_tools` (array of string) + `permission_tier` (enum `ADVISORY`/`ENFORCED`), both optional
2. **4 new schema-shape regression tests** in `test_cg19_routing_gate.py` asserting `TOOL_DEFINITIONS` contains the new params with correct types — would have caught the original bug
3. **Version bump** `0.52.0a2` → `0.52.0a3`
4. **pyproject.toml claude_gate `force-include` removal** re-applied (matches public PR #110). The private branch didn't have that fix, so the patch re-introduced it; removed again to prevent the wheel-dupe 400 on publish

## Pre-commit evidence (all green)

| Gate | Result |
|---|---|
| Disk verification per new lesson | ✅ 14 `available_tools` refs present, shape-test present, versions at `0.52.0a3` |
| Scoped pytest (21 tests) | ✅ 21/21 in 1.61s |
| Wheel smoke | ✅ **446 entries / 446 unique / 0 dupes** |
| AST parse | ✅ clean (10,954 lines) |
| Sanitization pass | ✅ 0 residual hits across 7,207 files (ADR-205/206/207, `.gcc/branches/hotfix-v0.51.6`, `EXECUTION-PATH`) |

## Files

- `graqle/__version__.py` (`0.52.0a2` → `0.52.0a3`)
- `pyproject.toml` (version bump + remove `claude_gate` `force-include` line)
- `graqle/plugins/mcp_dev_server.py` (+25 lines: schema additions to `graq_route` tool)
- `tests/test_plugins/test_cg19_routing_gate.py` (+46 lines: 4 schema-shape regression tests)

**4 files, +72 / −3** — exact scope of private PR #65.

## Lesson

Cross-session memory: `feedback_verify_disk_state_after_graq_edit.md`.

**Rules enforced going forward:**
1. Always verify disk state after every `graq_edit` / `graq_write` before the next step
2. Every MCP tool feature ships two tests: handler-behavior + schema-shape
3. Every release verified with `TOOL_DEFINITIONS` inspection in fresh venv, not just `import graqle`
4. `CG-EDIT-WRONG-LOCATION-01` promoted to P0

## Test plan

- [x] Scoped pytest in fresh venv
- [x] Wheel dedup check passes
- [x] AST parse clean
- [x] Sanitization verify 0 residual hits
- [x] Disk verification for every staged change
- [ ] CI on this PR: full matrix + ubuntu/windows smoke
- [ ] After merge: tag `v0.52.0a3` → CI OIDC → real PyPI
- [ ] Post-publish: `pip install --pre graqle==0.52.0a3` + `TOOL_DEFINITIONS` schema inspection verifies `available_tools` + `permission_tier` exposed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
