### PR TITLE
feat(governance): ship R18+R19+R20+R21 governance modules to public (ADR-201..204)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,7 @@ jobs:
             --ignore=tests/test_orchestration/test_debate.py \
             --ignore=tests/test_plugins/test_mcp_server.py \
             --ignore=tests/test_server/test_middleware.py \
-            --ignore=tests/test_server/test_models.py \
-            --ignore=tests/test_governance/test_shacl.py
+            --ignore=tests/test_server/test_models.py
 
       - name: Upload coverage report
         if: matrix.python-version == '3.12'

--- a/graqle/cli/commands/calibrate_governance.py
+++ b/graqle/cli/commands/calibrate_governance.py
@@ -1,0 +1,217 @@
+# ------------------------------------------------------------------
+# PATENT NOTICE -- Quantamix Solutions B.V.
+#
+# This module implements methods covered by European Patent
+# Application EP26166054.2 (Divisional, Claims F-J), owned by
+# Quantamix Solutions B.V.
+#
+# Use of this software is permitted under the graqle license.
+# Reimplementation of the patented methods outside this software
+# requires a separate patent license.
+#
+# Contact: support@quantamixsolutions.com
+# ------------------------------------------------------------------
+
+"""GraQle governance calibration CLI (R20 ADR-203).
+
+Provides ``graq calibrate-governance`` commands for audit-grade
+calibration of governance scores against real outcomes.
+
+Subcommands:
+    fit         Fit calibration model from (score, outcome) pairs
+    status      Show current calibration model status and ECE
+    predict     Predict calibrated risk for a given score
+    diagram     Export reliability diagram as SVG
+    versions    List all calibration versions
+
+This is separate from ``graq calibrate`` (R11 reasoning calibration)
+to avoid collision with existing CLI surface.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from graqle.governance.calibration import Calibrator, MIN_SAMPLES
+from graqle.governance.calibration_store import CalibrationStore
+from graqle.governance.reliability_diagram import generate_svg
+
+calibrate_governance_app = typer.Typer(
+    name="calibrate-governance",
+    help="R20 AGGC: Audit-grade governance score calibration.",
+    no_args_is_help=True,
+)
+
+
+@calibrate_governance_app.command("fit")
+def fit_command(
+    pairs_file: Path = typer.Argument(
+        ...,
+        help="JSONL file with {score, outcome} pairs (one per line).",
+    ),
+    method: str = typer.Option(
+        "isotonic",
+        help="Calibration method: platt or isotonic (default).",
+    ),
+    bootstrap_b: int = typer.Option(
+        100,
+        help="Bootstrap samples for confidence intervals (0 to skip).",
+    ),
+    output_dir: Path = typer.Option(
+        Path(".graqle/calibration"),
+        help="Directory to save calibration model.",
+    ),
+    seed: Optional[int] = typer.Option(None, help="Random seed."),
+) -> None:
+    """Fit a calibration model from (score, outcome) pairs."""
+    if not pairs_file.exists():
+        typer.secho(f"File not found: {pairs_file}", fg=typer.colors.RED)
+        raise typer.Exit(1)
+
+    pairs: list[tuple[float, int]] = []
+    with open(pairs_file, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            data = json.loads(line)
+            score = float(data["score"])
+            outcome = int(data["outcome"])
+            pairs.append((score, outcome))
+
+    typer.echo(f"Loaded {len(pairs)} (score, outcome) pairs")
+
+    if len(pairs) < MIN_SAMPLES:
+        typer.secho(
+            f"Warning: only {len(pairs)} pairs provided, minimum is {MIN_SAMPLES}",
+            fg=typer.colors.YELLOW,
+        )
+
+    cal = Calibrator()
+    model = cal.fit(pairs, method=method, bootstrap_b=bootstrap_b, seed=seed)
+
+    store = CalibrationStore(store_dir=output_dir)
+    path = store.save(model)
+
+    typer.echo(f"Status:  {model.status}")
+    typer.echo(f"Method:  {model.method}")
+    typer.echo(f"N:       {model.n_samples}")
+    if model.ece is not None:
+        typer.echo(f"ECE:     {model.ece:.4f}")
+        color = typer.colors.GREEN if model.ece_passed else typer.colors.YELLOW
+        typer.secho(
+            f"Target:  < {model.target_ece} ({'PASS' if model.ece_passed else 'FAIL'})",
+            fg=color,
+        )
+    typer.echo(f"Saved:   {path}")
+
+
+@calibrate_governance_app.command("status")
+def status_command(
+    store_dir: Path = typer.Option(
+        Path(".graqle/calibration"),
+        help="Directory containing calibration models.",
+    ),
+) -> None:
+    """Show current calibration model status."""
+    store = CalibrationStore(store_dir=store_dir)
+    current = store.load_current()
+    if current is None:
+        typer.secho("No active calibration model", fg=typer.colors.YELLOW)
+        versions = store.list_versions()
+        if versions:
+            typer.echo(f"Available versions: {len(versions)}")
+        raise typer.Exit(0)
+
+    typer.echo(f"Version: {current.version}")
+    typer.echo(f"Status:  {current.status}")
+    typer.echo(f"Method:  {current.method}")
+    typer.echo(f"N:       {current.n_samples}")
+    if current.ece is not None:
+        typer.echo(f"ECE:     {current.ece:.4f}")
+    typer.echo(f"Created: {current.created_at}")
+
+
+@calibrate_governance_app.command("predict")
+def predict_command(
+    score: float = typer.Argument(..., help="Governance score (0-100)."),
+    store_dir: Path = typer.Option(
+        Path(".graqle/calibration"),
+        help="Directory containing calibration models.",
+    ),
+) -> None:
+    """Predict calibrated risk for a governance score."""
+    store = CalibrationStore(store_dir=store_dir)
+    model = store.load_current()
+    if model is None:
+        typer.secho("No active calibration model", fg=typer.colors.RED)
+        raise typer.Exit(1)
+
+    cal = Calibrator()
+    cal.load_model(model)
+    prediction = cal.predict(score)
+
+    typer.echo(f"Score:    {prediction.score}")
+    typer.echo(f"Risk:     {prediction.risk:.4f}")
+    if prediction.ci_lower is not None:
+        typer.echo(f"CI:       [{prediction.ci_lower:.4f}, {prediction.ci_upper:.4f}]")
+    typer.echo(f"Status:   {prediction.status}")
+
+
+@calibrate_governance_app.command("diagram")
+def diagram_command(
+    output: Path = typer.Argument(..., help="Output SVG file path."),
+    version: Optional[str] = typer.Option(
+        None,
+        help="Specific version to plot (default: current).",
+    ),
+    store_dir: Path = typer.Option(
+        Path(".graqle/calibration"),
+        help="Directory containing calibration models.",
+    ),
+) -> None:
+    """Export reliability diagram as SVG."""
+    store = CalibrationStore(store_dir=store_dir)
+    if version:
+        model = store.load(version)
+    else:
+        model = store.load_current()
+    if model is None:
+        typer.secho("No calibration model found", fg=typer.colors.RED)
+        raise typer.Exit(1)
+
+    svg = generate_svg(model)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(svg, encoding="utf-8")
+    typer.secho(f"Reliability diagram written: {output}", fg=typer.colors.GREEN)
+
+
+@calibrate_governance_app.command("versions")
+def versions_command(
+    store_dir: Path = typer.Option(
+        Path(".graqle/calibration"),
+        help="Directory containing calibration models.",
+    ),
+) -> None:
+    """List all calibration versions."""
+    store = CalibrationStore(store_dir=store_dir)
+    versions = store.list_versions()
+    if not versions:
+        typer.echo("No calibration versions found")
+        return
+
+    typer.echo(f"{'Version':<20} {'Method':<10} {'Status':<15} {'N':<8} {'ECE':<8}")
+    typer.echo("-" * 70)
+    for v in versions:
+        ece_str = f"{v.get('ece', 0):.4f}" if v.get("ece") is not None else "N/A"
+        typer.echo(
+            f"{v.get('version', '')[:18]:<20} "
+            f"{v.get('method', ''):<10} "
+            f"{v.get('status', ''):<15} "
+            f"{v.get('n_samples', 0):<8} "
+            f"{ece_str:<8}"
+        )

--- a/graqle/governance/__init__.py
+++ b/graqle/governance/__init__.py
@@ -1,10 +1,14 @@
 """Governance primitives for graqle.
 
-Exposes the CG-14 config-drift auditor and its typed errors. Shared
-primitive consumed by CG-15 (KG-write gate) and G4 (protected_paths)
-in Wave 2 Phase 4.
+Wave 2 (0.52.0b1): CG-14 config-drift auditor, CG-15 KG-write gate,
+G4 protected_paths, CG-12 web gate, CG-13 deps gate.
+
+R18 (ADR-201): Governed Execution Trace Capture — append-only trace schema,
+foundation for R19 (Failure Chain Prediction), R20 (Calibration),
+R21 (Cross-Org Transfer), R23 (Embedding Fine-Tuning).
 """
 
+# Wave 2 — config-drift, KG-write, web, deps gates
 from graqle.governance.config_drift import (
     BaselineCorruptedError,
     ConfigDriftAuditor,
@@ -24,7 +28,18 @@ from graqle.governance.web_gate import (
 )
 from graqle.governance.deps_gate import check_deps_install
 
+# R18 — governed trace schema (public surface only; GovernanceDecision is TS-2 internal)
+from graqle.governance.trace_schema import (
+    ClearanceLevel,
+    Decision,
+    GateType,
+    GovernedTrace,
+    Outcome,
+    ToolCall,
+)
+
 __all__ = [
+    # Wave 2 gates
     "BaselineCorruptedError",
     "ConfigDriftAuditor",
     "DriftRecord",
@@ -35,4 +50,11 @@ __all__ = [
     "check_deps_install",
     "sanitize_response_content",
     "RedirectBlocked",
+    # R18 trace schema
+    "ClearanceLevel",
+    "Decision",
+    "GateType",
+    "GovernedTrace",
+    "Outcome",
+    "ToolCall",
 ]

--- a/graqle/governance/adaptation.py
+++ b/graqle/governance/adaptation.py
@@ -1,0 +1,194 @@
+# ------------------------------------------------------------------
+# PATENT NOTICE -- Quantamix Solutions B.V.
+#
+# This module implements methods covered by European Patent
+# Applications EP26162901.8, EP26166054.2, EP26167849.4 (composite),
+# owned by Quantamix Solutions B.V.
+#
+# Use of this software is permitted under the graqle license.
+# Reimplementation of the patented methods outside this software
+# requires a separate patent license.
+#
+# Contact: support@quantamixsolutions.com
+# ------------------------------------------------------------------
+
+"""Pattern Adaptation for Target Organization (R21 ADR-204).
+
+Rewrites abstract pattern identifiers through target-org mapping tables.
+Preserves structure, ordering, and semantic meaning; replaces identifiers
+only.
+
+Fail-closed posture: if a mapping is missing, the adaptation fails.
+No raw source identifiers ever survive into the adapted pattern.
+
+TS-2 Gate: Adaptation algorithm is core IP.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from graqle.governance.pattern_abstractor import (
+    AbstractPattern,
+    ClearanceTransition,
+    GateStep,
+    verify_privacy,
+)
+
+logger = logging.getLogger("graqle.governance.adaptation")
+
+
+class TargetOrgContext(BaseModel):
+    """Target organization mapping context.
+
+    Each org supplies its own mapping tables to translate abstract
+    gate classes and clearance labels back to concrete identifiers
+    for that org.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    org_id: str  # Raw org id — hashed on use, never stored in adapted pattern
+    gate_type_map: dict[str, str] = Field(default_factory=dict)
+    clearance_map: dict[str, str] = Field(default_factory=dict)
+    tool_name_map: dict[str, str] = Field(default_factory=dict)
+    adapter_version: str = "r21.v1"
+    strict: bool = True  # If True: fail closed on unknown mappings
+
+    @property
+    def org_hash(self) -> str:
+        return hashlib.sha256(self.org_id.encode("utf-8")).hexdigest()
+
+
+class AdaptationResult(BaseModel):
+    """Result of adapting a pattern to a target org."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    adapted_pattern: AbstractPattern
+    target_org_hash: str
+    unmapped_gates: list[str] = Field(default_factory=list)
+    unmapped_clearances: list[str] = Field(default_factory=list)
+    adapted_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class AdaptationError(Exception):
+    """Raised when adaptation fails (fail-closed on unknown mappings in strict mode)."""
+
+
+def adapt_pattern(
+    pattern: AbstractPattern,
+    context: TargetOrgContext,
+) -> AdaptationResult:
+    """Adapt an abstract pattern to a target organization's identifiers.
+
+    Parameters
+    ----------
+    pattern:
+        Abstract pattern from source org (already privacy-verified).
+    context:
+        Target org mapping tables.
+
+    Returns
+    -------
+    AdaptationResult with adapted pattern pointing to target org.
+
+    Raises
+    ------
+    AdaptationError: in strict mode if any mapping is missing.
+    """
+    unmapped_gates: list[str] = []
+    unmapped_clearances: list[str] = []
+
+    # Adapt each gate step
+    new_gate_sequence: list[GateStep] = []
+    for step in pattern.gate_sequence:
+        mapped_gate = context.gate_type_map.get(step.gate_type)
+        if mapped_gate is None:
+            if context.strict:
+                unmapped_gates.append(step.gate_type)
+                continue
+            mapped_gate = "TARGET_UNKNOWN_GATE"
+
+        mapped_clearance_before = context.clearance_map.get(step.clearance_before)
+        mapped_clearance_after = context.clearance_map.get(step.clearance_after)
+
+        if mapped_clearance_before is None:
+            if context.strict:
+                unmapped_clearances.append(step.clearance_before)
+                continue
+            mapped_clearance_before = "TARGET_UNKNOWN_CLEARANCE"
+
+        if mapped_clearance_after is None:
+            if context.strict:
+                unmapped_clearances.append(step.clearance_after)
+                continue
+            mapped_clearance_after = "TARGET_UNKNOWN_CLEARANCE"
+
+        new_gate_sequence.append(GateStep(
+            gate_type=mapped_gate,
+            decision=step.decision,  # decisions are already abstract
+            clearance_before=mapped_clearance_before,
+            clearance_after=mapped_clearance_after,
+            outcome=step.outcome,
+            ordinal=step.ordinal,
+        ))
+
+    # Adapt clearance transitions
+    new_transitions: list[ClearanceTransition] = []
+    for trans in pattern.clearance_transitions:
+        from_level = context.clearance_map.get(trans.from_level)
+        to_level = context.clearance_map.get(trans.to_level)
+        trigger = context.gate_type_map.get(trans.trigger_gate)
+        if from_level is None or to_level is None or trigger is None:
+            if context.strict:
+                if from_level is None:
+                    unmapped_clearances.append(trans.from_level)
+                if to_level is None:
+                    unmapped_clearances.append(trans.to_level)
+                if trigger is None:
+                    unmapped_gates.append(trans.trigger_gate)
+                continue
+            from_level = from_level or "TARGET_UNKNOWN_CLEARANCE"
+            to_level = to_level or "TARGET_UNKNOWN_CLEARANCE"
+            trigger = trigger or "TARGET_UNKNOWN_GATE"
+        new_transitions.append(ClearanceTransition(
+            from_level=from_level,
+            to_level=to_level,
+            trigger_gate=trigger,
+        ))
+
+    # Fail-closed check
+    if context.strict and (unmapped_gates or unmapped_clearances):
+        raise AdaptationError(
+            f"Adaptation failed in strict mode: "
+            f"unmapped_gates={sorted(set(unmapped_gates))}, "
+            f"unmapped_clearances={sorted(set(unmapped_clearances))}"
+        )
+
+    # Build adapted pattern — source_org_hash replaced with target's hash
+    adapted = pattern.model_copy(update={
+        "pattern_id": f"adapted-{pattern.pattern_id}-{context.org_hash[:8]}",
+        "source_org_hash": context.org_hash,  # now points to target
+        "gate_sequence": new_gate_sequence,
+        "clearance_transitions": new_transitions,
+    })
+
+    # Post-adaptation privacy verification
+    if not verify_privacy(adapted):
+        raise AdaptationError(
+            "Adapted pattern failed post-adaptation privacy verification. "
+            "Possible leakage of source-org identifiers."
+        )
+
+    return AdaptationResult(
+        adapted_pattern=adapted,
+        target_org_hash=context.org_hash,
+        unmapped_gates=sorted(set(unmapped_gates)),
+        unmapped_clearances=sorted(set(unmapped_clearances)),
+    )

--- a/graqle/governance/calibration.py
+++ b/graqle/governance/calibration.py
@@ -1,0 +1,501 @@
+# ------------------------------------------------------------------
+# PATENT NOTICE -- Quantamix Solutions B.V.
+#
+# This module implements methods covered by European Patent
+# Application EP26166054.2 (Divisional, Claims F-J), owned by
+# Quantamix Solutions B.V.
+#
+# Use of this software is permitted under the graqle license.
+# Reimplementation of the patented methods outside this software
+# requires a separate patent license.
+#
+# Contact: support@quantamixsolutions.com
+# ------------------------------------------------------------------
+
+"""Audit-Grade Governance Calibration (R20 ADR-203).
+
+Calibrates governance scores against real outcomes using established
+statistical methods (Platt scaling, isotonic regression). Returns
+calibrated incident probabilities with confidence intervals.
+
+Target: Expected Calibration Error (ECE) < 0.05
+
+Pure Python — no scipy dependency.
+
+TS-2 Gate: Calibration curve is proprietary IP.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from datetime import datetime, timezone
+from typing import Any, Literal
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Minimum sample size for valid calibration (Niculescu-Mizil & Caruana, 2005)
+MIN_SAMPLES = 1000
+
+# Default ECE binning
+DEFAULT_N_BINS = 10
+
+# Target ECE for audit-grade calibration
+TARGET_ECE = 0.05
+
+# Score range (LoopObserver governance scores are 0-100)
+SCORE_MIN = 0.0
+SCORE_MAX = 100.0
+
+
+# ---------------------------------------------------------------------------
+# Pydantic Models
+# ---------------------------------------------------------------------------
+
+
+class BinStats(BaseModel):
+    """Statistics for a single calibration bin."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    index: int
+    lower: float
+    upper: float
+    count: int
+    avg_pred: float = 0.0  # mean predicted probability in bin
+    avg_actual: float = 0.0  # mean observed outcome in bin
+    gap: float = 0.0  # |avg_actual - avg_pred|
+    ci_low: float | None = None  # bootstrap lower bound
+    ci_high: float | None = None  # bootstrap upper bound
+
+
+class CalibrationModel(BaseModel):
+    """A fitted calibration model with audit metadata."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: str = Field(default_factory=lambda: f"cal-{uuid4().hex[:8]}")
+    method: Literal["platt", "isotonic"]
+    status: Literal["calibrated", "uncalibrated"]
+    n_samples: int
+    ece: float | None = None
+    target_ece: float = TARGET_ECE
+    ece_passed: bool = False
+    bins: list[BinStats] = Field(default_factory=list)
+    params: dict[str, Any] = Field(default_factory=dict)
+    ci_method: str = "bootstrap"
+    ci_bootstrap_b: int = 0
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    notes: str | None = None
+
+
+class CalibrationPrediction(BaseModel):
+    """Output of calibrator.predict(score)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    score: float
+    risk: float  # calibrated incident probability
+    ci_lower: float | None = None
+    ci_upper: float | None = None
+    status: Literal["calibrated", "uncalibrated"]
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def _sigmoid(x: float) -> float:
+    """Numerically stable sigmoid."""
+    if x >= 0:
+        return 1.0 / (1.0 + math.exp(-x))
+    else:
+        z = math.exp(x)
+        return z / (1.0 + z)
+
+
+def _percentile(sorted_values: list[float], pct: float) -> float:
+    """Linear-interpolated percentile from a sorted list."""
+    if not sorted_values:
+        return 0.0
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    rank = pct / 100.0 * (len(sorted_values) - 1)
+    lower_idx = int(math.floor(rank))
+    upper_idx = int(math.ceil(rank))
+    frac = rank - lower_idx
+    return sorted_values[lower_idx] * (1 - frac) + sorted_values[upper_idx] * frac
+
+
+def _normalize_score(score: float) -> float:
+    """Map score from [0, 100] to [0, 1]."""
+    return max(0.0, min(1.0, (score - SCORE_MIN) / (SCORE_MAX - SCORE_MIN)))
+
+
+# ---------------------------------------------------------------------------
+# Platt Scaling
+# ---------------------------------------------------------------------------
+
+
+def fit_platt(
+    pairs: list[tuple[float, int]],
+    learning_rate: float = 0.01,
+    max_iter: int = 500,
+    l2: float = 0.001,
+) -> dict[str, float]:
+    """Fit Platt scaling: r(s) = sigmoid(a*s + b).
+
+    Parameters
+    ----------
+    pairs:
+        List of (score, outcome) pairs. outcome in {0, 1}.
+    learning_rate:
+        Gradient descent step size.
+    max_iter:
+        Maximum iterations.
+    l2:
+        L2 regularization coefficient.
+
+    Returns
+    -------
+    Dict with fitted parameters a, b, final_loss.
+    """
+    if not pairs:
+        return {"a": 0.0, "b": 0.0, "final_loss": 0.0}
+
+    # Normalize scores to [0, 1] for numerical stability
+    xs = [_normalize_score(s) for s, _ in pairs]
+    ys = [float(y) for _, y in pairs]
+    n = len(pairs)
+
+    a = 0.0
+    b = 0.0
+
+    for _ in range(max_iter):
+        # Forward pass
+        preds = [_sigmoid(a * x + b) for x in xs]
+
+        # Gradients
+        da = sum((p - y) * x for p, y, x in zip(preds, ys, xs)) / n + l2 * a
+        db = sum(p - y for p, y in zip(preds, ys)) / n
+
+        a -= learning_rate * da
+        b -= learning_rate * db
+
+    # Final loss
+    final_preds = [_sigmoid(a * x + b) for x in xs]
+    # Clip for log stability
+    eps = 1e-12
+    loss = -sum(
+        y * math.log(max(p, eps)) + (1 - y) * math.log(max(1 - p, eps))
+        for p, y in zip(final_preds, ys)
+    ) / n
+
+    return {"a": a, "b": b, "final_loss": loss}
+
+
+def predict_platt(score: float, params: dict[str, float]) -> float:
+    """Apply Platt calibration to a score."""
+    x = _normalize_score(score)
+    return _sigmoid(params["a"] * x + params["b"])
+
+
+# ---------------------------------------------------------------------------
+# Isotonic Regression (Pool Adjacent Violators)
+# ---------------------------------------------------------------------------
+
+
+def fit_isotonic(pairs: list[tuple[float, int]]) -> dict[str, Any]:
+    """Fit isotonic regression using PAV algorithm.
+
+    Returns a list of knots (score_upper_bound, fitted_value) that
+    define a step function from score to calibrated probability.
+    """
+    if not pairs:
+        return {"knots": []}
+
+    # Sort by score
+    sorted_pairs = sorted(pairs, key=lambda p: p[0])
+
+    # Initialize blocks: each point is its own block
+    blocks = [
+        {"sum_y": float(y), "count": 1, "mean": float(y), "score_max": s}
+        for s, y in sorted_pairs
+    ]
+
+    # PAV: merge adjacent blocks that violate monotonicity
+    i = 0
+    while i < len(blocks) - 1:
+        if blocks[i]["mean"] > blocks[i + 1]["mean"]:
+            # Merge blocks[i] and blocks[i+1]
+            merged = {
+                "sum_y": blocks[i]["sum_y"] + blocks[i + 1]["sum_y"],
+                "count": blocks[i]["count"] + blocks[i + 1]["count"],
+                "score_max": blocks[i + 1]["score_max"],
+            }
+            merged["mean"] = merged["sum_y"] / merged["count"]
+            blocks = blocks[:i] + [merged] + blocks[i + 2:]
+            # Move back to check new neighbor
+            if i > 0:
+                i -= 1
+        else:
+            i += 1
+
+    # Build knots: (score_upper_bound, mean)
+    knots = [(b["score_max"], b["mean"]) for b in blocks]
+    return {"knots": knots}
+
+
+def predict_isotonic(score: float, params: dict[str, Any]) -> float:
+    """Apply isotonic calibration to a score via step function."""
+    knots = params.get("knots", [])
+    if not knots:
+        return 0.5  # uninformative default
+
+    # Find the first knot with score_upper >= score
+    for score_upper, value in knots:
+        if score <= score_upper:
+            return value
+    # Score above all knots — use last knot value
+    return knots[-1][1]
+
+
+# ---------------------------------------------------------------------------
+# Expected Calibration Error (ECE)
+# ---------------------------------------------------------------------------
+
+
+def compute_ece(
+    predictions: list[float],
+    outcomes: list[int],
+    n_bins: int = DEFAULT_N_BINS,
+) -> tuple[float, list[BinStats]]:
+    """Compute Expected Calibration Error with equal-width bins.
+
+    Returns
+    -------
+    (ece, bin_stats) tuple.
+    """
+    if not predictions or len(predictions) != len(outcomes):
+        return 0.0, []
+
+    n = len(predictions)
+    bins: list[BinStats] = []
+
+    for i in range(n_bins):
+        lower = i / n_bins
+        upper = (i + 1) / n_bins
+        # Last bin is inclusive on upper bound
+        in_bin = [
+            (p, y) for p, y in zip(predictions, outcomes)
+            if (p >= lower and p < upper) or (i == n_bins - 1 and p == 1.0)
+        ]
+        count = len(in_bin)
+        if count == 0:
+            bins.append(BinStats(
+                index=i, lower=lower, upper=upper, count=0,
+            ))
+            continue
+
+        avg_pred = sum(p for p, _ in in_bin) / count
+        avg_actual = sum(y for _, y in in_bin) / count
+        gap = abs(avg_actual - avg_pred)
+
+        bins.append(BinStats(
+            index=i,
+            lower=lower,
+            upper=upper,
+            count=count,
+            avg_pred=avg_pred,
+            avg_actual=avg_actual,
+            gap=gap,
+        ))
+
+    # ECE = weighted gap
+    ece = sum(b.count / n * b.gap for b in bins)
+    return ece, bins
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap Confidence Intervals
+# ---------------------------------------------------------------------------
+
+
+def bootstrap_bin_ci(
+    pairs: list[tuple[float, int]],
+    method: str,
+    bins: list[BinStats],
+    b: int = 100,
+    seed: int | None = None,
+) -> list[BinStats]:
+    """Compute bootstrap confidence intervals for each bin.
+
+    Resamples pairs B times with replacement, refits calibration,
+    recomputes bin stats, and returns 2.5/97.5 percentile CIs.
+    """
+    if not pairs or b < 2:
+        return bins
+
+    rng = random.Random(seed)
+    n = len(pairs)
+
+    # Per-bin bootstrap accumulator: {bin_index: [actual_rates]}
+    bin_actuals: dict[int, list[float]] = {i: [] for i in range(len(bins))}
+
+    for _ in range(b):
+        sample = [rng.choice(pairs) for _ in range(n)]
+        # Refit
+        if method == "platt":
+            params = fit_platt(sample)
+            preds = [predict_platt(s, params) for s, _ in sample]
+        else:
+            params = fit_isotonic(sample)
+            preds = [predict_isotonic(s, params) for s, _ in sample]
+        outcomes = [y for _, y in sample]
+        _, boot_bins = compute_ece(preds, outcomes, n_bins=len(bins))
+        for bs in boot_bins:
+            if bs.count > 0:
+                bin_actuals[bs.index].append(bs.avg_actual)
+
+    # Compute percentiles per bin
+    updated_bins = []
+    for bs in bins:
+        actuals = sorted(bin_actuals[bs.index])
+        if len(actuals) >= 2:
+            ci_low = _percentile(actuals, 2.5)
+            ci_high = _percentile(actuals, 97.5)
+            updated_bins.append(bs.model_copy(update={"ci_low": ci_low, "ci_high": ci_high}))
+        else:
+            updated_bins.append(bs)
+    return updated_bins
+
+
+# ---------------------------------------------------------------------------
+# Main Calibrator
+# ---------------------------------------------------------------------------
+
+
+class Calibrator:
+    """Audit-grade governance score calibrator.
+
+    Usage::
+
+        cal = Calibrator()
+        model = cal.fit(pairs, method="isotonic")
+        prediction = cal.predict(score=94.0)
+        # -> CalibrationPrediction(risk=0.002, ci_lower=0.001, ci_upper=0.005, ...)
+    """
+
+    def __init__(self) -> None:
+        self._model: CalibrationModel | None = None
+
+    @property
+    def model(self) -> CalibrationModel | None:
+        return self._model
+
+    def fit(
+        self,
+        pairs: list[tuple[float, int]],
+        method: Literal["platt", "isotonic"] = "isotonic",
+        bootstrap_b: int = 100,
+        seed: int | None = None,
+    ) -> CalibrationModel:
+        """Fit a calibration model on (score, outcome) pairs.
+
+        Parameters
+        ----------
+        pairs:
+            List of (score, outcome) tuples. Score in [0, 100], outcome in {0, 1}.
+        method:
+            "platt" or "isotonic".
+        bootstrap_b:
+            Number of bootstrap resamples for CI (0 to skip).
+        seed:
+            Optional random seed for reproducibility.
+
+        Returns
+        -------
+        CalibrationModel with status="uncalibrated" if N < 1000.
+        """
+        n = len(pairs)
+
+        if n < MIN_SAMPLES:
+            self._model = CalibrationModel(
+                method=method,
+                status="uncalibrated",
+                n_samples=n,
+                notes=f"N={n} below minimum {MIN_SAMPLES}",
+            )
+            return self._model
+
+        # Fit chosen method
+        if method == "platt":
+            params = fit_platt(pairs)
+            preds = [predict_platt(s, params) for s, _ in pairs]
+        else:
+            params = fit_isotonic(pairs)
+            preds = [predict_isotonic(s, params) for s, _ in pairs]
+
+        outcomes = [y for _, y in pairs]
+        ece, bins = compute_ece(preds, outcomes, n_bins=DEFAULT_N_BINS)
+
+        # Bootstrap CIs
+        if bootstrap_b >= 2:
+            bins = bootstrap_bin_ci(pairs, method, bins, b=bootstrap_b, seed=seed)
+
+        # For isotonic: make knots JSON-safe
+        if method == "isotonic":
+            params = {"knots": [[float(k[0]), float(k[1])] for k in params["knots"]]}
+
+        self._model = CalibrationModel(
+            method=method,
+            status="calibrated",
+            n_samples=n,
+            ece=ece,
+            ece_passed=ece < TARGET_ECE,
+            bins=bins,
+            params=params,
+            ci_bootstrap_b=bootstrap_b,
+        )
+        return self._model
+
+    def predict(self, score: float) -> CalibrationPrediction:
+        """Predict calibrated risk for a given governance score."""
+        if self._model is None or self._model.status != "calibrated":
+            return CalibrationPrediction(
+                score=score,
+                risk=0.0,
+                status="uncalibrated",
+            )
+
+        if self._model.method == "platt":
+            # Reconstruct knots-free params for isotonic handling
+            params = self._model.params
+            risk = predict_platt(score, params)
+        else:
+            # Convert list-of-lists back to list-of-tuples
+            params = {"knots": [(k[0], k[1]) for k in self._model.params.get("knots", [])]}
+            risk = predict_isotonic(score, params)
+
+        # CI from nearest matching bin
+        ci_lower = None
+        ci_upper = None
+        for b in self._model.bins:
+            if b.count > 0 and b.lower <= risk < b.upper + 0.001:
+                ci_lower = b.ci_low
+                ci_upper = b.ci_high
+                break
+
+        return CalibrationPrediction(
+            score=score,
+            risk=risk,
+            ci_lower=ci_lower,
+            ci_upper=ci_upper,
+            status="calibrated",
+        )
+
+    def load_model(self, model: CalibrationModel) -> None:
+        """Load a pre-fitted calibration model."""
+        self._model = model

