### PR TITLE
fix: ChunkScorer TypeError — pass graph as first arg to scorer.score()

### DIFF
--- a/graqle/activation/real_providers.py
+++ b/graqle/activation/real_providers.py
@@ -48,9 +48,12 @@ class RealChunkScoringProvider:
         if not scorer:
             return ChunkScoreResult(summary="chunk scorer unavailable")
         try:
-            # ChunkScorer has a synchronous `score` method on most branches.
-            # Call it defensively; fall back to empty result on any failure.
-            raw = scorer.score(user_message) if hasattr(scorer, "score") else None
+            # ChunkScorer.score(graph, query) requires the loaded KG as first arg.
+            # graph is injected via activation_hints by ChatAgentLoop._act_hints.
+            graph = activation_hints.get("graph") if activation_hints else None
+            if graph is None:
+                return ChunkScoreResult(summary="chunk scorer unavailable: no graph in activation_hints")
+            raw = scorer.score(graph, user_message) if hasattr(scorer, "score") else None
             if raw is None:
                 return ChunkScoreResult(summary="chunk scorer returned None")
             # Normalize to our public shape

--- a/graqle/chat/agent_loop.py
+++ b/graqle/chat/agent_loop.py
@@ -312,6 +312,7 @@ class ChatAgentLoop:
                 "intent_id": activation.intent_id,
                 "candidates": [c.label for c in activation.candidates],
                 "scenario": scenario or "",
+                "graph": getattr(self, "graph", None),
             }
             try:
                 self._last_activation_verdict = await self.activation_layer.run(


### PR DESCRIPTION
## Summary
- `RealChunkScoringProvider.score()` was calling `scorer.score(user_message)` with 1 argument, but `ChunkScorer.score(graph, query)` requires the loaded KG as its first argument — causing `chunk scoring failed: TypeError` on every chat turn
- Fixed by extracting `graph` from `activation_hints` and passing it as first arg; gracefully returns an empty `ChunkScoreResult` when graph is absent
- `ChatAgentLoop._act_hints` now includes `"graph": getattr(self, "graph", None)` so the graph is injected without breaking mock/test instances that have no `graph` attribute

## Test plan
- [x] `pytest tests/test_activation/` — 137 passed, 2 skipped
- [x] `pytest tests/test_chat/` — 249 passed
- [x] Zero regressions

## Files changed
- `graqle/activation/real_providers.py` — extract graph from hints, pass as first arg
- `graqle/chat/agent_loop.py` — add `graph` key to `_act_hints`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)