### PR TITLE
chore(release): v0.52.1 — ChunkScorer TypeError fix

### DIFF
--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.52.0"
+__version__ = "0.52.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.52.0"
+version = "0.52.1"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Proprietary — see LICENSE"}


### PR DESCRIPTION
## Summary
- ChunkScorer TypeError fix (PR #126, already merged to master)
- Version bump `0.52.0` → `0.52.1`

## CI
- All tests green on master (CI run #24981225049)

## Next
Tag `v0.52.1` will trigger PyPI publish via OIDC CI workflow.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)