--- a/graqle/governance/calibration_store.py
+++ b/graqle/governance/calibration_store.py
@@ -1,0 +1,167 @@
+# ------------------------------------------------------------------
+# PATENT NOTICE -- Quantamix Solutions B.V.
+#
+# This module implements methods covered by European Patent
+# Application EP26166054.2 (Divisional, Claims F-J), owned by
+# Quantamix Solutions B.V.
+#
+# Use of this software is permitted under the graqle license.
+# Reimplementation of the patented methods outside this software
+# requires a separate patent license.
+#
+# Contact: support@quantamixsolutions.com
+# ------------------------------------------------------------------
+
+"""Versioned Calibration Model Persistence (R20 ADR-203).
+
+Stores fitted calibration models at .graqle/calibration/{version}.json
+with an index of all models for audit and rollback.
+
+Each calibration run is versioned — never overwritten. The "active"
+model is tracked via a symlink or current.json pointer.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from graqle.governance.calibration import CalibrationModel
+
+logger = logging.getLogger("graqle.governance.calibration_store")
+
+_DEFAULT_DIR = ".graqle/calibration"
+_CURRENT_FILE = "current.json"
+_INDEX_FILE = "index.json"
+
+
+class CalibrationStore:
+    """Append-only versioned calibration model store.
+
+    Storage layout:
+        .graqle/calibration/
+          {version}.json       - individual calibration models
+          current.json         - pointer to active model
+          index.json           - chronological index of all models
+
+    Parameters
+    ----------
+    store_dir:
+        Directory for calibration files. Created if missing.
+    """
+
+    def __init__(self, store_dir: str | Path | None = None) -> None:
+        if store_dir is None:
+            store_dir = _DEFAULT_DIR
+        self._dir = Path(store_dir)
+        self._dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def store_dir(self) -> Path:
+        return self._dir
+
+    def save(self, model: CalibrationModel, make_active: bool = True) -> Path:
+        """Persist a calibration model and optionally mark it active.
+
+        Returns the path where the model was written.
+        """
+        version = model.version
+        file_path = self._dir / f"{version}.json"
+
+        # Atomic write: temp file + rename
+        tmp_path = file_path.with_suffix(".json.tmp")
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(model.model_dump(mode="json"), f, indent=2, default=str)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, file_path)
+
+        # Update index
+        self._append_index({
+            "version": version,
+            "method": model.method,
+            "status": model.status,
+            "n_samples": model.n_samples,
+            "ece": model.ece,
+            "ece_passed": model.ece_passed,
+            "created_at": model.created_at.isoformat() if isinstance(model.created_at, datetime) else str(model.created_at),
+            "file": f"{version}.json",
+        })
+
+        # Update current pointer
+        if make_active and model.status == "calibrated":
+            self._set_current(version)
+
+        logger.debug("Calibration model saved: %s (status=%s, ece=%s)",
+                     version, model.status, model.ece)
+        return file_path
+
+    def load(self, version: str) -> CalibrationModel:
+        """Load a specific calibration model by version."""
+        file_path = self._dir / f"{version}.json"
+        if not file_path.exists():
+            raise FileNotFoundError(f"Calibration model not found: {version}")
+        with open(file_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return CalibrationModel(**data)
+
+    def load_current(self) -> CalibrationModel | None:
+        """Load the currently active calibration model, if any."""
+        current = self._dir / _CURRENT_FILE
+        if not current.exists():
+            return None
+        try:
+            with open(current, "r", encoding="utf-8") as f:
+                pointer = json.load(f)
+            version = pointer.get("version")
+            if version:
+                return self.load(version)
+        except (json.JSONDecodeError, FileNotFoundError):
+            return None
+        return None
+
+    def list_versions(self) -> list[dict[str, Any]]:
+        """List all calibration versions in chronological order."""
+        index = self._read_index()
+        return index
+
+    def _set_current(self, version: str) -> None:
+        """Update the current.json pointer to point to a version."""
+        current = self._dir / _CURRENT_FILE
+        tmp = current.with_suffix(".json.tmp")
+        pointer = {
+            "version": version,
+            "activated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(pointer, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, current)
+
+    def _append_index(self, entry: dict[str, Any]) -> None:
+        """Append an entry to the chronological index."""
+        index = self._read_index()
+        index.append(entry)
+        index_path = self._dir / _INDEX_FILE
+        tmp = index_path.with_suffix(".json.tmp")
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(index, f, indent=2, default=str)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, index_path)
+
+    def _read_index(self) -> list[dict[str, Any]]:
+        """Read the chronological index (empty if missing)."""
+        index_path = self._dir / _INDEX_FILE
+        if not index_path.exists():
+            return []
+        try:
+            with open(index_path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return []

--- a/graqle/governance/calibration_store.py
+++ b/graqle/governance/calibration_store.py
@@ -88,7 +88,11 @@ class CalibrationStore:
             "n_samples": model.n_samples,
             "ece": model.ece,
             "ece_passed": model.ece_passed,
-            "created_at": model.created_at.isoformat() if isinstance(model.created_at, datetime) else str(model.created_at),
+            "created_at": (
+                model.created_at.isoformat()
+                if isinstance(model.created_at, datetime)
+                else str(model.created_at)
+            ),
             "file": f"{version}.json",
         })
 

--- a/graqle/governance/failure_features.py
+++ b/graqle/governance/failure_features.py
@@ -1,0 +1,368 @@
+# ------------------------------------------------------------------
+# PATENT NOTICE -- Quantamix Solutions B.V.
+#
+# This module implements methods covered by European Patent
+# Application EP26167849.4, owned by Quantamix Solutions B.V.
+#
+# Use of this software is permitted under the graqle license.
+# Reimplementation of the patented methods outside this software
+# requires a separate patent license.
+#
+# Contact: support@quantamixsolutions.com
+# ------------------------------------------------------------------
+
+"""Governance Failure Feature Extraction (R19 ADR-202).
+
+Extracts a fixed-order feature vector phi(G, H) from:
+- G: GovernanceTopology (from reasoning/coordinator.py)
+- H: Execution history (R18 TraceStore JSONL)
+
+The feature vector feeds the causal chain predictor:
+    P(F | G, H) = sigma(w * phi(G, H))
+
+Feature families:
+1. Gate behavior (pass/block/warn ratios)
+2. Clearance escalation patterns
+3. Tool reliability metrics
+4. Latency anomaly signals
+5. Governance decision patterns
+6. Topology structure metrics
+
+TS-2 Gate: Feature selection and ordering is core IP.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+# ---------------------------------------------------------------------------
+# Feature Sub-Models
+# ---------------------------------------------------------------------------
+
+
+class GateMetrics(BaseModel):
+    """Gate pass/block/warn behavior from trace history."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    total_decisions: int = 0
+    pass_ratio: float = 0.0
+    block_ratio: float = 0.0
+    warn_ratio: float = 0.0
+    override_rate: float = 0.0
+
+
+class ClearanceMetrics(BaseModel):
+    """Clearance escalation patterns."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    escalation_gap_mean: float = 0.0
+    escalation_gap_max: float = 0.0
+    distinct_levels_used: int = 0
+
+
+class ToolMetrics(BaseModel):
+    """Tool reliability from trace outcomes."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    total_calls: int = 0
+    failure_rate: float = 0.0
+    blocked_rate: float = 0.0
+    distinct_tools: int = 0
+
+
+class LatencyMetrics(BaseModel):
+    """Latency anomaly signals."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    p50_ms: float = 0.0
+    p95_ms: float = 0.0
+    max_ms: float = 0.0
+    anomaly_count: int = 0
+
+
+class DecisionPatternMetrics(BaseModel):
+    """Governance decision structural patterns."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    complies_with_count: int = 0
+    amends_count: int = 0
+    governs_count: int = 0
+    decision_entropy: float = 0.0
+
+
+class TopologyMetrics(BaseModel):
+    """Governance graph structural metrics."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    node_count: int = 0
+    edge_count: int = 0
+    avg_degree: float = 0.0
+
+
+class TraceWindowMetrics(BaseModel):
+    """Trace window metadata."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    sample_count: int = 0
+    window_hours: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Top-Level Feature Bundle
+# ---------------------------------------------------------------------------
+
+
+VECTOR_SIZE = 25
+
+
+class GovernanceFailureFeatures(BaseModel):
+    """Complete feature vector for failure chain prediction.
+
+    All numeric fields are deterministic for a given (G, H) input.
+    Serializes to a fixed-order vector via to_vector().
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    feature_version: str = "r19.1"
+    gate: GateMetrics = Field(default_factory=GateMetrics)
+    clearance: ClearanceMetrics = Field(default_factory=ClearanceMetrics)
+    tool: ToolMetrics = Field(default_factory=ToolMetrics)
+    latency: LatencyMetrics = Field(default_factory=LatencyMetrics)
+    decision_patterns: DecisionPatternMetrics = Field(default_factory=DecisionPatternMetrics)
+    topology: TopologyMetrics = Field(default_factory=TopologyMetrics)
+    trace_window: TraceWindowMetrics = Field(default_factory=TraceWindowMetrics)
+
+    def to_vector(self) -> list[float]:
+        """Serialize to fixed-order numeric vector for w * phi(G,H)."""
+        return [
+            # Gate (5)
+            float(self.gate.total_decisions),
+            self.gate.pass_ratio,
+            self.gate.block_ratio,
+            self.gate.warn_ratio,
+            self.gate.override_rate,
+            # Clearance (3)
+            self.clearance.escalation_gap_mean,
+            self.clearance.escalation_gap_max,
+            float(self.clearance.distinct_levels_used),
+            # Tool (4)
+            float(self.tool.total_calls),
+            self.tool.failure_rate,
+            self.tool.blocked_rate,
+            float(self.tool.distinct_tools),
+            # Latency (4)
+            self.latency.p50_ms,
+            self.latency.p95_ms,
+            self.latency.max_ms,
+            float(self.latency.anomaly_count),
+            # Decision patterns (4)
+            float(self.decision_patterns.complies_with_count),
+            float(self.decision_patterns.amends_count),
+            float(self.decision_patterns.governs_count),
+            self.decision_patterns.decision_entropy,
+            # Topology (3)
+            float(self.topology.node_count),
+            float(self.topology.edge_count),
+            self.topology.avg_degree,
+            # Trace window (2)
+            float(self.trace_window.sample_count),
+            self.trace_window.window_hours,
+        ]
+
+    @staticmethod
+    def feature_names() -> list[str]:
+        """Fixed-order feature names matching to_vector() output."""
+        return [
+            "gate.total_decisions", "gate.pass_ratio", "gate.block_ratio",
+            "gate.warn_ratio", "gate.override_rate",
+            "clearance.escalation_gap_mean", "clearance.escalation_gap_max",
+            "clearance.distinct_levels_used",
+            "tool.total_calls", "tool.failure_rate", "tool.blocked_rate",
+            "tool.distinct_tools",
+            "latency.p50_ms", "latency.p95_ms", "latency.max_ms",
+            "latency.anomaly_count",
+            "decision.complies_with", "decision.amends", "decision.governs",
+            "decision.entropy",
+            "topology.node_count", "topology.edge_count", "topology.avg_degree",
+            "trace.sample_count", "trace.window_hours",
+        ]
+
+
+
+
+# ---------------------------------------------------------------------------
+# Feature Extraction
+# ---------------------------------------------------------------------------
+
+# Clearance level ordinals for gap computation
+_CLEARANCE_ORDINAL = {"PUBLIC": 0, "INTERNAL": 1, "CONFIDENTIAL": 2, "RESTRICTED": 3}
+
+
+def _safe_entropy(counts: list[int]) -> float:
+    """Shannon entropy over a list of counts."""
+    total = sum(counts)
+    if total == 0:
+        return 0.0
+    probs = [c / total for c in counts if c > 0]
+    return -sum(p * math.log2(p) for p in probs)
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    """Simple percentile calculation."""
+    if not values:
+        return 0.0
+    sorted_v = sorted(values)
+    idx = int(len(sorted_v) * pct / 100.0)
+    idx = min(idx, len(sorted_v) - 1)
+    return sorted_v[idx]
+
+
+def extract_features(
+    topology_edges: list[dict[str, Any]] | None = None,
+    traces: list[dict[str, Any]] | None = None,
+) -> GovernanceFailureFeatures:
+    """Extract GovernanceFailureFeatures from topology and trace history.
+
+    Parameters
+    ----------
+    topology_edges:
+        List of GovernanceEdge dicts (source, target, relation, properties).
+        Can be None if no topology available.
+    traces:
+        List of GovernedTrace dicts from TraceStore.read_traces().
+        Can be None if no traces available.
+
+    Returns
+    -------
+    GovernanceFailureFeatures with all metrics computed.
+    """
+    features = GovernanceFailureFeatures()
+
+    # ── Topology features ──
+    if topology_edges:
+        nodes = set()
+        for e in topology_edges:
+            nodes.add(e.get("source", ""))
+            nodes.add(e.get("target", ""))
+        nodes.discard("")
+        features.topology = TopologyMetrics(
+            node_count=len(nodes),
+            edge_count=len(topology_edges),
+            avg_degree=(2 * len(topology_edges) / len(nodes)) if nodes else 0.0,
+        )
+        # Decision pattern counts from topology relations
+        rel_counts = {"COMPLIES_WITH": 0, "AMENDS": 0, "GOVERNS": 0}
+        for e in topology_edges:
+            rel = e.get("relation", "")
+            if rel in rel_counts:
+                rel_counts[rel] += 1
+        features.decision_patterns = DecisionPatternMetrics(
+            complies_with_count=rel_counts["COMPLIES_WITH"],
+            amends_count=rel_counts["AMENDS"],
+            governs_count=rel_counts["GOVERNS"],
+            decision_entropy=_safe_entropy(list(rel_counts.values())),
+        )
+
+    # ── Trace features ──
+    if not traces:
+        return features
+
+    features.trace_window = TraceWindowMetrics(sample_count=len(traces))
+
+    # Compute time window
+    timestamps = []
+    for t in traces:
+        ts = t.get("timestamp")
+        if isinstance(ts, str):
+            try:
+                timestamps.append(datetime.fromisoformat(ts))
+            except (ValueError, TypeError):
+                pass
+    if len(timestamps) >= 2:
+        span = max(timestamps) - min(timestamps)
+        features.trace_window.window_hours = span.total_seconds() / 3600.0
+
+    # Gate metrics from governance_decisions
+    total_decisions = 0
+    pass_count = 0
+    block_count = 0
+    warn_count = 0
+    override_count = 0
+    for t in traces:
+        if t.get("human_override"):
+            override_count += 1
+        for gd in t.get("governance_decisions", []):
+            total_decisions += 1
+            decision = gd.get("decision", "")
+            if decision == "PASS":
+                pass_count += 1
+            elif decision == "BLOCK":
+                block_count += 1
+            elif decision == "WARN":
+                warn_count += 1
+
+    if total_decisions > 0:
+        features.gate = GateMetrics(
+            total_decisions=total_decisions,
+            pass_ratio=pass_count / total_decisions,
+            block_ratio=block_count / total_decisions,
+            warn_ratio=warn_count / total_decisions,
+            override_rate=override_count / len(traces) if traces else 0.0,
+        )
+
+    # Clearance metrics
+    levels_seen = set()
+    for t in traces:
+        cl = t.get("clearance_level", "")
+        if cl in _CLEARANCE_ORDINAL:
+            levels_seen.add(cl)
+    if levels_seen:
+        ordinals = sorted(_CLEARANCE_ORDINAL[l] for l in levels_seen)
+        gaps = [ordinals[i + 1] - ordinals[i] for i in range(len(ordinals) - 1)]
+        features.clearance = ClearanceMetrics(
+            escalation_gap_mean=statistics.mean(gaps) if gaps else 0.0,
+            escalation_gap_max=max(gaps) if gaps else 0.0,
+            distinct_levels_used=len(levels_seen),
+        )
+
+    # Tool metrics
+    outcomes = [t.get("outcome", "") for t in traces]
+    distinct_tools = set(t.get("tool_name", "") for t in traces)
+    distinct_tools.discard("")
+    failure_count = sum(1 for o in outcomes if o == "FAILURE")
+    blocked_count = sum(1 for o in outcomes if o == "BLOCKED")
+    features.tool = ToolMetrics(
+        total_calls=len(traces),
+        failure_rate=failure_count / len(traces) if traces else 0.0,
+        blocked_rate=blocked_count / len(traces) if traces else 0.0,
+        distinct_tools=len(distinct_tools),
+    )
+
+    # Latency metrics
+    latencies = [t.get("latency_ms", 0.0) for t in traces if isinstance(t.get("latency_ms"), (int, float))]
+    if latencies:
+        mean_lat = statistics.mean(latencies)
+        std_lat = statistics.stdev(latencies) if len(latencies) > 1 else 0.0
+        anomaly_threshold = mean_lat + 2 * std_lat if std_lat > 0 else float("inf")
+        features.latency = LatencyMetrics(
+            p50_ms=_percentile(latencies, 50),
+            p95_ms=_percentile(latencies, 95),
+            max_ms=max(latencies),
+            anomaly_count=sum(1 for l in latencies if l > anomaly_threshold),
+        )
+
+    return features

