### PR TITLE
fix(dist-lint): exempt R23 GSEFT embeddings from advisory leakage scan

### DIFF
--- a/graqle/embeddings/contrastive_trainer.py
+++ b/graqle/embeddings/contrastive_trainer.py
@@ -21,7 +21,7 @@ class TrainerConfig:
     base_model: str = "sentence-transformers/all-MiniLM-L6-v2"
     output_dir: str = ".graqle/gseft-checkpoints"
     epochs: int = 3
-    # B1 (TS-2): training hyperparameters externalized — no hardcoded defaults.
+    # B1: training hyperparameters externalized — no hardcoded defaults.
     # Set via GRAQLE_GSEFT_BATCH_SIZE / GRAQLE_GSEFT_LEARNING_RATE env vars,
     # or pass explicitly when constructing TrainerConfig.
     batch_size: int = field(

--- a/tests/test_distribution/test_no_internal_strings.py
+++ b/tests/test_distribution/test_no_internal_strings.py
@@ -111,6 +111,12 @@ EXEMPT_PATHS: set[str] = {
     "graqle/cli/commands/calibrate_governance.py",  # R20 CLI — ADR ref in module docstring
     # R22 (ADR-205): SHACL governance completeness verification — ADR refs are spec annotations
     "graqle/governance/shacl/",                     # R22 ADR-205 spec annotations + shapes.ttl
+    # R23 (ADR-206): GSEFT scaffold — ADR refs are spec annotations for deferred research modules
+    "graqle/embeddings/__init__.py",                # R23 ADR-206 spec annotation
+    "graqle/embeddings/contrastive_trainer.py",     # R23 ADR-206 spec annotation
+    "graqle/embeddings/governance_dataset.py",      # R23 ADR-206 spec annotation
+    "graqle/embeddings/governance_eval.py",         # R23 ADR-206 spec annotation
+    "graqle/embeddings/model_registry.py",          # R23 ADR-206 spec annotation
 }
 
 # Modules whose TS-2 compliance comments are informational, not pattern


### PR DESCRIPTION
## Summary
- `test_advisory_package_wide_leakage` was failing with 6 internal-reference hits introduced by the 0.52.0 R23 GSEFT scaffold files
- Root cause: `ADR-206` spec annotations in all 5 embeddings module docstrings + `TS-2` tag in a `contrastive_trainer.py` inline comment
- Fix 1: removed `TS-2` tag from `contrastive_trainer.py` comment (trade-secret tag must not appear in shipped source)
- Fix 2: added the 5 GSEFT embeddings files to `EXEMPT_PATHS` in the distribution lint test — same precedent as R18-R22 governance research modules

## Test impact
- `test_advisory_package_wide_leakage`: 6 hits → 0 ✅
- All other distribution lint tests unaffected

## CI
This is the only blocking CI failure after PR #124 merged. Once green, `git tag v0.52.0` triggers OIDC PyPI publish.