### PR TITLE
ci: bump pip in pip-audit job to fix CVE-2026-6357

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Upgrade pip (fixes CVE-2026-6357 in pip 26.0.1)
+        run: python -m pip install --upgrade 'pip>=26.1'
+
       - name: Install pip-audit
         run: pip install pip-audit
 


### PR DESCRIPTION
# Bump pip in pip-audit job to fix CVE-2026-6357

Cherry-picked from private PR [research-development-graqle#82](https://github.com/quantamixsol/research-development-graqle/pull/82), merged 2026-05-07.

## What

Adds a one-line pip upgrade step before `pip install pip-audit` in the `audit` job of `.github/workflows/ci.yml`. Total diff: +3 lines, 0 deletions, single file.

```yaml
- name: Upgrade pip (fixes CVE-2026-6357 in pip 26.0.1)
  run: python -m pip install --upgrade 'pip>=26.1'
```

## Why

The `pip-audit CVE scan` job has been failing on every PR for ~6 days with:

```
FAIL: CVE-2026-6357 in pip 26.0.1 — fix available: ['26.1']
```

The runner ships `pip 26.0.1`. `pip-audit` then introspects the environment, finds `pip 26.0.1` itself is in its CVE database, and exits 1. The other CI jobs already do `pip install --upgrade pip` (line 27); the pip-audit job was missing this step.

## Verified failure runs (public)

- [run 25491330722](https://github.com/quantamixsol/graqle/actions/runs/25491330722) — post-merge of #130
- [run 25494504019](https://github.com/quantamixsol/graqle/actions/runs/25494504019) — post-merge of #131

Both show identical signature.

## What this PR does NOT change

- No package code, tests, or runtime behaviour
- No PyPI artifact change
- No version bump or release trigger
- Only modifies one workflow file

## Process

Cherry-picked from private after the private PR was merged, per ABSOLUTE RULE #0 (private-first sequential gate).