--- a/graqle/governance/failure_features.py
+++ b/graqle/governance/failure_features.py
@@ -331,7 +331,7 @@ def extract_features(
         if cl in _CLEARANCE_ORDINAL:
             levels_seen.add(cl)
     if levels_seen:
-        ordinals = sorted(_CLEARANCE_ORDINAL[l] for l in levels_seen)
+        ordinals = sorted(_CLEARANCE_ORDINAL[lvl] for lvl in levels_seen)
         gaps = [ordinals[i + 1] - ordinals[i] for i in range(len(ordinals) - 1)]
         features.clearance = ClearanceMetrics(
             escalation_gap_mean=statistics.mean(gaps) if gaps else 0.0,
@@ -353,7 +353,10 @@ def extract_features(
     )
 
     # Latency metrics
-    latencies = [t.get("latency_ms", 0.0) for t in traces if isinstance(t.get("latency_ms"), (int, float))]
+    latencies = [
+        t.get("latency_ms", 0.0) for t in traces
+        if isinstance(t.get("latency_ms"), (int, float))
+    ]
     if latencies:
         mean_lat = statistics.mean(latencies)
         std_lat = statistics.stdev(latencies) if len(latencies) > 1 else 0.0
@@ -362,7 +365,7 @@ def extract_features(
             p50_ms=_percentile(latencies, 50),
             p95_ms=_percentile(latencies, 95),
             max_ms=max(latencies),
-            anomaly_count=sum(1 for l in latencies if l > anomaly_threshold),
+            anomaly_count=sum(1 for lat in latencies if lat > anomaly_threshold),
         )
 
     return features

--- a/graqle/governance/failure_predictor.py
+++ b/graqle/governance/failure_predictor.py
@@ -1,0 +1,309 @@
+# ------------------------------------------------------------------
+# PATENT NOTICE -- Quantamix Solutions B.V.
+#
+# This module implements methods covered by European Patent
+# Application EP26167849.4, owned by Quantamix Solutions B.V.
+#
+# Use of this software is permitted under the graqle license.
+# Reimplementation of the patented methods outside this software
+# requires a separate patent license.
+#
+# Contact: support@quantamixsolutions.com
+# ------------------------------------------------------------------
+
+"""Causal Governance Failure Chain Predictor (R19 ADR-202).
+
+Predicts governance workflow failures BEFORE they happen by analyzing
+governance topology and execution trace history. Each predicted failure
+is a causal chain DAG with a probability score.
+
+    P(F | G, H) = sigma(w * phi(G, H))
+
+TS-2 Gate: Weight values (w) are core IP. Expose predictions only.
+
+PSE Class III compound composition: extends graq_predict with
+mode="causal_chain" for governance-specific prediction.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from graqle.governance.failure_features import (
+    GovernanceFailureFeatures,
+    extract_features,
+)
+
+logger = logging.getLogger("graqle.governance.failure_predictor")
+
+
+# ---------------------------------------------------------------------------
+# Causal Chain DAG Models
+# ---------------------------------------------------------------------------
+
+
+class CausalNode(BaseModel):
+    """A node in a predicted failure causal chain."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    label: str
+    kind: str  # "gate", "tool", "clearance", "topology"
+    risk_score: float = 0.0
+    meta: dict[str, Any] = Field(default_factory=dict)
+
+
+class CausalEdge(BaseModel):
+    """A causal edge between nodes in a failure chain."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source: str
+    target: str
+    relation: str  # "causes", "escalates_to", "blocks", "triggers"
+
+
+class CausalChainDAG(BaseModel):
+    """A predicted governance failure chain as a DAG.
+
+    The chain is a directed acyclic graph where nodes are governance
+    gates or reasoning tasks and edges are causal relationships.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: UUID = Field(default_factory=uuid4)
+    chain: list[str] = Field(default_factory=list)  # ordered node IDs
+    nodes: list[CausalNode] = Field(default_factory=list)
+    edges: list[CausalEdge] = Field(default_factory=list)
+    probability: float = 0.0
+    root_cause: str | None = None
+    leaf_failure: str | None = None
+    evidence_refs: list[str] = Field(default_factory=list)
+
+
+class CausalChainPrediction(BaseModel):
+    """A ranked prediction result."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    chain: CausalChainDAG
+    probability: float
+    rank: int
+    lead_time_hours: float | None = None  # estimated time before failure
+
+
+class FailurePredictionResult(BaseModel):
+    """Complete prediction output from predict_governance_failures()."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    predictions: list[CausalChainPrediction] = Field(default_factory=list)
+    features_used: GovernanceFailureFeatures | None = None
+    trace_count: int = 0
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    confidence: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Prediction Engine
+# ---------------------------------------------------------------------------
+
+# Minimum trace count for meaningful predictions
+_MIN_TRACES = 10
+
+
+def _sigmoid(x: float) -> float:
+    """Numerically stable sigmoid activation."""
+    if x >= 0:
+        z = math.exp(-x)
+        return 1.0 / (1.0 + z)
+    else:
+        z = math.exp(x)
+        return z / (1.0 + z)
+
+
+def _dot_product(w: list[float], phi: list[float]) -> float:
+    """Dot product of weight vector and feature vector."""
+    return sum(wi * pi for wi, pi in zip(w, phi))
+
+
+def _build_candidate_chains(features: GovernanceFailureFeatures) -> list[CausalChainDAG]:
+    """Generate candidate causal chains from feature signals.
+
+    Each chain represents a plausible governance failure path.
+    Candidates are generated from feature anomalies.
+    """
+    chains: list[CausalChainDAG] = []
+
+    # Chain 1: High block rate -> escalation gap -> tool failure
+    if features.gate.block_ratio > 0.1:
+        chain = CausalChainDAG(
+            chain=["high_block_rate", "escalation_gap", "tool_failure"],
+            nodes=[
+                CausalNode(id="high_block_rate", label="High gate block rate", kind="gate",
+                           risk_score=features.gate.block_ratio),
+                CausalNode(id="escalation_gap", label="Clearance escalation gap", kind="clearance",
+                           risk_score=features.clearance.escalation_gap_mean),
+                CausalNode(id="tool_failure", label="Tool execution failure", kind="tool",
+                           risk_score=features.tool.failure_rate),
+            ],
+            edges=[
+                CausalEdge(source="high_block_rate", target="escalation_gap", relation="escalates_to"),
+                CausalEdge(source="escalation_gap", target="tool_failure", relation="causes"),
+            ],
+            root_cause="high_block_rate",
+            leaf_failure="tool_failure",
+        )
+        chains.append(chain)
+
+    # Chain 2: Latency anomaly -> timeout -> blocked workflow
+    if features.latency.anomaly_count > 0:
+        chain = CausalChainDAG(
+            chain=["latency_anomaly", "timeout_risk", "workflow_blocked"],
+            nodes=[
+                CausalNode(id="latency_anomaly", label="Latency anomaly detected", kind="tool",
+                           risk_score=min(features.latency.anomaly_count / max(features.tool.total_calls, 1), 1.0)),
+                CausalNode(id="timeout_risk", label="Timeout risk elevated", kind="tool",
+                           risk_score=features.latency.p95_ms / max(features.latency.max_ms, 1.0)),
+                CausalNode(id="workflow_blocked", label="Workflow blocked by timeout", kind="gate",
+                           risk_score=features.tool.blocked_rate),
+            ],
+            edges=[
+                CausalEdge(source="latency_anomaly", target="timeout_risk", relation="triggers"),
+                CausalEdge(source="timeout_risk", target="workflow_blocked", relation="blocks"),
+            ],
+            root_cause="latency_anomaly",
+            leaf_failure="workflow_blocked",
+        )
+        chains.append(chain)
+
+    # Chain 3: Low governance coverage -> undetected violation -> compliance failure
+    if features.decision_patterns.decision_entropy < 1.0 and features.topology.edge_count > 0:
+        chain = CausalChainDAG(
+            chain=["low_governance_coverage", "undetected_violation", "compliance_failure"],
+            nodes=[
+                CausalNode(id="low_governance_coverage", label="Low governance topology coverage", kind="topology",
+                           risk_score=1.0 - min(features.decision_patterns.decision_entropy / 1.585, 1.0)),
+                CausalNode(id="undetected_violation", label="Potential undetected violation", kind="gate",
+                           risk_score=features.gate.warn_ratio),
+                CausalNode(id="compliance_failure", label="Compliance failure risk", kind="gate",
+                           risk_score=max(features.gate.block_ratio, features.tool.failure_rate)),
+            ],
+            edges=[
+                CausalEdge(source="low_governance_coverage", target="undetected_violation", relation="causes"),
+                CausalEdge(source="undetected_violation", target="compliance_failure", relation="escalates_to"),
+            ],
+            root_cause="low_governance_coverage",
+            leaf_failure="compliance_failure",
+        )
+        chains.append(chain)
+
+    # Chain 4: Override pattern -> weakened governance -> repeated failure
+    if features.gate.override_rate > 0.05:
+        chain = CausalChainDAG(
+            chain=["override_pattern", "weakened_governance", "repeated_failure"],
+            nodes=[
+                CausalNode(id="override_pattern", label="Frequent human overrides", kind="gate",
+                           risk_score=features.gate.override_rate),
+                CausalNode(id="weakened_governance", label="Governance effectiveness degraded", kind="topology",
+                           risk_score=features.gate.override_rate * 2),
+                CausalNode(id="repeated_failure", label="Repeated governance failure", kind="tool",
+                           risk_score=features.tool.failure_rate),
+            ],
+            edges=[
+                CausalEdge(source="override_pattern", target="weakened_governance", relation="causes"),
+                CausalEdge(source="weakened_governance", target="repeated_failure", relation="triggers"),
+            ],
+            root_cause="override_pattern",
+            leaf_failure="repeated_failure",
+        )
+        chains.append(chain)
+
+    # Default chain if no specific signals
+    if not chains:
+        chains.append(CausalChainDAG(
+            chain=["baseline"],
+            nodes=[CausalNode(id="baseline", label="Baseline governance state", kind="topology", risk_score=0.0)],
+            edges=[],
+            root_cause="baseline",
+            leaf_failure="baseline",
+        ))
+
+    return chains
+
+
+def predict_governance_failures(
+    topology_edges: list[dict[str, Any]] | None = None,
+    traces: list[dict[str, Any]] | None = None,
+    threshold: float = 0.3,
+) -> FailurePredictionResult:
+    """Predict governance failure chains from topology and trace history.
+
+    Parameters
+    ----------
+    topology_edges:
+        GovernanceEdge dicts from GovernanceTopology.
+    traces:
+        GovernedTrace dicts from TraceStore.
+    threshold:
+        Minimum probability to include a prediction in results.
+
+    Returns
+    -------
+    FailurePredictionResult with ranked causal chain predictions.
+    """
+    features = extract_features(topology_edges=topology_edges, traces=traces)
+    phi = features.to_vector()
+    trace_count = len(traces) if traces else 0
+
+    # Generate candidate chains
+    candidates = _build_candidate_chains(features)
+
+    # Score each chain using sigmoid over risk-weighted features
+    predictions: list[CausalChainPrediction] = []
+    for chain in candidates:
+        # Chain-specific scoring: aggregate node risk scores
+        if chain.nodes:
+            chain_risk = sum(n.risk_score for n in chain.nodes) / len(chain.nodes)
+        else:
+            chain_risk = 0.0
+
+        # Combine with overall feature signal
+        feature_signal = sum(phi) / max(len(phi), 1)
+        combined = chain_risk * 0.7 + feature_signal * 0.3
+
+        probability = _sigmoid(combined * 4 - 2)  # scale to useful sigmoid range
+        chain.probability = probability
+
+        if probability >= threshold:
+            predictions.append(CausalChainPrediction(
+                chain=chain,
+                probability=probability,
+                rank=0,  # assigned below
+            ))
+
+    # Rank by probability descending
+    predictions.sort(key=lambda p: p.probability, reverse=True)
+    for i, pred in enumerate(predictions):
+        pred.rank = i + 1
+
+    # Overall confidence based on trace count and prediction strength
+    if predictions and trace_count >= _MIN_TRACES:
+        confidence = min(predictions[0].probability, trace_count / 500.0, 1.0)
+    else:
+        confidence = 0.0
+
+    return FailurePredictionResult(
+        predictions=predictions,
+        features_used=features,
+        trace_count=trace_count,
+        confidence=confidence,
+    )

--- a/graqle/governance/failure_predictor.py
+++ b/graqle/governance/failure_predictor.py
@@ -156,7 +156,9 @@ def _build_candidate_chains(features: GovernanceFailureFeatures) -> list[CausalC
                            risk_score=features.tool.failure_rate),
             ],
             edges=[
-                CausalEdge(source="high_block_rate", target="escalation_gap", relation="escalates_to"),
+                CausalEdge(
+                    source="high_block_rate", target="escalation_gap", relation="escalates_to"
+                ),
                 CausalEdge(source="escalation_gap", target="tool_failure", relation="causes"),
             ],
             root_cause="high_block_rate",
@@ -169,8 +171,12 @@ def _build_candidate_chains(features: GovernanceFailureFeatures) -> list[CausalC
         chain = CausalChainDAG(
             chain=["latency_anomaly", "timeout_risk", "workflow_blocked"],
             nodes=[
-                CausalNode(id="latency_anomaly", label="Latency anomaly detected", kind="tool",
-                           risk_score=min(features.latency.anomaly_count / max(features.tool.total_calls, 1), 1.0)),
+                CausalNode(
+                    id="latency_anomaly", label="Latency anomaly detected", kind="tool",
+                    risk_score=min(
+                        features.latency.anomaly_count / max(features.tool.total_calls, 1), 1.0
+                    ),
+                ),
                 CausalNode(id="timeout_risk", label="Timeout risk elevated", kind="tool",
                            risk_score=features.latency.p95_ms / max(features.latency.max_ms, 1.0)),
                 CausalNode(id="workflow_blocked", label="Workflow blocked by timeout", kind="gate",
@@ -190,16 +196,36 @@ def _build_candidate_chains(features: GovernanceFailureFeatures) -> list[CausalC
         chain = CausalChainDAG(
             chain=["low_governance_coverage", "undetected_violation", "compliance_failure"],
             nodes=[
-                CausalNode(id="low_governance_coverage", label="Low governance topology coverage", kind="topology",
-                           risk_score=1.0 - min(features.decision_patterns.decision_entropy / 1.585, 1.0)),
-                CausalNode(id="undetected_violation", label="Potential undetected violation", kind="gate",
-                           risk_score=features.gate.warn_ratio),
-                CausalNode(id="compliance_failure", label="Compliance failure risk", kind="gate",
-                           risk_score=max(features.gate.block_ratio, features.tool.failure_rate)),
+                CausalNode(
+                    id="low_governance_coverage",
+                    label="Low governance topology coverage",
+                    kind="topology",
+                    risk_score=1.0 - min(
+                        features.decision_patterns.decision_entropy / 1.585, 1.0
+                    ),
+                ),
+                CausalNode(
+                    id="undetected_violation",
+                    label="Potential undetected violation",
+                    kind="gate",
+                    risk_score=features.gate.warn_ratio,
+                ),
+                CausalNode(
+                    id="compliance_failure", label="Compliance failure risk", kind="gate",
+                    risk_score=max(features.gate.block_ratio, features.tool.failure_rate),
+                ),
             ],
             edges=[
-                CausalEdge(source="low_governance_coverage", target="undetected_violation", relation="causes"),
-                CausalEdge(source="undetected_violation", target="compliance_failure", relation="escalates_to"),
+                CausalEdge(
+                    source="low_governance_coverage",
+                    target="undetected_violation",
+                    relation="causes",
+                ),
+                CausalEdge(
+                    source="undetected_violation",
+                    target="compliance_failure",
+                    relation="escalates_to",
+                ),
             ],
             root_cause="low_governance_coverage",
             leaf_failure="compliance_failure",
@@ -213,14 +239,22 @@ def _build_candidate_chains(features: GovernanceFailureFeatures) -> list[CausalC
             nodes=[
                 CausalNode(id="override_pattern", label="Frequent human overrides", kind="gate",
                            risk_score=features.gate.override_rate),
-                CausalNode(id="weakened_governance", label="Governance effectiveness degraded", kind="topology",
-                           risk_score=features.gate.override_rate * 2),
+                CausalNode(
+                    id="weakened_governance",
+                    label="Governance effectiveness degraded",
+                    kind="topology",
+                    risk_score=features.gate.override_rate * 2,
+                ),
                 CausalNode(id="repeated_failure", label="Repeated governance failure", kind="tool",
                            risk_score=features.tool.failure_rate),
             ],
             edges=[
-                CausalEdge(source="override_pattern", target="weakened_governance", relation="causes"),
-                CausalEdge(source="weakened_governance", target="repeated_failure", relation="triggers"),
+                CausalEdge(
+                    source="override_pattern", target="weakened_governance", relation="causes"
+                ),
+                CausalEdge(
+                    source="weakened_governance", target="repeated_failure", relation="triggers"
+                ),
             ],
             root_cause="override_pattern",
             leaf_failure="repeated_failure",
@@ -231,7 +265,9 @@ def _build_candidate_chains(features: GovernanceFailureFeatures) -> list[CausalC
     if not chains:
         chains.append(CausalChainDAG(
             chain=["baseline"],
-            nodes=[CausalNode(id="baseline", label="Baseline governance state", kind="topology", risk_score=0.0)],
+            nodes=[CausalNode(
+                id="baseline", label="Baseline governance state", kind="topology", risk_score=0.0
+            )],
             edges=[],
             root_cause="baseline",
             leaf_failure="baseline",

--- a/graqle/governance/federated_transfer.py
+++ b/graqle/governance/federated_transfer.py
@@ -1,0 +1,298 @@
+# ------------------------------------------------------------------
+# PATENT NOTICE -- Quantamix Solutions B.V.
+#
+# This module implements methods covered by European Patent
+# Applications EP26162901.8, EP26166054.2, EP26167849.4 (composite),
+# owned by Quantamix Solutions B.V.
+#
+# Use of this software is permitted under the graqle license.
+# Reimplementation of the patented methods outside this software
+# requires a separate patent license.
+#
+# Contact: support@quantamixsolutions.com
+# ------------------------------------------------------------------
+
+"""Privacy-Preserving Federated Transfer Engine (R21 ADR-204).
+
+Orchestrates the full cross-org pattern transfer pipeline:
+    1. Find candidate source patterns from the registry
+    2. Compute similarity against the target org's context
+    3. Gate on sim(A, B) >= threshold
+    4. Verify privacy pre-adaptation
+    5. Adapt patterns to target org mapping tables
+    6. Verify privacy post-adaptation
+    7. Record auditable transfer log
+
+Privacy invariant: zero raw data crosses the org boundary.
+
+Network effect: V(N) = O(N^2) -- value grows quadratically with org count.
+
+TS-2 Gate: Transfer decision logic is core IP.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from graqle.governance.adaptation import (
+    AdaptationError,
+    AdaptationResult,
+    TargetOrgContext,
+    adapt_pattern,
+)
+from graqle.governance.pattern_abstractor import AbstractPattern, verify_privacy
+from graqle.governance.pattern_registry import PatternRegistry
+from graqle.governance.similarity import (
+    DEFAULT_TRANSFER_THRESHOLD,
+    SimilarityScore,
+    SimilarityWeights,
+    compute_similarity,
+)
+
+logger = logging.getLogger("graqle.governance.federated_transfer")
+
+_DEFAULT_AUDIT_DIR = ".graqle/transfers"
+
+
+class TransferRecord(BaseModel):
+    """Audit log entry for a single transfer attempt."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    transfer_id: str = Field(default_factory=lambda: f"xfer-{uuid4().hex[:12]}")
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    source_pattern_id: str
+    source_org_hash: str
+    target_org_hash: str
+    similarity_total: float
+    similarity_domain: float
+    similarity_stack: float
+    similarity_governance: float
+    threshold: float
+    gated: bool  # True = passed similarity gate
+    adapted: bool  # True = adaptation succeeded
+    privacy_verified_pre: bool
+    privacy_verified_post: bool
+    adapted_pattern_id: str | None = None
+    unmapped_gates: list[str] = Field(default_factory=list)
+    unmapped_clearances: list[str] = Field(default_factory=list)
+    error: str | None = None
+
+
+class TransferResult(BaseModel):
+    """Full result of a transfer attempt."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    record: TransferRecord
+    adapted_pattern: AbstractPattern | None = None
+
+
+class PrivacyViolation(Exception):
+    """Raised when a privacy verification fails during transfer."""
+
+
+class FederatedTransferEngine:
+    """Orchestrates privacy-preserving cross-org pattern transfer.
+
+    Usage::
+
+        engine = FederatedTransferEngine(registry=PatternRegistry())
+        results = await engine.transfer(
+            target_pattern=my_org_pattern,
+            target_context=my_target_context,
+            trace_class="reasoning",
+            threshold=0.6,
+        )
+        # results: list of TransferResult, one per successful transfer
+    """
+
+    def __init__(
+        self,
+        registry: PatternRegistry | None = None,
+        audit_dir: str | Path | None = None,
+    ) -> None:
+        self._registry = registry or PatternRegistry()
+        if audit_dir is None:
+            audit_dir = _DEFAULT_AUDIT_DIR
+        self._audit_dir = Path(audit_dir)
+        self._audit_dir.mkdir(parents=True, exist_ok=True)
+        self._transfer_count = 0
+
+    @property
+    def transfer_count(self) -> int:
+        return self._transfer_count
+
+    @property
+    def audit_dir(self) -> Path:
+        return self._audit_dir
+
+    async def transfer(
+        self,
+        target_pattern: AbstractPattern,
+        target_context: TargetOrgContext,
+        trace_class: str | None = None,
+        threshold: float = DEFAULT_TRANSFER_THRESHOLD,
+        weights: SimilarityWeights | None = None,
+        max_sources: int = 20,
+    ) -> list[TransferResult]:
+        """Find candidate source patterns and transfer those that qualify.
+
+        Parameters
+        ----------
+        target_pattern:
+            Abstract pattern representing the target org's own governance fingerprint.
+            Used for similarity matching and origin exclusion.
+        target_context:
+            Target org mapping tables (gate/clearance/tool).
+        trace_class:
+            Optional filter for candidate source patterns.
+        threshold:
+            Minimum total similarity for transfer to proceed.
+        weights:
+            Override default similarity weights.
+        max_sources:
+            Maximum candidate sources to evaluate.
+
+        Returns
+        -------
+        List of TransferResult — one per candidate (including gated-out).
+        Only results with adapted=True have adapted_pattern populated.
+        """
+        effective_class = trace_class or target_pattern.trace_class
+        candidates = self._registry.find_matches(
+            trace_class=effective_class,
+            exclude_org_hash=target_context.org_hash,
+            limit=max_sources,
+        )
+
+        results: list[TransferResult] = []
+        for source in candidates:
+            result = await self._transfer_one(
+                source=source,
+                target_pattern=target_pattern,
+                target_context=target_context,
+                threshold=threshold,
+                weights=weights,
+            )
+            results.append(result)
+            self._transfer_count += 1
+
+        return results
+
+    async def _transfer_one(
+        self,
+        source: AbstractPattern,
+        target_pattern: AbstractPattern,
+        target_context: TargetOrgContext,
+        threshold: float,
+        weights: SimilarityWeights | None,
+    ) -> TransferResult:
+        """Transfer a single source pattern through the full pipeline."""
+        score = compute_similarity(source, target_pattern, weights=weights, threshold=threshold)
+
+        # Pre-adaptation privacy check
+        pre_ok = verify_privacy(source)
+
+        record = TransferRecord(
+            source_pattern_id=source.pattern_id,
+            source_org_hash=source.source_org_hash,
+            target_org_hash=target_context.org_hash,
+            similarity_total=score.total,
+            similarity_domain=score.domain,
+            similarity_stack=score.stack,
+            similarity_governance=score.governance,
+            threshold=threshold,
+            gated=score.meets_threshold,
+            adapted=False,
+            privacy_verified_pre=pre_ok,
+            privacy_verified_post=False,
+        )
+
+        # Gate: similarity threshold
+        if not score.meets_threshold:
+            record.error = f"below_threshold: {score.total:.3f} < {threshold}"
+            await self._write_audit(record)
+            return TransferResult(record=record)
+
+        # Gate: pre-adaptation privacy
+        if not pre_ok:
+            record.error = "pre_privacy_verification_failed"
+            await self._write_audit(record)
+            return TransferResult(record=record)
+
+        # Adapt
+        try:
+            adaptation = adapt_pattern(source, target_context)
+        except AdaptationError as e:
+            record.error = f"adaptation_failed: {str(e)[:200]}"
+            record.unmapped_gates = []  # adaptation error keeps details internal
+            await self._write_audit(record)
+            return TransferResult(record=record)
+
+        # Post-adaptation privacy (already verified inside adapt_pattern, re-verify)
+        post_ok = verify_privacy(adaptation.adapted_pattern)
+        record.privacy_verified_post = post_ok
+        record.unmapped_gates = adaptation.unmapped_gates
+        record.unmapped_clearances = adaptation.unmapped_clearances
+
+        if not post_ok:
+            record.error = "post_privacy_verification_failed"
+            await self._write_audit(record)
+            return TransferResult(record=record)
+
+        record.adapted = True
+        record.adapted_pattern_id = adaptation.adapted_pattern.pattern_id
+
+        await self._write_audit(record)
+        return TransferResult(record=record, adapted_pattern=adaptation.adapted_pattern)
+
+    async def _write_audit(self, record: TransferRecord) -> None:
+        """Append an audit record. Hash-only, no raw payload content."""
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        file_path = self._audit_dir / f"{today}.jsonl"
+        line = json.dumps(record.model_dump(mode="json"), default=str) + "\n"
+
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, self._sync_append, file_path, line)
+
+    @staticmethod
+    def _sync_append(file_path: Path, line: str) -> None:
+        fd = os.open(str(file_path), os.O_WRONLY | os.O_APPEND | os.O_CREAT)
+        try:
+            os.write(fd, line.encode("utf-8"))
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+
+    def read_audit(
+        self,
+        date: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Read transfer audit entries for a given date (default: today)."""
+        if date is None:
+            date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        file_path = self._audit_dir / f"{date}.jsonl"
+        if not file_path.exists():
+            return []
+        records: list[dict[str, Any]] = []
+        with open(file_path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+        return records[-limit:][::-1]

--- a/graqle/governance/near_miss_store.py
+++ b/graqle/governance/near_miss_store.py
@@ -1,0 +1,161 @@
+# ------------------------------------------------------------------
+# PATENT NOTICE -- Quantamix Solutions B.V.
+#
+# This module implements methods covered by European Patent
+# Application EP26167849.4, owned by Quantamix Solutions B.V.
+#
+# Use of this software is permitted under the graqle license.
+# Reimplementation of the patented methods outside this software
+# requires a separate patent license.
+#
+# Contact: support@quantamixsolutions.com
+# ------------------------------------------------------------------
+
+"""Near-Miss Corpus Management (R19 ADR-202).
+
+Records predicted governance failures that were PREVENTED before
+they occurred. Each prevented failure strengthens the prediction
+corpus — creating a proprietary data moat.
+
+Near-miss corpus growth: after 1,000 prevented failures, GraQle has
+a failure corpus no competitor can buy.
+
+Storage: append-only JSONL at .graqle/near-misses/{YYYY-MM-DD}.jsonl
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+logger = logging.getLogger("graqle.governance.near_miss_store")
+
+_DEFAULT_DIR = ".graqle/near-misses"
+
+
+# ---------------------------------------------------------------------------
+# Near-Miss Record
+# ---------------------------------------------------------------------------
+
+
+class NearMissRecord(BaseModel):
+    """A predicted failure that was prevented.
+
+    Each near-miss is a label for the prediction model:
+    "this chain was predicted at probability P and did NOT result in failure
+    because intervention X was applied."
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: UUID = Field(default_factory=uuid4)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    trace_id: str | None = None
+    predicted_chain_id: str | None = None
+    predicted_probability: float = 0.0
+    chain_summary: str = ""
+    root_cause: str | None = None
+    prevented_by: str = ""  # "manual_review", "gate_block", "auto_correction", etc.
+    outcome: str = "prevented"  # always "prevented" for near-misses
+    features_hash: str | None = None  # SHA-256 of feature vector for dedup
+
+
+# ---------------------------------------------------------------------------
+# Near-Miss Store
+# ---------------------------------------------------------------------------
+
+
+class NearMissStore:
+    """Append-only near-miss corpus with daily file rotation.
+
+    Storage format: .graqle/near-misses/{YYYY-MM-DD}.jsonl
+    Each line is a JSON-serialized NearMissRecord.
+
+    Parameters
+    ----------
+    store_dir:
+        Directory for JSONL files. Created if missing.
+    """
+
+    def __init__(self, store_dir: str | Path | None = None) -> None:
+        if store_dir is None:
+            store_dir = _DEFAULT_DIR
+        self._dir = Path(store_dir)
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._count = 0
+
+    @property
+    def count(self) -> int:
+        """Near-misses recorded in this session."""
+        return self._count
+
+    def _current_file(self) -> Path:
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        return self._dir / f"{today}.jsonl"
+
+    async def record(self, near_miss: NearMissRecord) -> None:
+        """Append a near-miss record to the daily JSONL file."""
+        line = json.dumps(near_miss.model_dump(mode="json"), default=str) + "\n"
+        file_path = self._current_file()
+
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, self._sync_append, file_path, line)
+
+        self._count += 1
+        logger.debug(
+            "Near-miss recorded: chain=%s, prevented_by=%s (total: %d)",
+            near_miss.chain_summary[:50],
+            near_miss.prevented_by,
+            self._count,
+        )
+
+    @staticmethod
+    def _sync_append(file_path: Path, line: str) -> None:
+        fd = os.open(str(file_path), os.O_WRONLY | os.O_APPEND | os.O_CREAT)
+        try:
+            os.write(fd, line.encode("utf-8"))
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+
+    def read_near_misses(
+        self,
+        date: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Read near-miss records from a daily JSONL file."""
+        if date is None:
+            date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+        file_path = self._dir / f"{date}.jsonl"
+        if not file_path.exists():
+            return []
+
+        records: list[dict[str, Any]] = []
+        with open(file_path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+
+        return records[-limit:][::-1]
+
+    def corpus_size(self) -> int:
+        """Total near-misses across all daily files."""
+        total = 0
+        for jsonl_file in self._dir.glob("*.jsonl"):
+            with open(jsonl_file, "r", encoding="utf-8") as f:
+                total += sum(1 for line in f if line.strip())
+        return total

--- a/graqle/governance/pattern_abstractor.py
+++ b/graqle/governance/pattern_abstractor.py
@@ -1,0 +1,442 @@
+# ------------------------------------------------------------------
+# PATENT NOTICE -- Quantamix Solutions B.V.
+#
+# This module implements methods covered by European Patent
+# Applications EP26162901.8, EP26166054.2, EP26167849.4 (composite),
+# owned by Quantamix Solutions B.V.
+#
+# Use of this software is permitted under the graqle license.
+# Reimplementation of the patented methods outside this software
+# requires a separate patent license.
+#
+# Contact: support@quantamixsolutions.com
+# ------------------------------------------------------------------
+
+"""Pattern Abstractor for Cross-Org Transfer (R21 ADR-204).
+
+Extracts structural governance patterns from R18 GovernedTrace records,
+stripping all PII, credentials, raw identifiers, and org-specific strings.
+
+Output: AbstractPattern containing only gate decision sequences,
+clearance transitions, and aggregate outcomes — never raw data.
+
+Privacy posture: allowlist-only schema. Any unrecognized input field is
+dropped. Every emitted field is validated against the forbidden-content
+denylist before return.
+
+TS-2 Gate: Abstraction algorithm is core IP.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+logger = logging.getLogger("graqle.governance.pattern_abstractor")
+
+ABSTRACTOR_VERSION = "r21.v1"
+
+
+# ---------------------------------------------------------------------------
+# Forbidden content patterns (denylist for recursive scan)
+# ---------------------------------------------------------------------------
+
+# Patterns that must NEVER appear in an abstract pattern
+_FORBIDDEN_PATTERNS = [
+    re.compile(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}"),  # email
+    re.compile(r"https?://[^\s]+"),                                  # URL
+    re.compile(r"/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_./\\-]+"),             # unix path
+    re.compile(r"[A-Za-z]:[\\/][^\s]+"),                            # windows path
+    re.compile(r"\b(?:sk|pk|api)[-_][a-zA-Z0-9]{16,}"),             # API keys
+    re.compile(r"\b[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\b"),  # IPv4
+    re.compile(r"Bearer\s+[a-zA-Z0-9_\-.]+"),                       # Bearer token
+    re.compile(r"[a-fA-F0-9]{32,}"),                                # long hex (not SHA-256)
+]
+
+# Minimum entropy to consider a string a potential credential
+_ENTROPY_SUSPICION_THRESHOLD = 4.5
+
+
+def _shannon_entropy(s: str) -> float:
+    """Compute Shannon entropy of a string (bits per char)."""
+    if not s:
+        return 0.0
+    freq: dict[str, int] = {}
+    for ch in s:
+        freq[ch] = freq.get(ch, 0) + 1
+    import math
+    length = len(s)
+    entropy = 0.0
+    for count in freq.values():
+        p = count / length
+        entropy -= p * math.log2(p)
+    return entropy
+
+
+def _contains_forbidden(value: Any, allow_sha256: bool = True) -> bool:
+    """Recursively check if any value contains forbidden content."""
+    if value is None or isinstance(value, (bool, int, float)):
+        return False
+    if isinstance(value, str):
+        # Allow SHA-256 hashes (64 hex chars exactly)
+        if allow_sha256 and len(value) == 64 and all(c in "0123456789abcdef" for c in value.lower()):
+            return False
+        for pattern in _FORBIDDEN_PATTERNS:
+            if pattern.search(value):
+                return True
+        # Entropy check for opaque suspicious strings
+        if len(value) >= 20 and _shannon_entropy(value) >= _ENTROPY_SUSPICION_THRESHOLD:
+            # Allow if it looks like a normalized tag (lowercase words)
+            if not re.match(r"^[a-z][a-z0-9_-]*$", value):
+                return True
+        return False
+    if isinstance(value, list):
+        return any(_contains_forbidden(v, allow_sha256) for v in value)
+    if isinstance(value, dict):
+        return any(_contains_forbidden(v, allow_sha256) for v in value.values())
+    return True  # unknown type -> fail closed
+
+
+# ---------------------------------------------------------------------------
+# Pydantic Models
+# ---------------------------------------------------------------------------
+
+
+class GateStep(BaseModel):
+    """Single step in an abstracted gate sequence."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    gate_type: str  # abstract class (e.g., "clearance", "budget", "ip_gate")
+    decision: str  # normalized: pass/block/warn
+    clearance_before: str  # normalized level name
+    clearance_after: str
+    outcome: str  # normalized outcome code
+    ordinal: int  # order in sequence
+
+
+class ClearanceTransition(BaseModel):
+    """Single clearance level transition observed."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    from_level: str
+    to_level: str
+    trigger_gate: str  # abstract gate class
+
+
+class OutcomeAggregates(BaseModel):
+    """Aggregate outcome statistics across traces."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    pass_rate: float = 0.0
+    fail_rate: float = 0.0
+    block_rate: float = 0.0
+    retry_count: int = 0
+    escalation_count: int = 0
+    avg_latency_ms: float = 0.0
+    counts_by_outcome: dict[str, int] = Field(default_factory=dict)
+
+
+class SimilarityProfile(BaseModel):
+    """Multi-dimensional similarity profile for matching."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    domain: float = 0.0  # [0, 1]
+    stack: float = 0.0
+    governance: float = 0.0
+
+
+class Provenance(BaseModel):
+    """Hash-only provenance. Never raw trace data."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    r18_trace_hash: str  # SHA-256 of source trace batch
+    extractor_version: str = ABSTRACTOR_VERSION
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class Redactions(BaseModel):
+    """Flags indicating which redactions were applied."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    pii_removed: bool = True
+    org_ids_removed: bool = True
+    creds_removed: bool = True
+
+
+class AbstractPattern(BaseModel):
+    """An abstracted governance pattern safe for cross-org transfer.
+
+    Invariants:
+        - No PII, credentials, URLs, paths, or raw identifiers
+        - source_org_hash is SHA-256 (never raw org name)
+        - All fields are structural or aggregate — no free text
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = "r21.v1"
+    pattern_id: str = Field(default_factory=lambda: f"pat-{uuid4().hex[:12]}")
+    source_org_hash: str  # SHA-256 of org identifier
+    trace_class: str  # coarse category (e.g., "reasoning", "generation", "review")
+    domain_tags: list[str] = Field(default_factory=list)
+    stack_tags: list[str] = Field(default_factory=list)
+    governance_tags: list[str] = Field(default_factory=list)
+    gate_sequence: list[GateStep] = Field(default_factory=list)
+    clearance_transitions: list[ClearanceTransition] = Field(default_factory=list)
+    outcome_aggregates: OutcomeAggregates = Field(default_factory=OutcomeAggregates)
+    similarity_profile: SimilarityProfile = Field(default_factory=SimilarityProfile)
+    provenance: Provenance
+    redactions: Redactions = Field(default_factory=Redactions)
+
+
+# ---------------------------------------------------------------------------
+# Abstraction Algorithm
+# ---------------------------------------------------------------------------
+
+# Map raw tool names to abstract trace classes
+_TRACE_CLASS_MAP = {
+    "graq_reason": "reasoning",
+    "graq_reason_batch": "reasoning",
+    "graq_generate": "generation",
+    "graq_edit": "editing",
+    "graq_review": "review",
+    "graq_predict": "prediction",
+    "graq_auto": "autonomous",
+    "graq_bash": "shell",
+    "graq_read": "read",
+    "graq_write": "write",
+}
+
+# Map raw gate IDs to abstract gate classes
+_GATE_CLASS_MAP = {
+    "CG-01": "session",
+    "CG-02": "plan",
+    "CG-03": "edit_gate",
+    "CG-04": "batch",
+    "CLEARANCE": "clearance",
+    "IP_TRADE": "ip_gate",
+    "GIT_GOVERNANCE": "git_gate",
+    "BUDGET": "budget_gate",
+}
+
+
+def _hash_org(org_id: str) -> str:
+    """Hash an org identifier to SHA-256."""
+    return hashlib.sha256(org_id.encode("utf-8")).hexdigest()
+
+
+def _hash_trace_batch(traces: list[dict[str, Any]]) -> str:
+    """Hash a trace batch for provenance (no content stored)."""
+    hasher = hashlib.sha256()
+    for t in traces:
+        trace_id = str(t.get("id", ""))
+        hasher.update(trace_id.encode("utf-8"))
+    return hasher.hexdigest()
+
+
+def _abstract_trace_class(tool_name: str) -> str:
+    """Map tool_name to abstract trace class, stripping kogni_ prefix."""
+    canonical = tool_name.replace("kogni_", "graq_", 1) if tool_name.startswith("kogni_") else tool_name
+    return _TRACE_CLASS_MAP.get(canonical, "other")
+
+
+def _abstract_gate_type(gate_id: str, gate_type: str) -> str:
+    """Map a raw gate to an abstract gate class."""
+    if gate_id in _GATE_CLASS_MAP:
+        return _GATE_CLASS_MAP[gate_id]
+    return _GATE_CLASS_MAP.get(gate_type, "other_gate")
+
+
+def _normalize_clearance(level: str) -> str:
+    """Normalize a clearance level label to abstract form."""
+    normalized = level.upper().strip() if isinstance(level, str) else "UNKNOWN"
+    if normalized in ("PUBLIC", "INTERNAL", "CONFIDENTIAL", "RESTRICTED"):
+        return normalized
+    return "UNKNOWN"
+
+
+def _normalize_decision(decision: str) -> str:
+    """Normalize a gate decision to abstract form."""
+    normalized = decision.upper().strip() if isinstance(decision, str) else "UNKNOWN"
+    if normalized in ("PASS", "BLOCK", "WARN"):
+        return normalized
+    return "UNKNOWN"
+
+
+def _normalize_outcome(outcome: str) -> str:
+    """Normalize a trace outcome to abstract form."""
+    normalized = outcome.upper().strip() if isinstance(outcome, str) else "UNKNOWN"
+    if normalized in ("SUCCESS", "PARTIAL", "FAILURE", "BLOCKED"):
+        return normalized
+    return "UNKNOWN"
+
+
+def extract_abstract_pattern(
+    traces: list[dict[str, Any]],
+    org_id: str,
+    trace_class_override: str | None = None,
+    domain_tags: list[str] | None = None,
+    stack_tags: list[str] | None = None,
+    governance_tags: list[str] | None = None,
+) -> AbstractPattern:
+    """Extract an abstract pattern from a batch of R18 traces.
+
+    Parameters
+    ----------
+    traces:
+        List of GovernedTrace dicts (from TraceStore.read_traces).
+    org_id:
+        Raw org identifier. Will be SHA-256 hashed before storage.
+    trace_class_override:
+        Optional override for trace class (default: inferred from majority tool).
+    domain_tags, stack_tags, governance_tags:
+        Optional normalized tag lists for similarity matching.
+
+    Returns
+    -------
+    AbstractPattern with all PII/raw identifiers stripped.
+
+    Raises
+    ------
+    ValueError: if the abstract pattern fails privacy verification.
+    """
+    if not traces:
+        raise ValueError("Cannot extract pattern from empty trace batch")
+
+    source_org_hash = _hash_org(org_id)
+    provenance_hash = _hash_trace_batch(traces)
+
+    # Infer trace class from majority tool
+    if trace_class_override:
+        trace_class = trace_class_override
+    else:
+        tool_classes: dict[str, int] = {}
+        for t in traces:
+            tool = t.get("tool_name", "")
+            cls = _abstract_trace_class(tool)
+            tool_classes[cls] = tool_classes.get(cls, 0) + 1
+        trace_class = max(tool_classes.items(), key=lambda x: x[1])[0] if tool_classes else "other"
+
+    # Build gate sequence (up to first 50 gate decisions)
+    gate_sequence: list[GateStep] = []
+    for t in traces[:50]:
+        clearance = _normalize_clearance(t.get("clearance_level", ""))
+        for gd in t.get("governance_decisions", []):
+            gate_type = _abstract_gate_type(
+                gd.get("gate_id", ""),
+                gd.get("gate_type", ""),
+            )
+            decision = _normalize_decision(gd.get("decision", ""))
+            gate_sequence.append(GateStep(
+                gate_type=gate_type,
+                decision=decision,
+                clearance_before=clearance,
+                clearance_after=clearance,  # simplified for v1
+                outcome=_normalize_outcome(t.get("outcome", "")),
+                ordinal=len(gate_sequence),
+            ))
+
+    # Clearance transitions (observed level changes)
+    transitions: list[ClearanceTransition] = []
+    clearance_levels = set()
+    for t in traces:
+        cl = _normalize_clearance(t.get("clearance_level", ""))
+        if cl != "UNKNOWN":
+            clearance_levels.add(cl)
+
+    # Outcome aggregates
+    outcome_counts: dict[str, int] = {}
+    total_latency = 0.0
+    latency_count = 0
+    retry_count = 0
+    escalation_count = 0
+    for t in traces:
+        outcome = _normalize_outcome(t.get("outcome", ""))
+        outcome_counts[outcome] = outcome_counts.get(outcome, 0) + 1
+        latency = t.get("latency_ms", 0.0)
+        if isinstance(latency, (int, float)) and latency >= 0:
+            total_latency += latency
+            latency_count += 1
+        if t.get("human_override"):
+            escalation_count += 1
+
+    total = len(traces)
+    aggregates = OutcomeAggregates(
+        pass_rate=outcome_counts.get("SUCCESS", 0) / total,
+        fail_rate=outcome_counts.get("FAILURE", 0) / total,
+        block_rate=outcome_counts.get("BLOCKED", 0) / total,
+        retry_count=retry_count,
+        escalation_count=escalation_count,
+        avg_latency_ms=total_latency / latency_count if latency_count > 0 else 0.0,
+        counts_by_outcome=outcome_counts,
+    )
+
+    # Normalize provided tags (lowercase, alphanumeric + hyphens/underscores)
+    def _normalize_tags(tags: list[str] | None) -> list[str]:
+        if not tags:
+            return []
+        out = []
+        for tag in tags:
+            if isinstance(tag, str):
+                clean = re.sub(r"[^a-z0-9_-]", "", tag.lower().strip())
+                if clean and len(clean) <= 32:
+                    out.append(clean)
+        return out[:20]  # cap count
+
+    pattern = AbstractPattern(
+        source_org_hash=source_org_hash,
+        trace_class=trace_class,
+        domain_tags=_normalize_tags(domain_tags),
+        stack_tags=_normalize_tags(stack_tags),
+        governance_tags=_normalize_tags(governance_tags),
+        gate_sequence=gate_sequence,
+        clearance_transitions=transitions,
+        outcome_aggregates=aggregates,
+        provenance=Provenance(r18_trace_hash=provenance_hash),
+    )
+
+    # Post-abstraction privacy verification
+    if not verify_privacy(pattern):
+        raise ValueError("Abstracted pattern failed privacy verification")
+
+    return pattern
+
+
+def verify_privacy(pattern: AbstractPattern) -> bool:
+    """Verify an abstract pattern contains no forbidden content.
+
+    Three-layer verification:
+    1. Schema is allowlist-only (enforced by Pydantic extra=forbid)
+    2. source_org_hash is valid SHA-256
+    3. Recursive denylist scan on all fields
+
+    Returns False on any violation (fail-closed).
+    """
+    # Layer 2: SHA-256 format check
+    if not isinstance(pattern.source_org_hash, str):
+        return False
+    if len(pattern.source_org_hash) != 64:
+        return False
+    if not all(c in "0123456789abcdef" for c in pattern.source_org_hash.lower()):
+        return False
+
+    # Layer 3: Recursive denylist scan on model_dump output
+    data = pattern.model_dump(mode="json")
+    # The source_org_hash and r18_trace_hash are SHA-256 (allowed)
+    if _contains_forbidden(data, allow_sha256=True):
+        return False
+
+    return True

--- a/graqle/governance/pattern_abstractor.py
+++ b/graqle/governance/pattern_abstractor.py
@@ -86,7 +86,8 @@ def _contains_forbidden(value: Any, allow_sha256: bool = True) -> bool:
         return False
     if isinstance(value, str):
         # Allow SHA-256 hashes (64 hex chars exactly)
-        if allow_sha256 and len(value) == 64 and all(c in "0123456789abcdef" for c in value.lower()):
+        hex_chars = "0123456789abcdef"
+        if allow_sha256 and len(value) == 64 and all(c in hex_chars for c in value.lower()):
             return False
         for pattern in _FORBIDDEN_PATTERNS:
             if pattern.search(value):
@@ -249,7 +250,11 @@ def _hash_trace_batch(traces: list[dict[str, Any]]) -> str:
 
 def _abstract_trace_class(tool_name: str) -> str:
     """Map tool_name to abstract trace class, stripping kogni_ prefix."""
-    canonical = tool_name.replace("kogni_", "graq_", 1) if tool_name.startswith("kogni_") else tool_name
+    canonical = (
+        tool_name.replace("kogni_", "graq_", 1)
+        if tool_name.startswith("kogni_")
+        else tool_name
+    )
     return _TRACE_CLASS_MAP.get(canonical, "other")
 
 

--- a/graqle/governance/pattern_registry.py
+++ b/graqle/governance/pattern_registry.py
@@ -1,0 +1,240 @@
+# ------------------------------------------------------------------
+# PATENT NOTICE -- Quantamix Solutions B.V.
+#
+# This module implements methods covered by European Patent
+# Applications EP26162901.8, EP26166054.2, EP26167849.4 (composite),
+# owned by Quantamix Solutions B.V.
+#
+# Use of this software is permitted under the graqle license.
+# Reimplementation of the patented methods outside this software
+# requires a separate patent license.
+#
+# Contact: support@quantamixsolutions.com
+# ------------------------------------------------------------------
+
+"""Cross-Organization Pattern Registry (R21 ADR-204).
+
+Append-only store for privacy-verified abstract governance patterns.
+Each entry contains only hashed provenance and structural abstractions.
+
+Storage layout: .graqle/patterns/{YYYY-MM-DD}.jsonl
+Index: .graqle/patterns/index.json with metadata only.
+
+Privacy invariants:
+- source_org_hash is SHA-256 only (never raw org name)
+- Every pattern is re-verified against denylist on read
+- Rejected patterns are never stored (fail-closed)
+
+Multi-tenant isolation: Org A cannot query Org B's patterns unless the
+caller provides Org B's pattern IDs directly (no pattern enumeration
+by org hash from an outsider).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from graqle.governance.pattern_abstractor import AbstractPattern, verify_privacy
+
+logger = logging.getLogger("graqle.governance.pattern_registry")
+
+_DEFAULT_DIR = ".graqle/patterns"
+_INDEX_FILE = "index.json"
+
+
+class RegistryEntry(BaseModel):
+    """Index metadata for a stored pattern — no raw data."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    pattern_id: str
+    source_org_hash: str
+    trace_class: str
+    created_at: datetime
+    file: str  # daily jsonl filename
+
+
+class PatternRegistry:
+    """Append-only cross-org pattern registry.
+
+    Parameters
+    ----------
+    store_dir:
+        Root directory for pattern storage. Created if missing.
+    """
+
+    def __init__(self, store_dir: str | Path | None = None) -> None:
+        if store_dir is None:
+            store_dir = _DEFAULT_DIR
+        self._dir = Path(store_dir)
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._count = 0
+
+    @property
+    def store_dir(self) -> Path:
+        return self._dir
+
+    @property
+    def count(self) -> int:
+        """Patterns added in this session."""
+        return self._count
+
+    def _current_file(self) -> Path:
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        return self._dir / f"{today}.jsonl"
+
+    async def register(self, pattern: AbstractPattern) -> RegistryEntry:
+        """Register a pattern. Fails closed on privacy violation.
+
+        Raises
+        ------
+        ValueError: if pattern fails privacy verification.
+        """
+        if not verify_privacy(pattern):
+            raise ValueError(
+                f"Pattern {pattern.pattern_id} failed privacy verification; refusing to register"
+            )
+
+        # Serialize
+        data = pattern.model_dump(mode="json")
+        line = json.dumps(data, default=str) + "\n"
+
+        file_path = self._current_file()
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, self._sync_append, file_path, line)
+
+        entry = RegistryEntry(
+            pattern_id=pattern.pattern_id,
+            source_org_hash=pattern.source_org_hash,
+            trace_class=pattern.trace_class,
+            created_at=pattern.provenance.created_at,
+            file=file_path.name,
+        )
+
+        self._append_index(entry)
+        self._count += 1
+        logger.debug(
+            "Pattern registered: %s (trace_class=%s, org_hash_prefix=%s)",
+            pattern.pattern_id,
+            pattern.trace_class,
+            pattern.source_org_hash[:8],
+        )
+        return entry
+
+    @staticmethod
+    def _sync_append(file_path: Path, line: str) -> None:
+        fd = os.open(str(file_path), os.O_WRONLY | os.O_APPEND | os.O_CREAT)
+        try:
+            os.write(fd, line.encode("utf-8"))
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+
+    def _append_index(self, entry: RegistryEntry) -> None:
+        index_path = self._dir / _INDEX_FILE
+        existing = self._read_index()
+        existing.append(entry.model_dump(mode="json"))
+        tmp = index_path.with_suffix(".json.tmp")
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(existing, f, indent=2, default=str)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, index_path)
+
+    def _read_index(self) -> list[dict[str, Any]]:
+        index_path = self._dir / _INDEX_FILE
+        if not index_path.exists():
+            return []
+        try:
+            with open(index_path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return []
+
+    def list_patterns(
+        self,
+        trace_class: str | None = None,
+        limit: int = 100,
+    ) -> list[RegistryEntry]:
+        """List pattern metadata entries (no raw content).
+
+        Parameters
+        ----------
+        trace_class:
+            Filter by trace class (e.g., "reasoning", "generation").
+        limit:
+            Maximum entries to return.
+        """
+        entries = self._read_index()
+        if trace_class:
+            entries = [e for e in entries if e.get("trace_class") == trace_class]
+        return [RegistryEntry(**e) for e in entries[-limit:][::-1]]
+
+    def corpus_size(self) -> int:
+        """Total patterns across all daily files."""
+        total = 0
+        for jsonl_file in self._dir.glob("*.jsonl"):
+            with open(jsonl_file, "r", encoding="utf-8") as f:
+                total += sum(1 for line in f if line.strip())
+        return total
+
+    def load_pattern(self, pattern_id: str) -> AbstractPattern | None:
+        """Load a specific pattern by ID.
+
+        Scans daily files until found. Re-verifies privacy on load.
+        Returns None if not found or verification fails.
+        """
+        for jsonl_file in sorted(self._dir.glob("*.jsonl")):
+            with open(jsonl_file, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        data = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if data.get("pattern_id") == pattern_id:
+                        try:
+                            pattern = AbstractPattern(**data)
+                            if not verify_privacy(pattern):
+                                logger.warning(
+                                    "Loaded pattern %s failed re-verification; rejecting",
+                                    pattern_id,
+                                )
+                                return None
+                            return pattern
+                        except Exception:
+                            return None
+        return None
+
+    def find_matches(
+        self,
+        trace_class: str,
+        exclude_org_hash: str | None = None,
+        limit: int = 20,
+    ) -> list[AbstractPattern]:
+        """Find patterns matching a trace class, optionally excluding an org.
+
+        Used by the federated transfer engine to find source patterns
+        for a target org. Excludes patterns from the target's own org hash
+        so you don't "transfer" a pattern back to its origin.
+        """
+        matches: list[AbstractPattern] = []
+        for entry in self.list_patterns(trace_class=trace_class, limit=500):
+            if exclude_org_hash and entry.source_org_hash == exclude_org_hash:
+                continue
+            pattern = self.load_pattern(entry.pattern_id)
+            if pattern is not None:
+                matches.append(pattern)
+            if len(matches) >= limit:
+                break
+        return matches

--- a/graqle/governance/reliability_diagram.py
+++ b/graqle/governance/reliability_diagram.py
@@ -1,0 +1,201 @@
+# ------------------------------------------------------------------
+# PATENT NOTICE -- Quantamix Solutions B.V.
+#
+# This module implements methods covered by European Patent
+# Application EP26166054.2 (Divisional, Claims F-J), owned by
+# Quantamix Solutions B.V.
+#
+# Use of this software is permitted under the graqle license.
+# Reimplementation of the patented methods outside this software
+# requires a separate patent license.
+#
+# Contact: support@quantamixsolutions.com
+# ------------------------------------------------------------------
+
+"""Reliability Diagram SVG Generator (R20 ADR-203).
+
+Generates an audit-grade reliability diagram as an SVG string.
+No external plotting libraries — pure string generation.
+
+The diagram shows:
+- Perfect calibration diagonal (y=x)
+- Per-bin points with confidence interval whiskers
+- ECE metric and sample count labels
+- Status indicator (calibrated / uncalibrated)
+"""
+
+from __future__ import annotations
+
+from graqle.governance.calibration import CalibrationModel
+
+
+# SVG canvas dimensions
+_WIDTH = 500
+_HEIGHT = 500
+_MARGIN = 60
+_PLOT_WIDTH = _WIDTH - 2 * _MARGIN
+_PLOT_HEIGHT = _HEIGHT - 2 * _MARGIN
+
+
+def _x_to_px(x: float) -> float:
+    """Map [0, 1] data x to SVG px."""
+    return _MARGIN + x * _PLOT_WIDTH
+
+
+def _y_to_px(y: float) -> float:
+    """Map [0, 1] data y to SVG px (inverted)."""
+    return _MARGIN + (1.0 - y) * _PLOT_HEIGHT
+
+
+def generate_svg(model: CalibrationModel) -> str:
+    """Generate reliability diagram SVG for a calibration model.
+
+    Parameters
+    ----------
+    model:
+        Fitted CalibrationModel (must be "calibrated" status to show bins).
+
+    Returns
+    -------
+    SVG string suitable for display or export.
+    """
+    parts: list[str] = []
+
+    # Header
+    parts.append(
+        f'<svg xmlns="http://www.w3.org/2000/svg" '
+        f'width="{_WIDTH}" height="{_HEIGHT}" '
+        f'viewBox="0 0 {_WIDTH} {_HEIGHT}" '
+        f'font-family="sans-serif" font-size="12">'
+    )
+
+    # Background
+    parts.append(f'<rect width="{_WIDTH}" height="{_HEIGHT}" fill="white"/>')
+
+    # Plot area border
+    parts.append(
+        f'<rect x="{_MARGIN}" y="{_MARGIN}" '
+        f'width="{_PLOT_WIDTH}" height="{_PLOT_HEIGHT}" '
+        f'fill="#fafafa" stroke="#333" stroke-width="1"/>'
+    )
+
+    # Grid lines (every 0.2)
+    for i in range(1, 5):
+        v = i / 5.0
+        x_px = _x_to_px(v)
+        y_px = _y_to_px(v)
+        parts.append(
+            f'<line x1="{x_px}" y1="{_MARGIN}" x2="{x_px}" '
+            f'y2="{_MARGIN + _PLOT_HEIGHT}" stroke="#e5e5e5" stroke-width="1"/>'
+        )
+        parts.append(
+            f'<line x1="{_MARGIN}" y1="{y_px}" '
+            f'x2="{_MARGIN + _PLOT_WIDTH}" y2="{y_px}" stroke="#e5e5e5" stroke-width="1"/>'
+        )
+
+    # Perfect calibration diagonal (y = x)
+    parts.append(
+        f'<line x1="{_x_to_px(0)}" y1="{_y_to_px(0)}" '
+        f'x2="{_x_to_px(1)}" y2="{_y_to_px(1)}" '
+        f'stroke="#888" stroke-width="1.5" stroke-dasharray="4,4"/>'
+    )
+
+    # Axis labels
+    parts.append(
+        f'<text x="{_WIDTH / 2}" y="{_HEIGHT - 20}" '
+        f'text-anchor="middle" fill="#333">Predicted probability</text>'
+    )
+    parts.append(
+        f'<text x="20" y="{_HEIGHT / 2}" '
+        f'text-anchor="middle" fill="#333" '
+        f'transform="rotate(-90, 20, {_HEIGHT / 2})">Observed frequency</text>'
+    )
+
+    # Axis tick labels
+    for i in range(6):
+        v = i / 5.0
+        parts.append(
+            f'<text x="{_x_to_px(v)}" y="{_MARGIN + _PLOT_HEIGHT + 18}" '
+            f'text-anchor="middle" fill="#555">{v:.1f}</text>'
+        )
+        parts.append(
+            f'<text x="{_MARGIN - 8}" y="{_y_to_px(v) + 4}" '
+            f'text-anchor="end" fill="#555">{v:.1f}</text>'
+        )
+
+    # Plot per-bin points (only if calibrated)
+    if model.status == "calibrated" and model.bins:
+        # CI whiskers first (underneath points)
+        for b in model.bins:
+            if b.count == 0:
+                continue
+            x_px = _x_to_px(b.avg_pred)
+            if b.ci_low is not None and b.ci_high is not None:
+                y_low = _y_to_px(b.ci_low)
+                y_high = _y_to_px(b.ci_high)
+                parts.append(
+                    f'<line x1="{x_px}" y1="{y_low}" x2="{x_px}" y2="{y_high}" '
+                    f'stroke="#1e40af" stroke-width="2"/>'
+                )
+                # Whisker caps
+                cap = 4
+                parts.append(
+                    f'<line x1="{x_px - cap}" y1="{y_low}" '
+                    f'x2="{x_px + cap}" y2="{y_low}" stroke="#1e40af" stroke-width="2"/>'
+                )
+                parts.append(
+                    f'<line x1="{x_px - cap}" y1="{y_high}" '
+                    f'x2="{x_px + cap}" y2="{y_high}" stroke="#1e40af" stroke-width="2"/>'
+                )
+
+        # Bin points
+        for b in model.bins:
+            if b.count == 0:
+                continue
+            x_px = _x_to_px(b.avg_pred)
+            y_px = _y_to_px(b.avg_actual)
+            # Size scales with count
+            max_count = max(bb.count for bb in model.bins if bb.count > 0)
+            radius = 4 + 6 * (b.count / max_count)
+            parts.append(
+                f'<circle cx="{x_px}" cy="{y_px}" r="{radius:.1f}" '
+                f'fill="#2563eb" fill-opacity="0.7" stroke="#1e40af" stroke-width="1.5"/>'
+            )
+
+    # Title
+    title = f"Reliability Diagram - {model.method.title()}"
+    parts.append(
+        f'<text x="{_WIDTH / 2}" y="25" text-anchor="middle" '
+        f'font-size="16" font-weight="bold" fill="#111">{title}</text>'
+    )
+
+    # Metadata block (top-left of plot area)
+    meta_x = _MARGIN + 10
+    meta_y = _MARGIN + 18
+    ece_str = f"{model.ece:.4f}" if model.ece is not None else "N/A"
+    status_color = "#16a34a" if model.status == "calibrated" else "#dc2626"
+    parts.append(
+        f'<text x="{meta_x}" y="{meta_y}" fill="{status_color}" font-weight="bold">'
+        f'Status: {model.status}</text>'
+    )
+    parts.append(
+        f'<text x="{meta_x}" y="{meta_y + 16}" fill="#333">N = {model.n_samples}</text>'
+    )
+    parts.append(
+        f'<text x="{meta_x}" y="{meta_y + 32}" fill="#333">ECE = {ece_str}</text>'
+    )
+    ece_passed = "PASS" if model.ece_passed else "FAIL"
+    ece_color = "#16a34a" if model.ece_passed else "#dc2626"
+    parts.append(
+        f'<text x="{meta_x}" y="{meta_y + 48}" fill="{ece_color}">'
+        f'Target ECE &lt; {model.target_ece}: {ece_passed}</text>'
+    )
+
+    # Version footer
+    parts.append(
+        f'<text x="{_WIDTH - 10}" y="{_HEIGHT - 8}" '
+        f'text-anchor="end" fill="#888" font-size="10">{model.version}</text>'
+    )
+
+    parts.append('</svg>')
+    return "\n".join(parts)

--- a/graqle/governance/similarity.py
+++ b/graqle/governance/similarity.py
@@ -1,0 +1,208 @@
+# ------------------------------------------------------------------
+# PATENT NOTICE -- Quantamix Solutions B.V.
+#
+# This module implements methods covered by European Patent
+# Applications EP26162901.8, EP26166054.2, EP26167849.4 (composite),
+# owned by Quantamix Solutions B.V.
+#
+# Use of this software is permitted under the graqle license.
+# Reimplementation of the patented methods outside this software
+# requires a separate patent license.
+#
+# Contact: support@quantamixsolutions.com
+# ------------------------------------------------------------------
+
+"""Project Similarity for Cross-Org Transfer (R21 ADR-204).
+
+Computes sim(A, B) = alpha*sim_domain + beta*sim_stack + gamma*sim_governance
+where:
+- sim_domain: industry/domain tag overlap
+- sim_stack: technology stack tag overlap
+- sim_governance: governance configuration overlap
+- alpha + beta + gamma = 1.0
+
+Defaults: alpha=0.35, beta=0.30, gamma=0.35
+
+This similarity module is SEPARATE from graqle/activation/chunk_scorer.py
+cosine_similarity — that is for embedding similarity. This is for
+project-level compliance matching.
+
+TS-2 Gate: Similarity weights are learned from transfer outcomes (core IP).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from graqle.governance.pattern_abstractor import AbstractPattern, SimilarityProfile
+
+# Default weights — learned from transfer outcomes in production
+DEFAULT_ALPHA = 0.35  # domain weight
+DEFAULT_BETA = 0.30   # stack weight
+DEFAULT_GAMMA = 0.35  # governance weight
+
+# Minimum similarity required to allow a transfer
+DEFAULT_TRANSFER_THRESHOLD = 0.6
+
+
+class SimilarityWeights(BaseModel):
+    """Weights for the three-dimensional similarity score."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    alpha: float = Field(ge=0.0, le=1.0, default=DEFAULT_ALPHA)
+    beta: float = Field(ge=0.0, le=1.0, default=DEFAULT_BETA)
+    gamma: float = Field(ge=0.0, le=1.0, default=DEFAULT_GAMMA)
+
+    def validate_sum(self) -> bool:
+        """Verify weights sum to ~1.0."""
+        total = self.alpha + self.beta + self.gamma
+        return abs(total - 1.0) < 0.001
+
+
+class SimilarityScore(BaseModel):
+    """Full similarity breakdown between two projects."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    total: float = Field(ge=0.0, le=1.0)
+    domain: float = Field(ge=0.0, le=1.0)
+    stack: float = Field(ge=0.0, le=1.0)
+    governance: float = Field(ge=0.0, le=1.0)
+    weights: SimilarityWeights
+    meets_threshold: bool
+    threshold: float
+
+
+def jaccard(set_a: set[str], set_b: set[str]) -> float:
+    """Jaccard similarity between two sets: |A ∩ B| / |A ∪ B|."""
+    if not set_a and not set_b:
+        return 0.0
+    intersection = len(set_a & set_b)
+    union = len(set_a | set_b)
+    return intersection / union if union > 0 else 0.0
+
+
+def domain_similarity(tags_a: list[str], tags_b: list[str]) -> float:
+    """Compute domain tag overlap via Jaccard."""
+    return jaccard(set(tags_a), set(tags_b))
+
+
+def stack_similarity(tags_a: list[str], tags_b: list[str]) -> float:
+    """Compute stack tag overlap via Jaccard."""
+    return jaccard(set(tags_a), set(tags_b))
+
+
+def governance_similarity(
+    gov_tags_a: list[str],
+    gov_tags_b: list[str],
+    pattern_a: AbstractPattern | None = None,
+    pattern_b: AbstractPattern | None = None,
+) -> float:
+    """Compute governance overlap.
+
+    Combines:
+    - governance tag Jaccard (50%)
+    - gate_type sequence overlap (25%, if patterns provided)
+    - clearance level overlap (25%, if patterns provided)
+    """
+    tag_sim = jaccard(set(gov_tags_a), set(gov_tags_b))
+
+    if pattern_a is None or pattern_b is None:
+        return tag_sim
+
+    # Gate type overlap
+    gates_a = set(step.gate_type for step in pattern_a.gate_sequence)
+    gates_b = set(step.gate_type for step in pattern_b.gate_sequence)
+    gate_sim = jaccard(gates_a, gates_b)
+
+    # Clearance level overlap
+    clearances_a = set(step.clearance_before for step in pattern_a.gate_sequence)
+    clearances_b = set(step.clearance_before for step in pattern_b.gate_sequence)
+    clearance_sim = jaccard(clearances_a, clearances_b)
+
+    return 0.5 * tag_sim + 0.25 * gate_sim + 0.25 * clearance_sim
+
+
+def compute_similarity(
+    pattern_a: AbstractPattern,
+    pattern_b: AbstractPattern,
+    weights: SimilarityWeights | None = None,
+    threshold: float = DEFAULT_TRANSFER_THRESHOLD,
+) -> SimilarityScore:
+    """Compute full similarity between two abstract patterns.
+
+    Parameters
+    ----------
+    pattern_a, pattern_b:
+        Abstract patterns from two different organizations.
+    weights:
+        Override default weights (must sum to 1.0).
+    threshold:
+        Minimum total similarity for transfer eligibility.
+
+    Returns
+    -------
+    SimilarityScore with per-dimension breakdown and threshold check.
+
+    Raises
+    ------
+    ValueError: if weights do not sum to 1.0.
+    """
+    if weights is None:
+        weights = SimilarityWeights()
+    elif not weights.validate_sum():
+        raise ValueError(
+            f"Weights must sum to 1.0, got {weights.alpha + weights.beta + weights.gamma}"
+        )
+
+    domain = domain_similarity(pattern_a.domain_tags, pattern_b.domain_tags)
+    stack = stack_similarity(pattern_a.stack_tags, pattern_b.stack_tags)
+    governance = governance_similarity(
+        pattern_a.governance_tags,
+        pattern_b.governance_tags,
+        pattern_a=pattern_a,
+        pattern_b=pattern_b,
+    )
+
+    total = weights.alpha * domain + weights.beta * stack + weights.gamma * governance
+
+    return SimilarityScore(
+        total=total,
+        domain=domain,
+        stack=stack,
+        governance=governance,
+        weights=weights,
+        meets_threshold=total >= threshold,
+        threshold=threshold,
+    )
+
+
+def build_similarity_profile(
+    pattern: AbstractPattern,
+    against: list[AbstractPattern],
+    weights: SimilarityWeights | None = None,
+) -> SimilarityProfile:
+    """Compute average similarity profile of a pattern against a corpus.
+
+    Used to populate SimilarityProfile on an abstract pattern at creation time.
+    """
+    if not against:
+        return SimilarityProfile()
+
+    domain_scores = []
+    stack_scores = []
+    gov_scores = []
+    for other in against:
+        score = compute_similarity(pattern, other, weights=weights)
+        domain_scores.append(score.domain)
+        stack_scores.append(score.stack)
+        gov_scores.append(score.governance)
+
+    return SimilarityProfile(
+        domain=sum(domain_scores) / len(domain_scores),
+        stack=sum(stack_scores) / len(stack_scores),
+        governance=sum(gov_scores) / len(gov_scores),
+    )

--- a/graqle/governance/trace_capture.py
+++ b/graqle/governance/trace_capture.py
@@ -1,0 +1,250 @@
+# ------------------------------------------------------------------
+# PATENT NOTICE -- Quantamix Solutions B.V.
+#
+# This module implements methods covered by European Patent
+# Applications EP26162901.8 and EP26166054.2, owned by
+# Quantamix Solutions B.V.
+#
+# Use of this software is permitted under the graqle license.
+# Reimplementation of the patented methods outside this software
+# requires a separate patent license.
+#
+# Contact: support@quantamixsolutions.com
+# ------------------------------------------------------------------
+
+"""Governed Execution Trace Capture Middleware (R18 ADR-201).
+
+Async context manager that wraps MCP tool handler execution in
+KogniDevServer.handle_tool(). Creates a GovernedTrace before execution,
+collects governance decisions during execution, finalizes outcome/latency
+after execution, and persists to the trace store.
+
+Non-bypassable: every governed tool entrypoint flows through TraceCapture.
+Latency target: < 50ms overhead (AC-5).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from graqle.governance.trace_schema import (
+    ClearanceLevel,
+    Decision,
+    GateType,
+    GovernanceDecision,
+    GovernedTrace,
+    Outcome,
+    ToolCall,
+)
+
+if TYPE_CHECKING:
+    from graqle.governance.trace_store import TraceStore
+
+logger = logging.getLogger("graqle.governance.trace_capture")
+
+# Tools that are considered governed entrypoints (emit traces).
+# Non-governed tools (internal helpers, aliases) are excluded.
+GOVERNED_TOOLS: frozenset[str] = frozenset({
+    "graq_context", "graq_inspect", "graq_reason", "graq_reason_batch",
+    "graq_preflight", "graq_lessons", "graq_impact", "graq_safety_check",
+    "graq_learn", "graq_predict", "graq_reload", "graq_audit",
+    "graq_runtime", "graq_route", "graq_correct", "graq_lifecycle",
+    "graq_gate", "graq_gov_gate", "graq_drace",
+    "graq_edit", "graq_generate", "graq_review", "graq_debug",
+    "graq_scaffold", "graq_workflow", "graq_test", "graq_plan",
+    "graq_profile", "graq_auto",
+    "graq_read", "graq_write", "graq_grep", "graq_glob", "graq_bash",
+    "graq_git_status", "graq_git_diff", "graq_git_log",
+    "graq_git_commit", "graq_git_branch",
+    "graq_github_pr", "graq_github_diff",
+    "graq_vendor", "graq_web_search", "graq_gcc_status",
+    "graq_ingest", "graq_todo",
+    # Scorch plugin
+    "graq_scorch_audit", "graq_scorch_behavioral", "graq_scorch_report",
+    "graq_scorch_a11y", "graq_scorch_perf", "graq_scorch_seo",
+    "graq_scorch_mobile", "graq_scorch_i18n", "graq_scorch_security",
+    "graq_scorch_conversion", "graq_scorch_brand", "graq_scorch_auth_flow",
+    "graq_scorch_diff",
+    # Phantom plugin
+    "graq_phantom_browse", "graq_phantom_click", "graq_phantom_type",
+    "graq_phantom_screenshot", "graq_phantom_audit", "graq_phantom_flow",
+    "graq_phantom_discover", "graq_phantom_session",
+})
+
+
+def _extract_query(arguments: dict[str, Any]) -> str:
+    """Extract a query string from tool arguments.
+
+    Tries common argument names in priority order.
+    Falls back to a truncated JSON dump of the arguments.
+    """
+    for key in ("question", "query", "task", "action", "goal", "description", "command"):
+        val = arguments.get(key)
+        if val and isinstance(val, str):
+            return val[:4000]
+    # Fallback: serialize arguments
+    try:
+        return json.dumps(arguments, default=str)[:4000]
+    except Exception:
+        return "(unable to extract query)"
+
+
+def _extract_outcome_from_result(result_json: str) -> tuple[Outcome, float, float]:
+    """Parse handler result JSON to extract outcome, confidence, cost.
+
+    Returns (outcome, confidence, cost_usd).
+    """
+    try:
+        data = json.loads(result_json)
+    except (json.JSONDecodeError, TypeError):
+        return Outcome.SUCCESS, 0.0, 0.0
+
+    # Check for error indicators
+    if isinstance(data, dict):
+        if "error" in data:
+            return Outcome.FAILURE, 0.0, 0.0
+        confidence = 0.0
+        cost = 0.0
+        # Extract confidence from various field names
+        for conf_key in ("confidence", "activation_confidence", "answer_confidence"):
+            val = data.get(conf_key)
+            if isinstance(val, (int, float)) and 0.0 <= val <= 1.0:
+                confidence = float(val)
+                break
+        # Extract cost
+        cost_val = data.get("cost_usd")
+        if isinstance(cost_val, (int, float)):
+            cost = float(cost_val)
+        return Outcome.SUCCESS, confidence, cost
+
+    return Outcome.SUCCESS, 0.0, 0.0
+
+
+def is_governed(tool_name: str) -> bool:
+    """Check if a tool name is a governed entrypoint.
+
+    Kogni aliases (kogni_*) are mapped to their graq_* equivalents.
+    """
+    canonical = tool_name.replace("kogni_", "graq_", 1) if tool_name.startswith("kogni_") else tool_name
+    return canonical in GOVERNED_TOOLS
+
+
+class TraceCapture:
+    """Async context manager for governed execution trace capture.
+
+    Usage in handle_tool()::
+
+        if is_governed(name):
+            async with TraceCapture(name, arguments, trace_store) as tc:
+                # governance gates fire here, call tc.record_gate_decision()
+                result = await handler(arguments)
+                tc.set_result(result)
+            return tc.result
+        else:
+            result = await handler(arguments)
+            return result
+
+    Attributes:
+        trace: The GovernedTrace being built.
+        result: The handler result string (set via set_result).
+    """
+
+    def __init__(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        store: TraceStore | None = None,
+    ) -> None:
+        self._tool_name = tool_name
+        self._arguments = arguments
+        self._store = store
+        self._start_time: float = 0.0
+        self.trace: GovernedTrace | None = None
+        self.result: str = ""
+
+    async def __aenter__(self) -> TraceCapture:
+        self._start_time = time.monotonic()
+        query = _extract_query(self._arguments)
+        self.trace = GovernedTrace(
+            tool_name=self._tool_name,
+            query=query,
+            outcome=Outcome.SUCCESS,  # default, updated in __aexit__
+            confidence=0.0,
+            clearance_level=ClearanceLevel.INTERNAL,
+        )
+        return self
+
+    def record_gate_decision(
+        self,
+        gate_id: str,
+        gate_type: GateType,
+        decision: Decision,
+        reason: str = "",
+        auto_corrected: bool = False,
+    ) -> None:
+        """Record a governance gate decision during tool execution."""
+        if self.trace is None:
+            return
+        self.trace.governance_decisions.append(
+            GovernanceDecision(
+                gate_id=gate_id,
+                gate_type=gate_type,
+                decision=decision,
+                reason=reason[:200],
+                auto_corrected=auto_corrected,
+            )
+        )
+
+    def set_result(self, result: str) -> None:
+        """Store the handler result for post-processing in __aexit__."""
+        self.result = result
+
+    def set_context_nodes(self, nodes: list[str]) -> None:
+        """Record which KG nodes were activated for this call."""
+        if self.trace is not None:
+            self.trace.context_nodes = nodes
+
+    def add_tool_call(self, tool: str, args: dict[str, Any] | None = None, summary: str | None = None) -> None:
+        """Record a nested tool invocation."""
+        if self.trace is not None:
+            self.trace.tool_calls.append(
+                ToolCall(tool=tool, args=args or {}, result_summary=summary)
+            )
+
+    async def __aexit__(self, exc_type: type | None, exc_val: BaseException | None, exc_tb: Any) -> bool:
+        elapsed_ms = (time.monotonic() - self._start_time) * 1000
+
+        if self.trace is None:
+            return False
+
+        self.trace.latency_ms = elapsed_ms
+
+        if exc_val is not None:
+            # Exception during handler execution
+            self.trace.outcome = Outcome.FAILURE
+            self.trace.error = str(exc_val)[:1000]
+            self.trace.confidence = 0.0
+        elif self.result:
+            # Parse result for outcome/confidence/cost
+            outcome, confidence, cost = _extract_outcome_from_result(self.result)
+            self.trace.outcome = outcome
+            self.trace.confidence = confidence
+            self.trace.cost_usd = cost
+        # else: keep defaults (SUCCESS, 0.0, 0.0)
+
+        # Check if any governance decision was BLOCK
+        if any(gd.decision == Decision.BLOCK for gd in self.trace.governance_decisions):
+            self.trace.outcome = Outcome.BLOCKED
+
+        # Persist trace (non-blocking, best-effort)
+        if self._store is not None:
+            try:
+                await self._store.append(self.trace)
+            except Exception:
+                logger.warning("Failed to persist trace for %s", self._tool_name, exc_info=True)
+
+        return False  # Never suppress exceptions

--- a/graqle/governance/trace_capture.py
+++ b/graqle/governance/trace_capture.py
@@ -129,7 +129,11 @@ def is_governed(tool_name: str) -> bool:
 
     Kogni aliases (kogni_*) are mapped to their graq_* equivalents.
     """
-    canonical = tool_name.replace("kogni_", "graq_", 1) if tool_name.startswith("kogni_") else tool_name
+    canonical = (
+        tool_name.replace("kogni_", "graq_", 1)
+        if tool_name.startswith("kogni_")
+        else tool_name
+    )
     return canonical in GOVERNED_TOOLS
 
 
@@ -208,14 +212,18 @@ class TraceCapture:
         if self.trace is not None:
             self.trace.context_nodes = nodes
 
-    def add_tool_call(self, tool: str, args: dict[str, Any] | None = None, summary: str | None = None) -> None:
+    def add_tool_call(
+        self, tool: str, args: dict[str, Any] | None = None, summary: str | None = None
+    ) -> None:
         """Record a nested tool invocation."""
         if self.trace is not None:
             self.trace.tool_calls.append(
                 ToolCall(tool=tool, args=args or {}, result_summary=summary)
             )
 
-    async def __aexit__(self, exc_type: type | None, exc_val: BaseException | None, exc_tb: Any) -> bool:
+    async def __aexit__(
+        self, exc_type: type | None, exc_val: BaseException | None, exc_tb: Any
+    ) -> bool:
         elapsed_ms = (time.monotonic() - self._start_time) * 1000
 
         if self.trace is None:

--- a/graqle/governance/trace_schema.py
+++ b/graqle/governance/trace_schema.py
@@ -1,0 +1,211 @@
+# ------------------------------------------------------------------
+# PATENT NOTICE -- Quantamix Solutions B.V.
+#
+# This module implements methods covered by European Patent
+# Applications EP26162901.8 and EP26166054.2, owned by
+# Quantamix Solutions B.V.
+#
+# Use of this software is permitted under the graqle license.
+# Reimplementation of the patented methods outside this software
+# requires a separate patent license.
+#
+# Contact: support@quantamixsolutions.com
+# ------------------------------------------------------------------
+
+"""Governed Execution Trace Schema (R18 ADR-201).
+
+Defines the Pydantic trace model for capturing governed execution events,
+tool calls, and governance decisions. Every MCP tool call produces a
+GovernedTrace record that is validated, persisted, and ingested into the KG.
+
+Public serialization (to_public_dict) excludes governance_decisions.
+Internal serialization (to_internal_dict) preserves the full trace.
+
+TS-2 Gate: GovernanceDecision structure is internal IP.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class GateType(str, Enum):
+    """Types of governance gates that can produce decisions."""
+
+    CLEARANCE = "CLEARANCE"
+    IP_TRADE = "IP_TRADE"
+    GIT_GOVERNANCE = "GIT_GOVERNANCE"
+    BUDGET = "BUDGET"
+
+
+class Decision(str, Enum):
+    """Outcome of a governance gate evaluation."""
+
+    PASS = "PASS"
+    BLOCK = "BLOCK"
+    WARN = "WARN"
+
+
+class ClearanceLevel(str, Enum):
+    """Classification level for trace records.
+
+    Aligned with core/types.ClearanceLevel (int, Enum).
+    R18 spec uses 'SECRET' for the highest level; implementation uses
+    'RESTRICTED' to match the existing core/types convention.
+    Mapping: spec SECRET = implementation RESTRICTED.
+    """
+
+    PUBLIC = "PUBLIC"
+    INTERNAL = "INTERNAL"
+    CONFIDENTIAL = "CONFIDENTIAL"
+    RESTRICTED = "RESTRICTED"
+
+
+class Outcome(str, Enum):
+    """Overall outcome of a governed tool execution."""
+
+    SUCCESS = "SUCCESS"
+    PARTIAL = "PARTIAL"
+    FAILURE = "FAILURE"
+    BLOCKED = "BLOCKED"
+
+
+# ---------------------------------------------------------------------------
+# Nested Models
+# ---------------------------------------------------------------------------
+
+
+class ToolCall(BaseModel):
+    """Record of a nested tool invocation within a governed execution."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    tool: str
+    args: dict[str, Any] = Field(default_factory=dict)
+    result_summary: str | None = None
+
+
+class GovernanceDecision(BaseModel):
+    """A single governance gate decision. TS-2 gated internal IP."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    gate_id: str
+    gate_type: GateType
+    decision: Decision
+    reason: str = Field(max_length=200)
+    auto_corrected: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Main Trace Model
+# ---------------------------------------------------------------------------
+
+_QUERY_MAX_LENGTH = 4000
+_NON_PRINTABLE_RE = re.compile(r"[^\x20-\x7E\t\n]")
+
+
+class GovernedTrace(BaseModel):
+    """A single governed execution trace record.
+
+    Every MCP tool call produces one GovernedTrace. The trace is validated
+    at creation time, persisted to the append-only trace store, and
+    asynchronously ingested into the knowledge graph.
+
+    Invariants:
+        - id is UUID v4 (auto-generated)
+        - timestamp is always UTC-aware
+        - query is sanitized and non-empty
+        - confidence is finite and in [0.0, 1.0]
+        - override_reason is required iff human_override is True
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: UUID = Field(default_factory=uuid4)
+    timestamp: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+    )
+    tool_name: str
+    query: str
+    context_nodes: list[str] = Field(default_factory=list)
+    tool_calls: list[ToolCall] = Field(default_factory=list)
+    governance_decisions: list[GovernanceDecision] = Field(
+        default_factory=list,
+        repr=False,
+        json_schema_extra={"internal": True},
+    )
+    clearance_level: ClearanceLevel = ClearanceLevel.INTERNAL
+    outcome: Outcome
+    confidence: float = Field(ge=0.0, le=1.0)
+    cost_usd: float = Field(ge=0.0, default=0.0)
+    latency_ms: float = Field(ge=0.0, default=0.0)
+    human_override: bool = False
+    override_reason: str | None = None
+    error: str | None = None
+
+    # -- Validators --------------------------------------------------------
+
+    @field_validator("query")
+    @classmethod
+    def sanitize_query(cls, value: str) -> str:
+        """Strip whitespace, remove non-printable chars, truncate, reject empty."""
+        sanitized = _NON_PRINTABLE_RE.sub("", value).strip()
+        sanitized = sanitized[:_QUERY_MAX_LENGTH]
+        if not sanitized:
+            raise ValueError("query must not be empty after sanitization")
+        return sanitized
+
+    @field_validator("timestamp")
+    @classmethod
+    def normalize_timestamp(cls, value: datetime) -> datetime:
+        """Ensure timestamp is UTC-aware. Naive datetimes are assumed UTC."""
+        if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
+    @field_validator("confidence")
+    @classmethod
+    def validate_confidence_finite(cls, value: float) -> float:
+        """Reject NaN and Infinity values."""
+        if math.isnan(value) or math.isinf(value):
+            raise ValueError("confidence must be a finite number")
+        return value
+
+    @model_validator(mode="after")
+    def validate_override(self) -> GovernedTrace:
+        """Enforce override_reason consistency with human_override flag."""
+        if self.human_override:
+            if self.override_reason is None or not self.override_reason.strip():
+                raise ValueError(
+                    "override_reason is required when human_override is True"
+                )
+            self.override_reason = self.override_reason.strip()
+        else:
+            self.override_reason = None
+        return self
+
+    # -- Serialization -----------------------------------------------------
+
+    def to_public_dict(self) -> dict[str, Any]:
+        """Serialize excluding TS-2 gated governance_decisions."""
+        return self.model_dump(
+            mode="json",
+            exclude={"governance_decisions"},
+        )
+
+    def to_internal_dict(self) -> dict[str, Any]:
+        """Full serialization including all governance fields."""
+        return self.model_dump(mode="json")

--- a/graqle/governance/trace_store.py
+++ b/graqle/governance/trace_store.py
@@ -1,0 +1,192 @@
+# ------------------------------------------------------------------
+# PATENT NOTICE -- Quantamix Solutions B.V.
+#
+# This module implements methods covered by European Patent
+# Applications EP26162901.8 and EP26166054.2, owned by
+# Quantamix Solutions B.V.
+#
+# Use of this software is permitted under the graqle license.
+# Reimplementation of the patented methods outside this software
+# requires a separate patent license.
+#
+# Contact: support@quantamixsolutions.com
+# ------------------------------------------------------------------
+
+"""Append-Only Governed Trace Store (R18 ADR-201).
+
+Persists GovernedTrace records to JSONL (JSON Lines) files with
+append-only semantics. Historical traces are never mutated.
+
+Trace corpus growth is monotonic: T(n+1) = T(n) U {t_n}
+Retrieval quality is non-decreasing: R(T(n+1)) >= R(T(n))
+
+The store writes to .graqle/traces/{YYYY-MM-DD}.jsonl with daily rotation.
+KG ingestion is triggered asynchronously after each append.
+
+TS-2 Gate: Trace files contain governance_decisions (internal IP).
+Store files must not be committed to public repositories.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from graqle.governance.trace_schema import GovernedTrace
+
+logger = logging.getLogger("graqle.governance.trace_store")
+
+# Default trace directory relative to project root
+_DEFAULT_TRACE_DIR = ".graqle/traces"
+
+
+class TraceStore:
+    """Append-only trace persistence with daily file rotation.
+
+    Each day's traces go into a separate JSONL file:
+        .graqle/traces/2026-04-09.jsonl
+
+    Traces are serialized using to_internal_dict() (includes governance_decisions).
+    Files are opened in append mode -- never truncated or overwritten.
+
+    Parameters
+    ----------
+    trace_dir:
+        Directory for JSONL trace files. Created if missing.
+    on_trace:
+        Optional callback invoked after each successful append.
+        Signature: (trace: GovernedTrace) -> None.
+        Use for KG ingestion hooks.
+    """
+
+    def __init__(
+        self,
+        trace_dir: str | Path | None = None,
+        on_trace: Callable[[GovernedTrace], None] | None = None,
+    ) -> None:
+        if trace_dir is None:
+            trace_dir = _DEFAULT_TRACE_DIR
+        self._trace_dir = Path(trace_dir)
+        self._on_trace = on_trace
+        self._count = 0
+        # Ensure directory exists
+        self._trace_dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def trace_dir(self) -> Path:
+        """Path to the trace storage directory."""
+        return self._trace_dir
+
+    @property
+    def count(self) -> int:
+        """Number of traces appended in this session."""
+        return self._count
+
+    def _current_file(self) -> Path:
+        """Get the JSONL file path for today (UTC)."""
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        return self._trace_dir / f"{today}.jsonl"
+
+    async def append(self, trace: GovernedTrace) -> None:
+        """Append a trace record to the daily JSONL file.
+
+        This is the primary write path. It:
+        1. Serializes the trace using to_internal_dict()
+        2. Appends one JSON line to the daily file
+        3. Increments the session counter
+        4. Invokes the on_trace callback (if set)
+
+        The write is performed in a thread executor to avoid
+        blocking the async event loop.
+        """
+        line = json.dumps(trace.to_internal_dict(), default=str) + "\n"
+        file_path = self._current_file()
+
+        # Write in executor to keep async non-blocking
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, self._sync_append, file_path, line)
+
+        self._count += 1
+        logger.debug("Trace appended: %s (total: %d)", trace.tool_name, self._count)
+
+        # Fire callback (best-effort, non-blocking)
+        if self._on_trace is not None:
+            try:
+                self._on_trace(trace)
+            except Exception:
+                logger.warning("on_trace callback failed", exc_info=True)
+
+    @staticmethod
+    def _sync_append(file_path: Path, line: str) -> None:
+        """Synchronous append with fsync for durability."""
+        fd = os.open(str(file_path), os.O_WRONLY | os.O_APPEND | os.O_CREAT)
+        try:
+            os.write(fd, line.encode("utf-8"))
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+
+    def read_traces(
+        self,
+        date: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Read traces from a daily JSONL file.
+
+        Parameters
+        ----------
+        date:
+            ISO date string (YYYY-MM-DD). Defaults to today (UTC).
+        limit:
+            Maximum number of traces to return (most recent first).
+
+        Returns
+        -------
+        List of trace dicts (internal format including governance_decisions).
+        """
+        if date is None:
+            date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+        file_path = self._trace_dir / f"{date}.jsonl"
+        if not file_path.exists():
+            return []
+
+        traces: list[dict[str, Any]] = []
+        with open(file_path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    traces.append(json.loads(line))
+                except json.JSONDecodeError:
+                    logger.warning("Corrupt trace line in %s", file_path)
+                    continue
+
+        # Return most recent first, limited
+        return traces[-limit:][::-1]
+
+    def corpus_size(self) -> int:
+        """Count total traces across all daily files.
+
+        This scans all .jsonl files in the trace directory.
+        Used for AC-3 verification (monotonic growth).
+        """
+        total = 0
+        for jsonl_file in self._trace_dir.glob("*.jsonl"):
+            with open(jsonl_file, "r", encoding="utf-8") as f:
+                total += sum(1 for line in f if line.strip())
+        return total
+
+    def list_dates(self) -> list[str]:
+        """List all dates that have trace files, sorted ascending."""
+        dates = []
+        for jsonl_file in sorted(self._trace_dir.glob("*.jsonl")):
+            stem = jsonl_file.stem  # "2026-04-09"
+            dates.append(stem)
+        return dates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,8 @@ dev = [
     "httpx>=0.25",
     "boto3>=1.28",
     "requests>=2.28",
+    "rdflib>=7.0.0",
+    "pyshacl>=0.25.0",
 ]
 
 [project.scripts]

--- a/tests/test_generation/test_phase10_layer1.py
+++ b/tests/test_generation/test_phase10_layer1.py
@@ -17,6 +17,15 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _disable_shacl_gate():
+    """Disable SHACL gate for all tests in this module."""
+    import graqle.plugins.mcp_dev_server
+    original = graqle.plugins.mcp_dev_server._SHACL_GATE_ENABLED
+    graqle.plugins.mcp_dev_server._SHACL_GATE_ENABLED = False
+    yield
+    graqle.plugins.mcp_dev_server._SHACL_GATE_ENABLED = original
+
 # ──────────────────────────────────────────────────────────────────────────────
 # 1. GovernanceMiddleware — cumulative radius anti-gaming
 # ──────────────────────────────────────────────────────────────────────────────

--- a/tests/test_generation/test_phase4_tools.py
+++ b/tests/test_generation/test_phase4_tools.py
@@ -70,6 +70,15 @@ def _build_mock_graph() -> MagicMock:
     return graph
 
 
+@pytest.fixture(autouse=True)
+def _disable_shacl_gate():
+    import graqle.plugins.mcp_dev_server as _mds
+    old = _mds._SHACL_GATE_ENABLED
+    _mds._SHACL_GATE_ENABLED = False
+    yield
+    _mds._SHACL_GATE_ENABLED = old
+
+
 @pytest.fixture
 def server(tmp_path):
     srv = KogniDevServer.__new__(KogniDevServer)

--- a/tests/test_governance/test_calibration.py
+++ b/tests/test_governance/test_calibration.py
@@ -1,0 +1,380 @@
+"""Tests for R20 Audit-Grade Governance Calibration (ADR-203).
+
+Covers: calibration.py, calibration_store.py, reliability_diagram.py.
+Acceptance criteria: AC-1 through AC-7.
+"""
+
+import json
+import math
+import random
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from graqle.governance.calibration import (
+    MIN_SAMPLES,
+    TARGET_ECE,
+    DEFAULT_N_BINS,
+    BinStats,
+    CalibrationModel,
+    CalibrationPrediction,
+    Calibrator,
+    bootstrap_bin_ci,
+    compute_ece,
+    fit_isotonic,
+    fit_platt,
+    predict_isotonic,
+    predict_platt,
+    _percentile,
+    _sigmoid,
+)
+from graqle.governance.calibration_store import CalibrationStore
+from graqle.governance.reliability_diagram import generate_svg
+
+
+def _make_pairs(n: int = 1200, seed: int = 42) -> list[tuple[float, int]]:
+    """Simulate (score, outcome) pairs with realistic distribution."""
+    random.seed(seed)
+    pairs = []
+    for _ in range(n):
+        score = random.uniform(0, 100)
+        # Higher score -> lower incident rate
+        p_incident = max(0.0, min(1.0, (100 - score) / 100.0))
+        outcome = 1 if random.random() < p_incident else 0
+        pairs.append((score, outcome))
+    return pairs
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Helper function tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestHelpers:
+    def test_sigmoid_zero(self):
+        assert abs(_sigmoid(0) - 0.5) < 0.001
+
+    def test_sigmoid_stable(self):
+        assert _sigmoid(1000) == 1.0
+        assert _sigmoid(-1000) == 0.0
+
+    def test_percentile_basic(self):
+        vals = [1.0, 2.0, 3.0, 4.0, 5.0]
+        assert _percentile(vals, 50) == 3.0
+        assert _percentile(vals, 0) == 1.0
+        assert _percentile(vals, 100) == 5.0
+
+    def test_percentile_empty(self):
+        assert _percentile([], 50) == 0.0
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Platt scaling tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestPlatt:
+    def test_fit_basic(self):
+        pairs = _make_pairs(500)
+        params = fit_platt(pairs)
+        assert "a" in params
+        assert "b" in params
+        assert "final_loss" in params
+
+    def test_predict_in_range(self):
+        params = {"a": 1.0, "b": 0.0}
+        for score in [0, 25, 50, 75, 100]:
+            r = predict_platt(score, params)
+            assert 0.0 <= r <= 1.0
+
+    def test_fit_converges(self):
+        # Well-separated data should produce meaningful params
+        pairs = []
+        for _ in range(500):
+            pairs.append((20.0, 1))  # low score -> incident
+            pairs.append((80.0, 0))  # high score -> no incident
+        params = fit_platt(pairs)
+        # Low score should have high risk, high score low risk
+        r_low = predict_platt(20, params)
+        r_high = predict_platt(80, params)
+        assert r_low > r_high
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Isotonic regression tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestIsotonic:
+    def test_fit_basic(self):
+        pairs = _make_pairs(500)
+        params = fit_isotonic(pairs)
+        assert "knots" in params
+        assert len(params["knots"]) > 0
+
+    def test_monotonic_fit(self):
+        """PAV should produce monotonic non-decreasing fit."""
+        pairs = _make_pairs(1200)
+        params = fit_isotonic(pairs)
+        means = [v for _, v in params["knots"]]
+        for i in range(1, len(means)):
+            assert means[i] >= means[i - 1] - 1e-9  # monotonic
+
+    def test_predict_in_range(self):
+        params = fit_isotonic(_make_pairs(500))
+        for score in [0, 25, 50, 75, 100]:
+            r = predict_isotonic(score, params)
+            assert 0.0 <= r <= 1.0
+
+    def test_empty_pairs(self):
+        params = fit_isotonic([])
+        assert params["knots"] == []
+
+    def test_inverse_relationship(self):
+        """Higher score should predict lower risk (inverse)."""
+        pairs = _make_pairs(1500)
+        params = fit_isotonic(pairs)
+        r_low = predict_isotonic(10, params)
+        r_high = predict_isotonic(90, params)
+        # After sorting by score ascending, low scores get mapped to higher y values
+        # (since low score = high incident rate in our test data)
+        # The PAV fit is monotonic in the score order, so we expect r_low > r_high.
+        assert r_low > r_high or abs(r_low - r_high) < 0.1
+
+
+# ═══════════════════════════════════════════════════════════════════
+# ECE tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestECE:
+    def test_perfect_calibration(self):
+        """Perfectly calibrated predictions should have ECE ~ 0."""
+        predictions = [0.1] * 100 + [0.9] * 100
+        # 10 of first 100 are incidents, 90 of last 100 are incidents
+        outcomes = [1] * 10 + [0] * 90 + [1] * 90 + [0] * 10
+        ece, bins = compute_ece(predictions, outcomes)
+        assert ece < 0.05  # very well calibrated
+
+    def test_worst_calibration(self):
+        """Predictions opposite to reality should have high ECE."""
+        # Predict 0.1 but reality is 90% incidents, predict 0.9 but reality is 10%
+        predictions = [0.1] * 100 + [0.9] * 100
+        outcomes = [1] * 90 + [0] * 10 + [1] * 10 + [0] * 90
+        ece, bins = compute_ece(predictions, outcomes)
+        assert ece > 0.5
+
+    def test_bin_count(self):
+        predictions = [i / 100 for i in range(100)]
+        outcomes = [i // 50 for i in range(100)]
+        ece, bins = compute_ece(predictions, outcomes, n_bins=10)
+        assert len(bins) == 10
+
+    def test_empty_input(self):
+        ece, bins = compute_ece([], [])
+        assert ece == 0.0
+        assert bins == []
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Calibrator (main API) tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestCalibrator:
+    """AC-1: Calibration not valid until N >= 1000."""
+
+    def test_uncalibrated_below_min(self):
+        """AC-1: Returns uncalibrated for N < 1000."""
+        pairs = _make_pairs(100)
+        cal = Calibrator()
+        model = cal.fit(pairs, method="isotonic", bootstrap_b=0)
+        assert model.status == "uncalibrated"
+        assert model.n_samples == 100
+
+    def test_calibrated_at_min(self):
+        """AC-1: Returns calibrated for N >= 1000."""
+        pairs = _make_pairs(1000)
+        cal = Calibrator()
+        model = cal.fit(pairs, method="isotonic", bootstrap_b=0)
+        assert model.status == "calibrated"
+        assert model.n_samples == 1000
+
+    def test_isotonic_produces_ece(self):
+        """AC-2: ECE computed on fitted model."""
+        pairs = _make_pairs(1200)
+        cal = Calibrator()
+        model = cal.fit(pairs, method="isotonic", bootstrap_b=0)
+        assert model.ece is not None
+        assert 0.0 <= model.ece <= 1.0
+
+    def test_isotonic_ece_below_target(self):
+        """AC-2: Well-formed data should pass ECE target."""
+        pairs = _make_pairs(2000)
+        cal = Calibrator()
+        model = cal.fit(pairs, method="isotonic", bootstrap_b=0)
+        # Isotonic on realistic data should easily pass target
+        assert model.ece < 0.1  # generous bound
+
+    def test_confidence_intervals_produced(self):
+        """AC-3: Each bin has CI when bootstrap > 0."""
+        pairs = _make_pairs(1200)
+        cal = Calibrator()
+        model = cal.fit(pairs, method="isotonic", bootstrap_b=10, seed=42)
+        ci_bins = [b for b in model.bins if b.count > 0 and b.ci_low is not None]
+        assert len(ci_bins) > 0
+
+    def test_method_explicit(self):
+        """AC-4: Method name logged in metadata."""
+        pairs = _make_pairs(1200)
+        cal = Calibrator()
+        m1 = cal.fit(pairs, method="platt", bootstrap_b=0)
+        m2 = cal.fit(pairs, method="isotonic", bootstrap_b=0)
+        assert m1.method == "platt"
+        assert m2.method == "isotonic"
+
+    def test_versioned_model(self):
+        """AC-5: Each fit produces a unique version."""
+        pairs = _make_pairs(1100)
+        cal = Calibrator()
+        m1 = cal.fit(pairs, bootstrap_b=0)
+        m2 = cal.fit(pairs, bootstrap_b=0)
+        assert m1.version != m2.version
+
+    def test_predict_api(self):
+        """AC-7: graq_calibrate(score) -> {risk, ci_lower, ci_upper} API."""
+        pairs = _make_pairs(1200)
+        cal = Calibrator()
+        cal.fit(pairs, method="isotonic", bootstrap_b=10)
+        pred = cal.predict(94.0)
+        assert isinstance(pred, CalibrationPrediction)
+        assert pred.status == "calibrated"
+        assert 0.0 <= pred.risk <= 1.0
+
+    def test_predict_uncalibrated(self):
+        cal = Calibrator()
+        pred = cal.predict(94.0)
+        assert pred.status == "uncalibrated"
+        assert pred.risk == 0.0
+
+    def test_load_model(self):
+        pairs = _make_pairs(1100)
+        cal1 = Calibrator()
+        model = cal1.fit(pairs, method="isotonic", bootstrap_b=0)
+
+        cal2 = Calibrator()
+        cal2.load_model(model)
+        pred = cal2.predict(50.0)
+        assert pred.status == "calibrated"
+
+    def test_platt_method(self):
+        pairs = _make_pairs(1200)
+        cal = Calibrator()
+        model = cal.fit(pairs, method="platt", bootstrap_b=0)
+        assert model.status == "calibrated"
+        assert "a" in model.params
+        assert "b" in model.params
+
+
+# ═══════════════════════════════════════════════════════════════════
+# CalibrationStore tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestCalibrationStore:
+    """AC-5: Calibration artifacts versioned."""
+
+    def test_save_and_load(self):
+        pairs = _make_pairs(1100)
+        cal = Calibrator()
+        model = cal.fit(pairs, bootstrap_b=0)
+
+        d = tempfile.mkdtemp()
+        store = CalibrationStore(store_dir=d)
+        path = store.save(model)
+        assert path.exists()
+
+        loaded = store.load(model.version)
+        assert loaded.version == model.version
+        assert loaded.ece == model.ece
+        assert loaded.method == model.method
+
+    def test_current_pointer(self):
+        pairs = _make_pairs(1100)
+        cal = Calibrator()
+        model = cal.fit(pairs, bootstrap_b=0)
+
+        d = tempfile.mkdtemp()
+        store = CalibrationStore(store_dir=d)
+        store.save(model, make_active=True)
+
+        current = store.load_current()
+        assert current is not None
+        assert current.version == model.version
+
+    def test_list_versions(self):
+        d = tempfile.mkdtemp()
+        store = CalibrationStore(store_dir=d)
+        cal = Calibrator()
+        pairs = _make_pairs(1100)
+
+        for _ in range(3):
+            model = cal.fit(pairs, bootstrap_b=0)
+            store.save(model)
+
+        versions = store.list_versions()
+        assert len(versions) == 3
+
+    def test_load_missing_version(self):
+        d = tempfile.mkdtemp()
+        store = CalibrationStore(store_dir=d)
+        with pytest.raises(FileNotFoundError):
+            store.load("nonexistent")
+
+    def test_no_current_model(self):
+        d = tempfile.mkdtemp()
+        store = CalibrationStore(store_dir=d)
+        assert store.load_current() is None
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Reliability diagram tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestReliabilityDiagram:
+    """AC-6: Reliability diagram exportable."""
+
+    def test_svg_calibrated(self):
+        pairs = _make_pairs(1200)
+        cal = Calibrator()
+        model = cal.fit(pairs, method="isotonic", bootstrap_b=0)
+        svg = generate_svg(model)
+        assert svg.startswith("<svg")
+        assert svg.endswith("</svg>")
+        assert "Reliability Diagram" in svg
+        assert "calibrated" in svg.lower()
+
+    def test_svg_uncalibrated(self):
+        pairs = _make_pairs(100)
+        cal = Calibrator()
+        model = cal.fit(pairs, bootstrap_b=0)
+        svg = generate_svg(model)
+        assert svg.startswith("<svg")
+        assert "uncalibrated" in svg.lower()
+
+    def test_svg_contains_ece(self):
+        pairs = _make_pairs(1200)
+        cal = Calibrator()
+        model = cal.fit(pairs, method="isotonic", bootstrap_b=0)
+        svg = generate_svg(model)
+        assert "ECE" in svg
+
+    def test_svg_with_ci_whiskers(self):
+        pairs = _make_pairs(1200)
+        cal = Calibrator()
+        model = cal.fit(pairs, method="isotonic", bootstrap_b=10, seed=42)
+        svg = generate_svg(model)
+        # Whiskers use stroke-width=2
+        assert "stroke-width=\"2\"" in svg

--- a/tests/test_governance/test_failure_predictor.py
+++ b/tests/test_governance/test_failure_predictor.py
@@ -1,0 +1,374 @@
+"""Tests for R19 Causal Governance Failure Chain Predictor (ADR-202).
+
+Covers: failure_features.py, failure_predictor.py, near_miss_store.py.
+Acceptance criteria: AC-1 through AC-7.
+"""
+
+import asyncio
+import json
+import tempfile
+from datetime import datetime, timezone
+
+import pytest
+
+from graqle.governance.failure_features import (
+    GovernanceFailureFeatures,
+    extract_features,
+    _safe_entropy,
+    _percentile,
+)
+from graqle.governance.failure_predictor import (
+    CausalChainDAG,
+    CausalChainPrediction,
+    CausalEdge,
+    CausalNode,
+    FailurePredictionResult,
+    predict_governance_failures,
+    _sigmoid,
+    _build_candidate_chains,
+)
+from graqle.governance.near_miss_store import NearMissRecord, NearMissStore
+
+
+# ═══════════════════════════════════════════════════════════════════
+# failure_features.py tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestFeatureExtraction:
+    """Feature vector extraction from topology and traces."""
+
+    def test_empty_inputs(self):
+        features = extract_features()
+        assert features.feature_version == "r19.1"
+        assert features.gate.total_decisions == 0
+        assert features.trace_window.sample_count == 0
+
+    def test_topology_only(self):
+        edges = [
+            {"source": "A", "target": "B", "relation": "COMPLIES_WITH"},
+            {"source": "B", "target": "C", "relation": "GOVERNS"},
+            {"source": "A", "target": "C", "relation": "AMENDS"},
+        ]
+        features = extract_features(topology_edges=edges)
+        assert features.topology.node_count == 3
+        assert features.topology.edge_count == 3
+        assert features.decision_patterns.complies_with_count == 1
+        assert features.decision_patterns.amends_count == 1
+        assert features.decision_patterns.governs_count == 1
+        assert features.decision_patterns.decision_entropy > 0
+
+    def test_traces_gate_metrics(self):
+        traces = [
+            {"governance_decisions": [{"decision": "PASS"}], "outcome": "SUCCESS",
+             "clearance_level": "INTERNAL", "latency_ms": 100, "tool_name": "graq_reason",
+             "human_override": False, "timestamp": "2026-04-10T10:00:00+00:00"},
+            {"governance_decisions": [{"decision": "BLOCK"}], "outcome": "BLOCKED",
+             "clearance_level": "CONFIDENTIAL", "latency_ms": 200, "tool_name": "graq_write",
+             "human_override": False, "timestamp": "2026-04-10T10:01:00+00:00"},
+            {"governance_decisions": [{"decision": "WARN"}], "outcome": "SUCCESS",
+             "clearance_level": "PUBLIC", "latency_ms": 50, "tool_name": "graq_context",
+             "human_override": True, "timestamp": "2026-04-10T10:02:00+00:00"},
+        ]
+        features = extract_features(traces=traces)
+        assert features.gate.total_decisions == 3
+        assert abs(features.gate.pass_ratio - 1/3) < 0.01
+        assert abs(features.gate.block_ratio - 1/3) < 0.01
+        assert abs(features.gate.warn_ratio - 1/3) < 0.01
+        assert abs(features.gate.override_rate - 1/3) < 0.01
+
+    def test_traces_tool_metrics(self):
+        traces = [
+            {"governance_decisions": [], "outcome": "SUCCESS", "clearance_level": "INTERNAL",
+             "latency_ms": 100, "tool_name": "graq_reason", "human_override": False,
+             "timestamp": "2026-04-10T10:00:00+00:00"},
+            {"governance_decisions": [], "outcome": "FAILURE", "clearance_level": "INTERNAL",
+             "latency_ms": 5000, "tool_name": "graq_generate", "human_override": False,
+             "timestamp": "2026-04-10T10:01:00+00:00"},
+        ]
+        features = extract_features(traces=traces)
+        assert features.tool.total_calls == 2
+        assert features.tool.failure_rate == 0.5
+        assert features.tool.distinct_tools == 2
+
+    def test_traces_latency_metrics(self):
+        # Need enough data points for stdev-based anomaly detection
+        traces = []
+        for i in range(10):
+            traces.append({"governance_decisions": [], "outcome": "SUCCESS",
+                          "clearance_level": "INTERNAL", "latency_ms": 100 + i,
+                          "tool_name": "t", "human_override": False,
+                          "timestamp": f"2026-04-10T10:{i:02d}:00+00:00"})
+        # Add a clear outlier
+        traces.append({"governance_decisions": [], "outcome": "SUCCESS",
+                       "clearance_level": "INTERNAL", "latency_ms": 50000,
+                       "tool_name": "t", "human_override": False,
+                       "timestamp": "2026-04-10T10:10:00+00:00"})
+        features = extract_features(traces=traces)
+        assert features.latency.max_ms == 50000
+        assert features.latency.p50_ms > 0
+        assert features.latency.anomaly_count >= 1
+
+    def test_clearance_metrics(self):
+        traces = [
+            {"governance_decisions": [], "outcome": "SUCCESS", "clearance_level": "PUBLIC",
+             "latency_ms": 100, "tool_name": "t", "human_override": False,
+             "timestamp": "2026-04-10T10:00:00+00:00"},
+            {"governance_decisions": [], "outcome": "SUCCESS", "clearance_level": "RESTRICTED",
+             "latency_ms": 100, "tool_name": "t", "human_override": False,
+             "timestamp": "2026-04-10T10:01:00+00:00"},
+        ]
+        features = extract_features(traces=traces)
+        assert features.clearance.distinct_levels_used == 2
+        assert features.clearance.escalation_gap_max == 3  # PUBLIC(0) to RESTRICTED(3)
+
+
+class TestFeatureVector:
+    """Feature vector serialization."""
+
+    def test_vector_size(self):
+        features = GovernanceFailureFeatures()
+        vec = features.to_vector()
+        assert len(vec) == 25  # VECTOR_SIZE defined in failure_features.py
+
+    def test_feature_names_match_vector(self):
+        names = GovernanceFailureFeatures.feature_names()
+        vec = GovernanceFailureFeatures().to_vector()
+        assert len(names) == len(vec)
+
+    def test_vector_all_numeric(self):
+        features = extract_features(
+            topology_edges=[{"source": "A", "target": "B", "relation": "GOVERNS"}],
+            traces=[{"governance_decisions": [{"decision": "PASS"}], "outcome": "SUCCESS",
+                     "clearance_level": "INTERNAL", "latency_ms": 100, "tool_name": "t",
+                     "human_override": False, "timestamp": "2026-04-10T10:00:00+00:00"}],
+        )
+        vec = features.to_vector()
+        assert all(isinstance(v, float) for v in vec)
+
+
+class TestHelpers:
+    """Helper function tests."""
+
+    def test_safe_entropy_uniform(self):
+        # 3 equal counts: entropy = log2(3) ~ 1.585
+        e = _safe_entropy([10, 10, 10])
+        assert abs(e - 1.585) < 0.01
+
+    def test_safe_entropy_zero(self):
+        assert _safe_entropy([]) == 0.0
+        assert _safe_entropy([0, 0, 0]) == 0.0
+
+    def test_percentile_basic(self):
+        assert _percentile([1, 2, 3, 4, 5], 50) == 3
+        assert _percentile([], 50) == 0.0
+
+
+# ═══════════════════════════════════════════════════════════════════
+# failure_predictor.py tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestSigmoid:
+    """Sigmoid activation function."""
+
+    def test_zero_input(self):
+        assert abs(_sigmoid(0) - 0.5) < 0.001
+
+    def test_large_positive(self):
+        assert _sigmoid(10) > 0.99
+
+    def test_large_negative(self):
+        assert _sigmoid(-10) < 0.01
+
+    def test_numerically_stable(self):
+        # Should not overflow
+        assert _sigmoid(1000) == 1.0
+        assert _sigmoid(-1000) == 0.0
+
+
+class TestCausalChainDAG:
+    """Causal chain DAG model."""
+
+    def test_basic_creation(self):
+        chain = CausalChainDAG(
+            chain=["a", "b", "c"],
+            nodes=[
+                CausalNode(id="a", label="Node A", kind="gate"),
+                CausalNode(id="b", label="Node B", kind="tool"),
+                CausalNode(id="c", label="Node C", kind="gate"),
+            ],
+            edges=[
+                CausalEdge(source="a", target="b", relation="causes"),
+                CausalEdge(source="b", target="c", relation="triggers"),
+            ],
+            probability=0.85,
+            root_cause="a",
+            leaf_failure="c",
+        )
+        assert len(chain.nodes) == 3
+        assert len(chain.edges) == 2
+        assert chain.root_cause == "a"
+
+    def test_serialization(self):
+        chain = CausalChainDAG(chain=["x"], probability=0.5)
+        d = chain.model_dump(mode="json")
+        assert "chain" in d
+        assert "probability" in d
+        json.dumps(d, default=str)  # Should not raise
+
+
+class TestPredictGovernanceFailures:
+    """AC-1: Produces ranked failure-chain predictions."""
+
+    def _make_traces(self, n=20, block_ratio=0.3):
+        traces = []
+        for i in range(n):
+            decision = "BLOCK" if i < n * block_ratio else "PASS"
+            traces.append({
+                "governance_decisions": [{"decision": decision}],
+                "outcome": "BLOCKED" if decision == "BLOCK" else "SUCCESS",
+                "clearance_level": "INTERNAL",
+                "latency_ms": 100 + i * 10,
+                "tool_name": f"graq_tool_{i % 5}",
+                "human_override": i % 10 == 0,
+                "timestamp": f"2026-04-10T10:{i:02d}:00+00:00",
+            })
+        return traces
+
+    def test_produces_ranked_predictions(self):
+        """AC-1: Output contains ordered list of (chain, probability)."""
+        result = predict_governance_failures(traces=self._make_traces(50))
+        assert isinstance(result, FailurePredictionResult)
+        assert len(result.predictions) > 0
+        # Verify ranking
+        for i in range(1, len(result.predictions)):
+            assert result.predictions[i].probability <= result.predictions[i-1].probability
+            assert result.predictions[i].rank == i + 1
+
+    def test_causal_edges_present(self):
+        """AC-2: Each chain has source->target with causal label."""
+        result = predict_governance_failures(traces=self._make_traces(50))
+        for pred in result.predictions:
+            if len(pred.chain.nodes) > 1:
+                assert len(pred.chain.edges) > 0
+                for edge in pred.chain.edges:
+                    assert edge.source
+                    assert edge.target
+                    assert edge.relation
+
+    def test_backward_compatible(self):
+        """AC-7: Default mode works without causal_chain parameter."""
+        result = predict_governance_failures(traces=self._make_traces(20))
+        assert isinstance(result, FailurePredictionResult)
+
+    def test_empty_traces(self):
+        result = predict_governance_failures(traces=[])
+        assert result.trace_count == 0
+        assert result.confidence == 0.0
+
+    def test_topology_enhances_predictions(self):
+        edges = [
+            {"source": "CG-01", "target": "CG-02", "relation": "GOVERNS"},
+            {"source": "CG-02", "target": "CG-03", "relation": "COMPLIES_WITH"},
+        ]
+        result = predict_governance_failures(
+            topology_edges=edges,
+            traces=self._make_traces(30),
+        )
+        assert result.features_used is not None
+        assert result.features_used.topology.edge_count == 2
+
+    def test_high_block_rate_triggers_chain(self):
+        """High block rate should produce a failure chain prediction."""
+        traces = self._make_traces(30, block_ratio=0.5)
+        result = predict_governance_failures(traces=traces, threshold=0.1)
+        chain_ids = []
+        for p in result.predictions:
+            chain_ids.extend(p.chain.chain)
+        assert "high_block_rate" in chain_ids
+
+    def test_threshold_filters_predictions(self):
+        result_low = predict_governance_failures(
+            traces=self._make_traces(30), threshold=0.0)
+        result_high = predict_governance_failures(
+            traces=self._make_traces(30), threshold=0.99)
+        assert len(result_low.predictions) >= len(result_high.predictions)
+
+
+# ═══════════════════════════════════════════════════════════════════
+# near_miss_store.py tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestNearMissStore:
+    """Near-miss corpus management."""
+
+    def _make_record(self, chain="test_chain"):
+        return NearMissRecord(
+            chain_summary=chain,
+            predicted_probability=0.85,
+            prevented_by="gate_block",
+            root_cause="high_block_rate",
+        )
+
+    def test_record_creates_file(self):
+        """AC-6: Near-miss recorded."""
+        async def _test():
+            d = tempfile.mkdtemp()
+            store = NearMissStore(store_dir=d)
+            await store.record(self._make_record())
+            assert store.count == 1
+            records = store.read_near_misses()
+            assert len(records) == 1
+            assert records[0]["chain_summary"] == "test_chain"
+
+        asyncio.run(_test())
+
+    def test_corpus_growth_monotonic(self):
+        async def _test():
+            d = tempfile.mkdtemp()
+            store = NearMissStore(store_dir=d)
+            sizes = []
+            for i in range(5):
+                await store.record(self._make_record(f"chain_{i}"))
+                sizes.append(store.corpus_size())
+            for i in range(1, len(sizes)):
+                assert sizes[i] >= sizes[i-1]
+
+        asyncio.run(_test())
+
+    def test_record_fields(self):
+        async def _test():
+            d = tempfile.mkdtemp()
+            store = NearMissStore(store_dir=d)
+            await store.record(self._make_record())
+            records = store.read_near_misses()
+            r = records[0]
+            assert r["outcome"] == "prevented"
+            assert r["prevented_by"] == "gate_block"
+            assert r["predicted_probability"] == 0.85
+
+        asyncio.run(_test())
+
+    def test_empty_date(self):
+        d = tempfile.mkdtemp()
+        store = NearMissStore(store_dir=d)
+        assert store.read_near_misses(date="1999-01-01") == []
+
+    def test_valid_jsonl(self):
+        async def _test():
+            d = tempfile.mkdtemp()
+            store = NearMissStore(store_dir=d)
+            for i in range(3):
+                await store.record(self._make_record(f"chain_{i}"))
+            from pathlib import Path
+            files = list(Path(d).glob("*.jsonl"))
+            assert len(files) == 1
+            with open(files[0]) as f:
+                for line in f:
+                    data = json.loads(line)
+                    assert "id" in data
+                    assert "chain_summary" in data
+
+        asyncio.run(_test())

--- a/tests/test_governance/test_trace_capture.py
+++ b/tests/test_governance/test_trace_capture.py
@@ -1,0 +1,515 @@
+"""Tests for R18 Governed Execution Trace Capture (ADR-201).
+
+Covers: trace_schema.py, trace_capture.py, trace_store.py.
+Acceptance criteria: AC-1 through AC-7.
+"""
+
+import asyncio
+import json
+import math
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from graqle.governance.trace_schema import (
+    ClearanceLevel,
+    Decision,
+    GateType,
+    GovernanceDecision,
+    GovernedTrace,
+    Outcome,
+    ToolCall,
+)
+from graqle.governance.trace_capture import (
+    GOVERNED_TOOLS,
+    TraceCapture,
+    is_governed,
+    _extract_query,
+    _extract_outcome_from_result,
+)
+from graqle.governance.trace_store import TraceStore
+
+
+# ═══════════════════════════════════════════════════════════════════
+# trace_schema.py tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestGovernedTraceCreation:
+    """Basic GovernedTrace creation and defaults."""
+
+    def test_minimal_creation(self):
+        t = GovernedTrace(
+            tool_name="graq_reason",
+            query="test query",
+            outcome=Outcome.SUCCESS,
+            confidence=0.85,
+        )
+        assert isinstance(t.id, UUID)
+        assert t.tool_name == "graq_reason"
+        assert t.clearance_level == ClearanceLevel.INTERNAL
+        assert t.human_override is False
+        assert t.override_reason is None
+        assert t.error is None
+        assert t.context_nodes == []
+        assert t.tool_calls == []
+        assert t.governance_decisions == []
+
+    def test_timestamp_default_is_utc(self):
+        t = GovernedTrace(
+            tool_name="t", query="q", outcome=Outcome.SUCCESS, confidence=0.5,
+        )
+        assert t.timestamp.tzinfo is not None
+        assert t.timestamp.tzinfo == timezone.utc
+
+    def test_all_fields_populated(self):
+        t = GovernedTrace(
+            tool_name="graq_generate",
+            query="build a thing",
+            outcome=Outcome.PARTIAL,
+            confidence=0.72,
+            cost_usd=0.05,
+            latency_ms=1234.5,
+            clearance_level=ClearanceLevel.CONFIDENTIAL,
+            context_nodes=["node1", "node2"],
+            tool_calls=[ToolCall(tool="sub_tool", args={"x": 1}, result_summary="ok")],
+            governance_decisions=[
+                GovernanceDecision(
+                    gate_id="CG-01",
+                    gate_type=GateType.CLEARANCE,
+                    decision=Decision.PASS,
+                    reason="session active",
+                )
+            ],
+            error="partial failure",
+        )
+        assert t.outcome == Outcome.PARTIAL
+        assert len(t.context_nodes) == 2
+        assert len(t.tool_calls) == 1
+        assert len(t.governance_decisions) == 1
+
+
+class TestQuerySanitization:
+    """AC-2: Schema validation for query field."""
+
+    def test_strips_whitespace(self):
+        t = GovernedTrace(
+            tool_name="t", query="  hello  ", outcome=Outcome.SUCCESS, confidence=0.5,
+        )
+        assert t.query == "hello"
+
+    def test_removes_non_printable(self):
+        t = GovernedTrace(
+            tool_name="t", query="hello\x00world", outcome=Outcome.SUCCESS, confidence=0.5,
+        )
+        assert t.query == "helloworld"
+
+    def test_truncates_to_4000(self):
+        long_q = "a" * 5000
+        t = GovernedTrace(
+            tool_name="t", query=long_q, outcome=Outcome.SUCCESS, confidence=0.5,
+        )
+        assert len(t.query) == 4000
+
+    def test_rejects_empty_after_sanitization(self):
+        with pytest.raises(Exception):
+            GovernedTrace(
+                tool_name="t", query="   ", outcome=Outcome.SUCCESS, confidence=0.5,
+            )
+
+    def test_rejects_only_control_chars(self):
+        with pytest.raises(Exception):
+            GovernedTrace(
+                tool_name="t", query="\x00\x01\x02", outcome=Outcome.SUCCESS, confidence=0.5,
+            )
+
+
+class TestTimestampNormalization:
+    """AC-6: Governance labels attached at write time (timestamp integrity)."""
+
+    def test_naive_datetime_gets_utc(self):
+        t = GovernedTrace(
+            tool_name="t", query="q", outcome=Outcome.SUCCESS, confidence=0.5,
+            timestamp=datetime(2026, 4, 9, 12, 0, 0),
+        )
+        assert t.timestamp.tzinfo is not None
+
+    def test_aware_datetime_converted_to_utc(self):
+        from datetime import timedelta
+        est = timezone(timedelta(hours=-5))
+        t = GovernedTrace(
+            tool_name="t", query="q", outcome=Outcome.SUCCESS, confidence=0.5,
+            timestamp=datetime(2026, 4, 9, 12, 0, 0, tzinfo=est),
+        )
+        assert t.timestamp.tzinfo == timezone.utc
+        assert t.timestamp.hour == 17  # 12 EST = 17 UTC
+
+
+class TestConfidenceValidation:
+    """AC-2: Schema validation for confidence field."""
+
+    def test_valid_confidence(self):
+        t = GovernedTrace(
+            tool_name="t", query="q", outcome=Outcome.SUCCESS, confidence=0.5,
+        )
+        assert t.confidence == 0.5
+
+    def test_confidence_zero(self):
+        t = GovernedTrace(
+            tool_name="t", query="q", outcome=Outcome.SUCCESS, confidence=0.0,
+        )
+        assert t.confidence == 0.0
+
+    def test_confidence_one(self):
+        t = GovernedTrace(
+            tool_name="t", query="q", outcome=Outcome.SUCCESS, confidence=1.0,
+        )
+        assert t.confidence == 1.0
+
+    def test_rejects_above_one(self):
+        with pytest.raises(Exception):
+            GovernedTrace(
+                tool_name="t", query="q", outcome=Outcome.SUCCESS, confidence=1.5,
+            )
+
+    def test_rejects_negative(self):
+        with pytest.raises(Exception):
+            GovernedTrace(
+                tool_name="t", query="q", outcome=Outcome.SUCCESS, confidence=-0.1,
+            )
+
+    def test_rejects_nan(self):
+        with pytest.raises(Exception):
+            GovernedTrace(
+                tool_name="t", query="q", outcome=Outcome.SUCCESS, confidence=float("nan"),
+            )
+
+    def test_rejects_infinity(self):
+        with pytest.raises(Exception):
+            GovernedTrace(
+                tool_name="t", query="q", outcome=Outcome.SUCCESS, confidence=float("inf"),
+            )
+
+
+class TestOverrideValidation:
+    """AC-7: Human override explicitly recorded."""
+
+    def test_override_requires_reason(self):
+        with pytest.raises(Exception):
+            GovernedTrace(
+                tool_name="t", query="q", outcome=Outcome.SUCCESS,
+                confidence=0.5, human_override=True,
+            )
+
+    def test_override_rejects_empty_reason(self):
+        with pytest.raises(Exception):
+            GovernedTrace(
+                tool_name="t", query="q", outcome=Outcome.SUCCESS,
+                confidence=0.5, human_override=True, override_reason="   ",
+            )
+
+    def test_override_with_valid_reason(self):
+        t = GovernedTrace(
+            tool_name="t", query="q", outcome=Outcome.SUCCESS,
+            confidence=0.5, human_override=True, override_reason="user requested",
+        )
+        assert t.override_reason == "user requested"
+
+    def test_no_override_clears_reason(self):
+        t = GovernedTrace(
+            tool_name="t", query="q", outcome=Outcome.SUCCESS,
+            confidence=0.5, human_override=False, override_reason="stale",
+        )
+        assert t.override_reason is None
+
+
+class TestSerialization:
+    """TS-2 Gate: governance_decisions excluded from public serialization."""
+
+    def test_public_dict_excludes_governance_decisions(self):
+        t = GovernedTrace(
+            tool_name="t", query="q", outcome=Outcome.SUCCESS, confidence=0.5,
+            governance_decisions=[
+                GovernanceDecision(
+                    gate_id="g1", gate_type=GateType.CLEARANCE,
+                    decision=Decision.PASS, reason="ok",
+                )
+            ],
+        )
+        pub = t.to_public_dict()
+        assert "governance_decisions" not in pub
+        assert "tool_name" in pub
+
+    def test_internal_dict_includes_governance_decisions(self):
+        t = GovernedTrace(
+            tool_name="t", query="q", outcome=Outcome.SUCCESS, confidence=0.5,
+            governance_decisions=[
+                GovernanceDecision(
+                    gate_id="g1", gate_type=GateType.CLEARANCE,
+                    decision=Decision.PASS, reason="ok",
+                )
+            ],
+        )
+        internal = t.to_internal_dict()
+        assert "governance_decisions" in internal
+        assert len(internal["governance_decisions"]) == 1
+
+    def test_serialization_is_json_compatible(self):
+        t = GovernedTrace(
+            tool_name="t", query="q", outcome=Outcome.SUCCESS, confidence=0.5,
+        )
+        # Should not raise
+        json.dumps(t.to_public_dict(), default=str)
+        json.dumps(t.to_internal_dict(), default=str)
+
+
+# ═══════════════════════════════════════════════════════════════════
+# trace_capture.py tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestIsGoverned:
+    """Governed tool detection."""
+
+    def test_graq_reason_is_governed(self):
+        assert is_governed("graq_reason") is True
+
+    def test_kogni_reason_is_governed(self):
+        assert is_governed("kogni_reason") is True
+
+    def test_unknown_tool_not_governed(self):
+        assert is_governed("unknown_tool") is False
+
+    def test_all_governed_tools_recognized(self):
+        for tool in GOVERNED_TOOLS:
+            assert is_governed(tool) is True
+
+
+class TestExtractQuery:
+    """Query extraction from tool arguments."""
+
+    def test_extracts_question(self):
+        assert _extract_query({"question": "How?"}) == "How?"
+
+    def test_extracts_task(self):
+        assert _extract_query({"task": "Build it"}) == "Build it"
+
+    def test_fallback_to_json(self):
+        result = _extract_query({"x": 1, "y": 2})
+        assert "x" in result
+
+    def test_truncates_long_query(self):
+        result = _extract_query({"question": "a" * 5000})
+        assert len(result) == 4000
+
+
+class TestExtractOutcome:
+    """Outcome extraction from handler result JSON."""
+
+    def test_success_with_confidence(self):
+        outcome, conf, cost = _extract_outcome_from_result(
+            '{"answer": "yes", "confidence": 0.85, "cost_usd": 0.02}'
+        )
+        assert outcome == Outcome.SUCCESS
+        assert conf == 0.85
+        assert cost == 0.02
+
+    def test_error_result(self):
+        outcome, conf, cost = _extract_outcome_from_result(
+            '{"error": "something broke"}'
+        )
+        assert outcome == Outcome.FAILURE
+
+    def test_invalid_json(self):
+        outcome, conf, cost = _extract_outcome_from_result("not json")
+        assert outcome == Outcome.SUCCESS
+        assert conf == 0.0
+
+
+class TestTraceCaptureContextManager:
+    """Async context manager behavior."""
+
+    def test_basic_capture(self):
+        async def _test():
+            store = TraceStore(trace_dir=tempfile.mkdtemp())
+            async with TraceCapture("graq_reason", {"question": "test"}, store) as tc:
+                tc.set_result('{"answer": "x", "confidence": 0.9}')
+            assert store.count == 1
+            traces = store.read_traces()
+            assert len(traces) == 1
+            assert traces[0]["tool_name"] == "graq_reason"
+            assert traces[0]["confidence"] == 0.9
+
+        asyncio.run(_test())
+
+    def test_captures_latency(self):
+        async def _test():
+            store = TraceStore(trace_dir=tempfile.mkdtemp())
+            async with TraceCapture("graq_inspect", {"stats": True}, store) as tc:
+                tc.set_result('{"total_nodes": 100}')
+            traces = store.read_traces()
+            assert traces[0]["latency_ms"] >= 0
+
+        asyncio.run(_test())
+
+    def test_captures_exception(self):
+        async def _test():
+            store = TraceStore(trace_dir=tempfile.mkdtemp())
+            try:
+                async with TraceCapture("graq_reason", {"question": "q"}, store) as tc:
+                    raise RuntimeError("handler exploded")
+            except RuntimeError:
+                pass
+            traces = store.read_traces()
+            assert traces[0]["outcome"] == "FAILURE"
+            assert "handler exploded" in traces[0]["error"]
+
+        asyncio.run(_test())
+
+    def test_records_gate_decision(self):
+        async def _test():
+            store = TraceStore(trace_dir=tempfile.mkdtemp())
+            async with TraceCapture("graq_bash", {"command": "ls"}, store) as tc:
+                tc.record_gate_decision(
+                    "CG-02", GateType.GIT_GOVERNANCE, Decision.PASS, "plan active"
+                )
+                tc.set_result('{"stdout": "file.txt"}')
+            traces = store.read_traces()
+            gd = traces[0]["governance_decisions"]
+            assert len(gd) == 1
+            assert gd[0]["gate_id"] == "CG-02"
+            assert gd[0]["decision"] == "PASS"
+
+        asyncio.run(_test())
+
+    def test_blocked_gate_sets_outcome(self):
+        async def _test():
+            store = TraceStore(trace_dir=tempfile.mkdtemp())
+            async with TraceCapture("graq_write", {"file_path": "x.py"}, store) as tc:
+                tc.record_gate_decision(
+                    "CG-03", GateType.GIT_GOVERNANCE, Decision.BLOCK,
+                    "code file requires graq_edit"
+                )
+                tc.set_result('{"error": "CG-03_EDIT_GATE"}')
+            traces = store.read_traces()
+            assert traces[0]["outcome"] == "BLOCKED"
+
+        asyncio.run(_test())
+
+    def test_context_nodes_recorded(self):
+        async def _test():
+            store = TraceStore(trace_dir=tempfile.mkdtemp())
+            async with TraceCapture("graq_context", {"task": "test"}, store) as tc:
+                tc.set_context_nodes(["node_a", "node_b", "node_c"])
+                tc.set_result('{"context": "..."}')
+            traces = store.read_traces()
+            assert traces[0]["context_nodes"] == ["node_a", "node_b", "node_c"]
+
+        asyncio.run(_test())
+
+    def test_no_store_does_not_crash(self):
+        async def _test():
+            async with TraceCapture("graq_reason", {"question": "q"}, store=None) as tc:
+                tc.set_result('{"answer": "x"}')
+            # Should not raise
+
+        asyncio.run(_test())
+
+
+# ═══════════════════════════════════════════════════════════════════
+# trace_store.py tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestTraceStore:
+    """Append-only trace persistence."""
+
+    def _make_trace(self, tool_name="graq_test"):
+        return GovernedTrace(
+            tool_name=tool_name, query="test", outcome=Outcome.SUCCESS, confidence=0.5,
+        )
+
+    def test_append_creates_file(self):
+        async def _test():
+            d = tempfile.mkdtemp()
+            store = TraceStore(trace_dir=d)
+            await store.append(self._make_trace())
+            files = list(Path(d).glob("*.jsonl"))
+            assert len(files) == 1
+            assert store.count == 1
+
+        asyncio.run(_test())
+
+    def test_corpus_growth_monotonic(self):
+        """AC-3: T(n+1) >= T(n)."""
+        async def _test():
+            d = tempfile.mkdtemp()
+            store = TraceStore(trace_dir=d)
+            sizes = []
+            for i in range(5):
+                await store.append(self._make_trace(f"tool_{i}"))
+                sizes.append(store.corpus_size())
+            # Verify monotonic growth
+            for i in range(1, len(sizes)):
+                assert sizes[i] >= sizes[i - 1]
+
+        asyncio.run(_test())
+
+    def test_read_traces_returns_recent_first(self):
+        async def _test():
+            d = tempfile.mkdtemp()
+            store = TraceStore(trace_dir=d)
+            await store.append(self._make_trace("first"))
+            await store.append(self._make_trace("second"))
+            traces = store.read_traces()
+            assert traces[0]["tool_name"] == "second"
+            assert traces[1]["tool_name"] == "first"
+
+        asyncio.run(_test())
+
+    def test_read_traces_empty_date(self):
+        d = tempfile.mkdtemp()
+        store = TraceStore(trace_dir=d)
+        assert store.read_traces(date="1999-01-01") == []
+
+    def test_list_dates(self):
+        async def _test():
+            d = tempfile.mkdtemp()
+            store = TraceStore(trace_dir=d)
+            await store.append(self._make_trace())
+            dates = store.list_dates()
+            assert len(dates) >= 1
+            today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+            assert today in dates
+
+        asyncio.run(_test())
+
+    def test_on_trace_callback(self):
+        async def _test():
+            d = tempfile.mkdtemp()
+            captured = []
+            store = TraceStore(trace_dir=d, on_trace=lambda t: captured.append(t))
+            await store.append(self._make_trace())
+            assert len(captured) == 1
+            assert captured[0].tool_name == "graq_test"
+
+        asyncio.run(_test())
+
+    def test_trace_file_is_valid_jsonl(self):
+        async def _test():
+            d = tempfile.mkdtemp()
+            store = TraceStore(trace_dir=d)
+            for i in range(3):
+                await store.append(self._make_trace(f"tool_{i}"))
+            # Read raw file and validate each line is valid JSON
+            files = list(Path(d).glob("*.jsonl"))
+            with open(files[0], "r") as f:
+                for line in f:
+                    data = json.loads(line)  # Should not raise
+                    assert "tool_name" in data
+                    assert "id" in data
+
+        asyncio.run(_test())

--- a/tests/test_governance/test_transfer.py
+++ b/tests/test_governance/test_transfer.py
@@ -1,0 +1,589 @@
+"""Tests for R21 Cross-Organization Compliance Pattern Transfer (ADR-204).
+
+Covers: pattern_abstractor.py, similarity.py, adaptation.py,
+        pattern_registry.py, federated_transfer.py.
+
+Acceptance criteria: AC-1 through AC-7 (privacy + transfer correctness).
+"""
+
+import asyncio
+import hashlib
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from graqle.governance.adaptation import (
+    AdaptationError,
+    AdaptationResult,
+    TargetOrgContext,
+    adapt_pattern,
+)
+from graqle.governance.federated_transfer import (
+    FederatedTransferEngine,
+    TransferRecord,
+    TransferResult,
+)
+from graqle.governance.pattern_abstractor import (
+    ABSTRACTOR_VERSION,
+    AbstractPattern,
+    GateStep,
+    OutcomeAggregates,
+    _contains_forbidden,
+    _hash_org,
+    extract_abstract_pattern,
+    verify_privacy,
+)
+from graqle.governance.pattern_registry import PatternRegistry, RegistryEntry
+from graqle.governance.similarity import (
+    DEFAULT_ALPHA,
+    DEFAULT_BETA,
+    DEFAULT_GAMMA,
+    DEFAULT_TRANSFER_THRESHOLD,
+    SimilarityScore,
+    SimilarityWeights,
+    compute_similarity,
+    domain_similarity,
+    governance_similarity,
+    jaccard,
+    stack_similarity,
+)
+
+
+def _make_trace(
+    i: int = 0,
+    tool: str = "graq_reason",
+    clearance: str = "INTERNAL",
+    outcome: str = "SUCCESS",
+    decision: str = "PASS",
+    gate_id: str = "CG-01",
+    latency: float = 100.0,
+    override: bool = False,
+) -> dict:
+    return {
+        "id": f"trace-{i}",
+        "tool_name": tool,
+        "governance_decisions": [
+            {"gate_id": gate_id, "gate_type": "CLEARANCE", "decision": decision}
+        ],
+        "clearance_level": clearance,
+        "outcome": outcome,
+        "latency_ms": latency,
+        "human_override": override,
+    }
+
+
+def _batch(n: int = 10, **kwargs) -> list[dict]:
+    return [_make_trace(i=i, **kwargs) for i in range(n)]
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Forbidden-content scanner tests (AC-2, AC-7)
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestForbiddenContentScanner:
+    def test_email_rejected(self):
+        assert _contains_forbidden({"x": "admin@example.com"}) is True
+
+    def test_url_rejected(self):
+        assert _contains_forbidden({"x": "https://evil.com/api"}) is True
+        assert _contains_forbidden({"x": "http://internal.corp"}) is True
+
+    def test_unix_path_rejected(self):
+        assert _contains_forbidden({"x": "/home/haris/secret.key"}) is True
+
+    def test_windows_path_rejected(self):
+        assert _contains_forbidden({"x": "C:\\Users\\haris\\file.txt"}) is True
+
+    def test_api_key_rejected(self):
+        assert _contains_forbidden({"x": "sk-1234567890abcdefghijkl"}) is True
+
+    def test_ipv4_rejected(self):
+        assert _contains_forbidden({"x": "192.168.1.1"}) is True
+
+    def test_bearer_token_rejected(self):
+        assert _contains_forbidden({"x": "Bearer abc.def.ghi"}) is True
+
+    def test_sha256_allowed(self):
+        sha = hashlib.sha256(b"test").hexdigest()
+        assert _contains_forbidden({"x": sha}, allow_sha256=True) is False
+
+    def test_normal_values_allowed(self):
+        assert _contains_forbidden({"outcome": "PASS", "count": 5}) is False
+        assert _contains_forbidden({"tag": "fintech"}) is False
+
+    def test_nested_scan(self):
+        nested = {"outer": {"inner": {"email": "admin@test.com"}}}
+        assert _contains_forbidden(nested) is True
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Pattern abstractor tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestPatternAbstractor:
+    def test_basic_extraction(self):
+        pattern = extract_abstract_pattern(_batch(10), org_id="org-a")
+        assert isinstance(pattern, AbstractPattern)
+        assert pattern.schema_version == "r21.v1"
+        assert pattern.provenance.extractor_version == ABSTRACTOR_VERSION
+
+    def test_source_org_hash_is_sha256(self):
+        pattern = extract_abstract_pattern(_batch(10), org_id="acme-corp")
+        assert len(pattern.source_org_hash) == 64
+        assert all(c in "0123456789abcdef" for c in pattern.source_org_hash.lower())
+
+    def test_source_org_hash_deterministic(self):
+        p1 = extract_abstract_pattern(_batch(10), org_id="acme")
+        p2 = extract_abstract_pattern(_batch(10), org_id="acme")
+        assert p1.source_org_hash == p2.source_org_hash
+
+    def test_different_orgs_different_hashes(self):
+        p1 = extract_abstract_pattern(_batch(10), org_id="org-a")
+        p2 = extract_abstract_pattern(_batch(10), org_id="org-b")
+        assert p1.source_org_hash != p2.source_org_hash
+
+    def test_empty_traces_rejected(self):
+        with pytest.raises(ValueError):
+            extract_abstract_pattern([], org_id="org-a")
+
+    def test_trace_class_inference(self):
+        pattern = extract_abstract_pattern(_batch(10, tool="graq_reason"), org_id="o")
+        assert pattern.trace_class == "reasoning"
+
+        pattern2 = extract_abstract_pattern(_batch(10, tool="graq_generate"), org_id="o")
+        assert pattern2.trace_class == "generation"
+
+    def test_gate_sequence_populated(self):
+        pattern = extract_abstract_pattern(_batch(5), org_id="o")
+        assert len(pattern.gate_sequence) == 5
+
+    def test_outcome_aggregates(self):
+        traces = (
+            _batch(7, outcome="SUCCESS") +
+            _batch(3, outcome="FAILURE")
+        )
+        pattern = extract_abstract_pattern(traces, org_id="o")
+        assert abs(pattern.outcome_aggregates.pass_rate - 0.7) < 0.01
+        assert abs(pattern.outcome_aggregates.fail_rate - 0.3) < 0.01
+
+    def test_tags_normalized(self):
+        pattern = extract_abstract_pattern(
+            _batch(5), org_id="o",
+            domain_tags=["Fin-Tech!!!", "Payments"],
+        )
+        # Should lowercase, strip special chars
+        assert "fin-tech" in pattern.domain_tags
+        assert "payments" in pattern.domain_tags
+
+    def test_privacy_verified_on_extract(self):
+        """AC-7: Pattern must pass privacy verification."""
+        pattern = extract_abstract_pattern(_batch(10), org_id="o")
+        assert verify_privacy(pattern) is True
+
+    def test_raw_org_id_not_in_pattern(self):
+        """AC-2: Raw org identifier never present in abstract pattern."""
+        org_id = "acme-very-unique-name-12345"
+        pattern = extract_abstract_pattern(_batch(10), org_id=org_id)
+        dumped = json.dumps(pattern.model_dump(mode="json"), default=str)
+        assert org_id not in dumped
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Similarity tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestSimilarity:
+    def test_default_weights_sum_to_one(self):
+        assert abs(DEFAULT_ALPHA + DEFAULT_BETA + DEFAULT_GAMMA - 1.0) < 0.001
+
+    def test_jaccard_basic(self):
+        assert jaccard({"a", "b"}, {"b", "c"}) == 1 / 3
+        assert jaccard({"a"}, {"a"}) == 1.0
+        assert jaccard(set(), set()) == 0.0
+
+    def test_identical_patterns_high_similarity(self):
+        pat = extract_abstract_pattern(
+            _batch(10), org_id="o",
+            domain_tags=["fintech"], stack_tags=["python"], governance_tags=["soc2"],
+        )
+        score = compute_similarity(pat, pat)
+        assert score.total > 0.9
+
+    def test_disjoint_patterns_low_similarity(self):
+        pat_a = extract_abstract_pattern(
+            _batch(10, tool="graq_reason"), org_id="a",
+            domain_tags=["fintech"], stack_tags=["python"], governance_tags=["soc2"],
+        )
+        pat_b = extract_abstract_pattern(
+            _batch(10, tool="graq_generate"), org_id="b",
+            domain_tags=["gaming"], stack_tags=["rust"], governance_tags=["iso27001"],
+        )
+        score = compute_similarity(pat_a, pat_b)
+        assert score.total < 0.5
+
+    def test_invalid_weights_rejected(self):
+        with pytest.raises(ValueError):
+            bad = SimilarityWeights(alpha=0.5, beta=0.5, gamma=0.5)
+            compute_similarity(
+                extract_abstract_pattern(_batch(10), org_id="a"),
+                extract_abstract_pattern(_batch(10), org_id="b"),
+                weights=bad,
+            )
+
+    def test_threshold_gate(self):
+        pat = extract_abstract_pattern(
+            _batch(10), org_id="o",
+            domain_tags=["fintech"], stack_tags=["python"], governance_tags=["soc2"],
+        )
+        score = compute_similarity(pat, pat, threshold=0.99)
+        assert score.meets_threshold is True
+        score2 = compute_similarity(pat, pat, threshold=1.01)
+        assert score2.meets_threshold is False
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Adaptation tests (AC-1, AC-2)
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestAdaptation:
+    def _make_pattern(self, org: str = "org-a") -> AbstractPattern:
+        return extract_abstract_pattern(_batch(5), org_id=org)
+
+    def _full_context(self, org: str = "org-b") -> TargetOrgContext:
+        return TargetOrgContext(
+            org_id=org,
+            gate_type_map={
+                "session": "B-session",
+                "plan": "B-plan",
+                "clearance": "B-clear",
+                "ip_gate": "B-ip",
+            },
+            clearance_map={
+                "PUBLIC": "B-L0",
+                "INTERNAL": "B-L2",
+                "CONFIDENTIAL": "B-L3",
+                "RESTRICTED": "B-L4",
+                "UNKNOWN": "B-L0",
+            },
+        )
+
+    def test_successful_adaptation(self):
+        pattern = self._make_pattern()
+        ctx = self._full_context()
+        result = adapt_pattern(pattern, ctx)
+        assert isinstance(result, AdaptationResult)
+        assert result.adapted_pattern.source_org_hash == ctx.org_hash
+
+    def test_strict_mode_fails_on_unmapped(self):
+        """AC-1: Fail-closed on incomplete mappings."""
+        pattern = self._make_pattern()
+        ctx = TargetOrgContext(org_id="org-b", strict=True)  # no mappings
+        with pytest.raises(AdaptationError):
+            adapt_pattern(pattern, ctx)
+
+    def test_non_strict_uses_placeholders(self):
+        pattern = self._make_pattern()
+        ctx = TargetOrgContext(org_id="org-b", strict=False)
+        result = adapt_pattern(pattern, ctx)
+        for step in result.adapted_pattern.gate_sequence:
+            assert "TARGET_UNKNOWN" in step.gate_type or step.gate_type != ""
+
+    def test_adaptation_preserves_sequence_length(self):
+        pattern = self._make_pattern()
+        ctx = self._full_context()
+        result = adapt_pattern(pattern, ctx)
+        assert len(result.adapted_pattern.gate_sequence) == len(pattern.gate_sequence)
+
+    def test_adaptation_preserves_outcome_aggregates(self):
+        pattern = self._make_pattern()
+        ctx = self._full_context()
+        result = adapt_pattern(pattern, ctx)
+        assert (
+            result.adapted_pattern.outcome_aggregates.pass_rate
+            == pattern.outcome_aggregates.pass_rate
+        )
+
+    def test_adapted_pattern_privacy_verified(self):
+        """AC-7: Post-adaptation privacy check."""
+        pattern = self._make_pattern()
+        ctx = self._full_context()
+        result = adapt_pattern(pattern, ctx)
+        assert verify_privacy(result.adapted_pattern) is True
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Pattern registry tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestPatternRegistry:
+    def test_register_and_count(self):
+        async def _test():
+            reg = PatternRegistry(store_dir=tempfile.mkdtemp())
+            pat = extract_abstract_pattern(_batch(10), org_id="o")
+            entry = await reg.register(pat)
+            assert isinstance(entry, RegistryEntry)
+            assert reg.count == 1
+
+        asyncio.run(_test())
+
+    def test_register_rejects_privacy_violation(self):
+        """AC-2: Store refuses to register unclean patterns."""
+        async def _test():
+            reg = PatternRegistry(store_dir=tempfile.mkdtemp())
+            pat = extract_abstract_pattern(_batch(10), org_id="o")
+            # Corrupt the hash to fail verification
+            bad = pat.model_copy(update={"source_org_hash": "not-a-real-hash"})
+            with pytest.raises(ValueError):
+                await reg.register(bad)
+
+        asyncio.run(_test())
+
+    def test_list_patterns(self):
+        async def _test():
+            reg = PatternRegistry(store_dir=tempfile.mkdtemp())
+            for i in range(3):
+                pat = extract_abstract_pattern(_batch(5), org_id=f"org-{i}")
+                await reg.register(pat)
+            entries = reg.list_patterns()
+            assert len(entries) == 3
+
+        asyncio.run(_test())
+
+    def test_filter_by_trace_class(self):
+        async def _test():
+            reg = PatternRegistry(store_dir=tempfile.mkdtemp())
+            p1 = extract_abstract_pattern(_batch(5, tool="graq_reason"), org_id="o1")
+            p2 = extract_abstract_pattern(_batch(5, tool="graq_generate"), org_id="o2")
+            await reg.register(p1)
+            await reg.register(p2)
+            reasoning = reg.list_patterns(trace_class="reasoning")
+            assert len(reasoning) == 1
+
+        asyncio.run(_test())
+
+    def test_load_pattern_by_id(self):
+        async def _test():
+            reg = PatternRegistry(store_dir=tempfile.mkdtemp())
+            pat = extract_abstract_pattern(_batch(5), org_id="o")
+            await reg.register(pat)
+            loaded = reg.load_pattern(pat.pattern_id)
+            assert loaded is not None
+            assert loaded.pattern_id == pat.pattern_id
+
+        asyncio.run(_test())
+
+    def test_find_matches_excludes_origin(self):
+        """AC-6: Multi-tenant isolation — don't transfer back to source org."""
+        async def _test():
+            reg = PatternRegistry(store_dir=tempfile.mkdtemp())
+            pat_a = extract_abstract_pattern(_batch(5, tool="graq_reason"), org_id="org-a")
+            pat_b = extract_abstract_pattern(_batch(5, tool="graq_reason"), org_id="org-b")
+            await reg.register(pat_a)
+            await reg.register(pat_b)
+
+            matches = reg.find_matches(
+                trace_class="reasoning",
+                exclude_org_hash=_hash_org("org-a"),
+            )
+            for m in matches:
+                assert m.source_org_hash != _hash_org("org-a")
+
+        asyncio.run(_test())
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Federated transfer engine tests (AC-1 through AC-7)
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestFederatedTransfer:
+    def _full_context(self, org: str = "org-b") -> TargetOrgContext:
+        return TargetOrgContext(
+            org_id=org,
+            gate_type_map={
+                "session": "B-session", "plan": "B-plan",
+                "clearance": "B-clear", "ip_gate": "B-ip",
+            },
+            clearance_map={
+                "PUBLIC": "B-L0", "INTERNAL": "B-L2",
+                "CONFIDENTIAL": "B-L3", "RESTRICTED": "B-L4",
+                "UNKNOWN": "B-L0",
+            },
+        )
+
+    def test_successful_transfer(self):
+        async def _test():
+            reg = PatternRegistry(store_dir=tempfile.mkdtemp())
+            engine = FederatedTransferEngine(
+                registry=reg, audit_dir=tempfile.mkdtemp()
+            )
+            # Source from Org A
+            src = extract_abstract_pattern(
+                _batch(10), org_id="org-a",
+                domain_tags=["fintech"], stack_tags=["python"], governance_tags=["soc2"],
+            )
+            await reg.register(src)
+            # Target from Org B with similar profile
+            tgt = extract_abstract_pattern(
+                _batch(10), org_id="org-b",
+                domain_tags=["fintech"], stack_tags=["python"], governance_tags=["soc2"],
+            )
+            results = await engine.transfer(
+                target_pattern=tgt,
+                target_context=self._full_context(),
+                threshold=0.5,
+            )
+            assert len(results) == 1
+            assert results[0].record.gated is True
+            assert results[0].adapted_pattern is not None
+
+        asyncio.run(_test())
+
+    def test_below_threshold_gated_out(self):
+        """AC-1: Transfer only when similarity >= threshold."""
+        async def _test():
+            reg = PatternRegistry(store_dir=tempfile.mkdtemp())
+            engine = FederatedTransferEngine(
+                registry=reg, audit_dir=tempfile.mkdtemp()
+            )
+            src = extract_abstract_pattern(
+                _batch(10, tool="graq_reason"), org_id="org-a",
+                domain_tags=["fintech"], stack_tags=["python"],
+            )
+            await reg.register(src)
+            tgt = extract_abstract_pattern(
+                _batch(10, tool="graq_reason"), org_id="org-b",
+                domain_tags=["gaming"], stack_tags=["rust"], governance_tags=["pci"],
+            )
+            results = await engine.transfer(
+                target_pattern=tgt,
+                target_context=self._full_context(),
+                threshold=0.95,
+            )
+            # Either no candidates or all gated out
+            for r in results:
+                if not r.record.gated:
+                    assert r.record.adapted is False
+
+        asyncio.run(_test())
+
+    def test_audit_log_written(self):
+        """AC-4: Every transfer logged with source, similarity, adaptation."""
+        async def _test():
+            reg = PatternRegistry(store_dir=tempfile.mkdtemp())
+            audit_dir = tempfile.mkdtemp()
+            engine = FederatedTransferEngine(registry=reg, audit_dir=audit_dir)
+
+            src = extract_abstract_pattern(
+                _batch(10), org_id="org-a",
+                domain_tags=["fintech"], stack_tags=["py"], governance_tags=["soc2"],
+            )
+            await reg.register(src)
+            tgt = extract_abstract_pattern(
+                _batch(10), org_id="org-b",
+                domain_tags=["fintech"], stack_tags=["py"], governance_tags=["soc2"],
+            )
+            await engine.transfer(
+                target_pattern=tgt,
+                target_context=self._full_context(),
+            )
+            entries = engine.read_audit()
+            assert len(entries) >= 1
+            e = entries[0]
+            assert "source_pattern_id" in e
+            assert "similarity_total" in e
+            assert "privacy_verified_pre" in e
+
+        asyncio.run(_test())
+
+    def test_privacy_invariant_audit_log(self):
+        """AC-2: Audit log contains no raw org identifiers."""
+        async def _test():
+            reg = PatternRegistry(store_dir=tempfile.mkdtemp())
+            audit_dir = tempfile.mkdtemp()
+            engine = FederatedTransferEngine(registry=reg, audit_dir=audit_dir)
+
+            src = extract_abstract_pattern(
+                _batch(10), org_id="unique-org-name-xyz",
+                domain_tags=["fintech"], stack_tags=["py"], governance_tags=["soc2"],
+            )
+            await reg.register(src)
+            tgt = extract_abstract_pattern(
+                _batch(10), org_id="target-corp-abc",
+                domain_tags=["fintech"], stack_tags=["py"], governance_tags=["soc2"],
+            )
+            await engine.transfer(
+                target_pattern=tgt,
+                target_context=self._full_context(org="target-corp-abc"),
+            )
+            entries = engine.read_audit()
+            raw = json.dumps(entries, default=str)
+            assert "unique-org-name-xyz" not in raw
+            assert "target-corp-abc" not in raw
+
+        asyncio.run(_test())
+
+    def test_adaptation_failure_recorded(self):
+        async def _test():
+            reg = PatternRegistry(store_dir=tempfile.mkdtemp())
+            engine = FederatedTransferEngine(
+                registry=reg, audit_dir=tempfile.mkdtemp()
+            )
+            src = extract_abstract_pattern(
+                _batch(10), org_id="org-a",
+                domain_tags=["fintech"], stack_tags=["py"], governance_tags=["soc2"],
+            )
+            await reg.register(src)
+            tgt = extract_abstract_pattern(
+                _batch(10), org_id="org-b",
+                domain_tags=["fintech"], stack_tags=["py"], governance_tags=["soc2"],
+            )
+            # Empty context in strict mode -> adaptation fails
+            bad_ctx = TargetOrgContext(org_id="org-b", strict=True)
+            results = await engine.transfer(
+                target_pattern=tgt,
+                target_context=bad_ctx,
+                threshold=0.5,
+            )
+            assert len(results) == 1
+            assert results[0].record.gated is True
+            assert results[0].record.adapted is False
+            assert results[0].adapted_pattern is None
+
+        asyncio.run(_test())
+
+    def test_origin_exclusion(self):
+        """AC-6: Cannot transfer pattern back to its origin org."""
+        async def _test():
+            reg = PatternRegistry(store_dir=tempfile.mkdtemp())
+            engine = FederatedTransferEngine(
+                registry=reg, audit_dir=tempfile.mkdtemp()
+            )
+            src = extract_abstract_pattern(
+                _batch(10), org_id="org-a",
+                domain_tags=["fintech"], stack_tags=["py"], governance_tags=["soc2"],
+            )
+            await reg.register(src)
+            # Target is Org A itself
+            tgt = extract_abstract_pattern(
+                _batch(10), org_id="org-a",
+                domain_tags=["fintech"], stack_tags=["py"], governance_tags=["soc2"],
+            )
+            results = await engine.transfer(
+                target_pattern=tgt,
+                target_context=TargetOrgContext(
+                    org_id="org-a",
+                    gate_type_map={"clearance": "A-clear", "session": "A-sess"},
+                    clearance_map={"INTERNAL": "A-L2", "UNKNOWN": "A-L0"},
+                ),
+            )
+            assert len(results) == 0  # origin excluded
+
+        asyncio.run(_test())

--- a/tests/test_plugins/conftest.py
+++ b/tests/test_plugins/conftest.py
@@ -1,0 +1,17 @@
+"""Shared fixtures for tests/test_plugins/.
+
+R22 SHACL gate defaults ON (fail-closed). Unit tests that call handle_tool()
+on bare KogniDevServer instances (no governance trace) would all be blocked.
+This module-level autouse fixture disables the gate for the whole directory.
+"""
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _disable_shacl_gate():
+    """Disable R22 SHACL gate for bare-server unit tests in this directory."""
+    import graqle.plugins.mcp_dev_server as _mds
+    old = _mds._SHACL_GATE_ENABLED
+    _mds._SHACL_GATE_ENABLED = False
+    yield
+    _mds._SHACL_GATE_ENABLED = old


### PR DESCRIPTION
## Summary

Ships R18–R21 governance research modules to public master. These were merged to private/master on 2026-04-24 but were never cherry-picked to public — causing `test_shacl.py` (R22) to fail CI because it imports `graqle.governance.trace_schema` (R18).

### Modules shipped

| Research | Modules | ADR |
|---|---|---|
| R18 GETC | `trace_schema`, `trace_capture`, `trace_store` | ADR-201 |
| R19 Failure Predictor | `failure_features`, `failure_predictor` | ADR-202 |
| R20 Calibration | `calibration`, `calibration_store`, `reliability_diagram`, `near_miss_store`, `calibrate_governance` CLI | ADR-203 |
| R21 Federated Transfer | `federated_transfer`, `pattern_abstractor`, `pattern_registry`, `adaptation`, `similarity` | ADR-204 |

### Also included

- `governance/__init__.py` — combined R18-R21 exports
- `mcp_dev_server.py` — R18 trace capture wrap + R20 `graq_calibrate_governance` tool (162 tools total)
- 4 test files: `test_calibration`, `test_failure_predictor`, `test_trace_capture`, `test_transfer`
- CI workaround from PR #121 removed — `test_shacl.py` now runs fully

### Conflict resolution

`mcp_dev_server.py` conflicted between R18-R21 additions and R22 SHACL gate. Resolved by keeping both: R18 trace capture wrap + R22 SHACL output gate coexist correctly.

## Test plan

- [x] 3 commits cherry-picked cleanly (1 conflict in mcp_dev_server.py resolved)
- [x] All conflict markers cleared
- [x] CI workaround for test_shacl.py removed (R18 dependency now present)
- [x] Tool count remains 162 (graq_calibrate_governance + kogni alias already counted in 0.52.0b2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)