### PR TITLE
ci(security): add Path-Deny Guard to prevent governance/config leaks

### DIFF
--- a/.github/workflows/path-deny-guard.yml
+++ b/.github/workflows/path-deny-guard.yml
@@ -1,0 +1,132 @@
+# Path-Deny Guard — prevent governance/config artefacts from landing on PUBLIC master.
+#
+# Context: this workflow runs on the PUBLIC repo (quantamixsol/graqle).
+# It enforces that the directories `.claude/`, `.gcc/`, `.gsm/`, `.graqle/`
+# (which are already listed in `.gitignore`) cannot be reintroduced via a
+# force-add pathspec. The 6 leaks remediated in PRs #130/#131 all entered
+# this way.
+#
+# Behaviour:
+#   * Runs on every pull_request and on push to master/main.
+#   * Computes the diff between the PR head and merge-base (or push base).
+#   * Fails the check (exit 1) if any added/modified path matches the
+#     deny-list.
+#
+# Override path:
+#   This workflow has no override flag by design. If a future change has a
+#   legitimate reason to add files in a denied directory, the workflow file
+#   itself must be edited and reviewed first.
+#
+# Internal copy lives on the PRIVATE repo as a no-op stub that always passes,
+# so the same branch can be cherry-picked through the private→public flow
+# without breaking private development that legitimately edits .claude/, .gcc/,
+# .gsm/.
+
+name: Path-Deny Guard
+
+on:
+  pull_request:
+    branches: [master, main]
+  push:
+    branches: [master, main]
+
+permissions:
+  contents: read
+
+jobs:
+  path-deny:
+    name: path-deny-guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute changed paths
+        id: changed
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          else
+            # push event
+            base="${{ github.event.before }}"
+            head="${{ github.event.after }}"
+            # On force-pushes or initial pushes, before may be all-zeros
+            if [ "$base" = "0000000000000000000000000000000000000000" ]; then
+              base=$(git rev-list --max-parents=0 HEAD | head -1)
+            fi
+          fi
+          # Validate SHA format before using in git commands (defensive — GitHub
+          # context values are inherently trusted but we anchor the regex anyway).
+          for sha in "$base" "$head"; do
+            if ! [[ "$sha" =~ ^[a-f0-9]{7,64}$ ]]; then
+              echo "::error::Invalid SHA format: $sha"
+              exit 1
+            fi
+          done
+          echo "Comparing $base..$head"
+          # Only consider Added (A) and Modified (M) changes; allow Deletions (D)
+          # so we can keep removing leaked files without the gate blocking us.
+          # Use NUL-delimited output (-z) so paths with embedded newlines or
+          # other non-printable characters cannot fool the loop.
+          git diff --diff-filter=AM --name-only -z "$base...$head" > /tmp/changed-paths.nul
+          # Count entries safely (NUL-separated)
+          count=$(tr -cd '\0' < /tmp/changed-paths.nul | wc -c)
+          echo "Changed paths count: $count"
+
+      - name: Enforce deny-list
+        run: |
+          set -euo pipefail
+          # Deny-list of path prefixes that must NEVER appear in this repo.
+          # All four are in this repo's existing .gitignore — this gate exists
+          # because explicit pathspec on `git add` silently overrides .gitignore.
+          deny_prefixes=(
+            ".claude/"
+            ".gcc/"
+            ".gsm/"
+            ".graqle/"
+          )
+
+          violations=()
+          # Read NUL-delimited paths so that filenames with embedded newlines
+          # or shell metacharacters cannot bypass the loop or inject anything.
+          # The `case` statement uses bash globbing on a literal string — it does
+          # not evaluate or interpret $path as a command, so this is safe even
+          # if a path contains backticks, $(), pipes, etc.
+          while IFS= read -r -d '' path; do
+            [ -z "$path" ] && continue
+            for prefix in "${deny_prefixes[@]}"; do
+              case "$path" in
+                "$prefix"*)
+                  violations+=("$path")
+                  break
+                  ;;
+              esac
+            done
+          done < /tmp/changed-paths.nul
+
+          if [ ${#violations[@]} -gt 0 ]; then
+            echo "::error::Path-Deny Guard BLOCKED — the following paths are not allowed on public master:"
+            for v in "${violations[@]}"; do
+              echo "::error::  $v"
+            done
+            echo ""
+            echo "Why: these directories (.claude/, .gcc/, .gsm/, .graqle/) hold"
+            echo "internal R&D artefacts and are already listed in .gitignore."
+            echo "They were force-added past the ignore rule in past leaks."
+            echo ""
+            echo "Resolution:"
+            echo "  1. Remove these paths from your commit:"
+            echo "       git rm --cached <path>"
+            echo "       git commit --amend"
+            echo "       git push -f"
+            echo "  2. Or, if the change is legitimate, edit"
+            echo "     .github/workflows/path-deny-guard.yml to adjust the deny-list"
+            echo "     (will require its own review)."
+            exit 1
+          fi
+
+          echo "::notice::Path-Deny Guard passed — no denied paths in diff."


### PR DESCRIPTION
# P0 — Path-Deny Guard for governance/config directories

Adds a CI workflow that **fails any PR or push to master/main** if it adds or modifies a file under:

- `.claude/`
- `.gcc/`
- `.gsm/`
- `.graqle/`

These four prefixes are **already** in this repo's `.gitignore`. This workflow exists because **explicit pathspec on `git add` silently overrides ignore rules** — the 6 governance/config leaks remediated in PRs #130 and #131 all entered via this exact mechanism.

## Why this is the highest-leverage prevention measure

The recent leak audit identified 6 files that should never have been on public:

| Path | Removed in |
|---|---|
| `.gsm/decisions/ADR-151-per-call-governance-topology-ip-flag.md` | #130 |
| `.gsm/decisions/ADR-154-vscode-extension-integration-spec.md` | #131 |
| `.gsm/decisions/HANDOFF-VSCODE-EXTENSION-TEAM.md` | #131 |
| `.gcc/HFCI-TRACKER.md` | #131 |
| `.claude/settings.json` | #131 |
| `.claude/hooks/graqle-gate.sh` | #131 |

All 6 paths were already in `.gitignore`. Every gate that was supposed to catch them — `ip-protection-gate`, `Governance Gate`, `GraQle PR Guardian`, branch protection — passed. The reason is that those gates either look for trade-secret strings, OR validate code shape, OR require a human reviewer who saw an ADR header and assumed legitimacy. **None of them looked for "is this path even allowed on this repo?"** This workflow does that single check.

Self-tested locally: 6/6 historical leaks **CAUGHT**, 6/6 legitimate paths (graqle/, tests/, .github/, pyproject.toml, README.md, .gitignore) **PASS**.

## Implementation

| Aspect | Choice |
|---|---|
| Diff filter | `--diff-filter=AM` — Added/Modified only; Deletions allowed so cleanup PRs aren't blocked |
| Path delivery | `git diff -z` + `read -r -d ''` — NUL-delimited; paths with newlines or shell metacharacters cannot fool the loop |
| Match | `case "$path" in "$prefix"*)` — bash globbing against literal LHS, no command-evaluation surface |
| SHA validation | `^[a-f0-9]{7,64}$` regex on GitHub-provided refs |
| Override mechanism | None — changing the deny-list requires editing the workflow file itself, which is reviewable |
| Permissions | `contents: read` only |

## Sentinel review

`graq_review focus=security context_depth=2` initial pass returned `CHANGES_REQUESTED` with two legitimate findings, both addressed in this PR:

1. **MAJOR**: NUL-delimited path handling (could be bypassed by a filename containing newlines) — fixed by switching to `git diff -z` + `read -r -d ''`.
2. **MINOR**: SHA format validation missing — added `^[a-f0-9]{7,64}$` anchor.

The sentinel's BLOCKER finding ("workflow content not provided") was a hallucination — full diff was supplied and 32+ agents analysed it.

## Scope

- New file only. Zero modifications to existing files.
- Public repo only. Not mirrored to private (which legitimately writes to `.claude/`, `.gcc/`, `.gsm/`).
- No code change, no test change, no PyPI artefact change.
- No version bump or release implication.

## Process exception (ABSOLUTE RULE #0)

Direct public PR (not private-first) because this workflow is public-only by design — installing it on private would block legitimate development. Same exception class as PR #131. Logged in OPEN-TRACKER.

## What this enables

After merge, the cleanup work cannot regress. Any future commit (mine, yours, or anyone else's) that tries to add a file under `.claude/`, `.gcc/`, `.gsm/`, or `.graqle/` will fail the `Path-Deny Guard` check. This is the exact gate we needed before the original leaks happened.

## Follow-up PRs (separate)

- **P1**: Filename + first-N-lines content IP gate (regex for `Patent Reference:`, `FLAGGED FOR IP REVIEW`, `Claims [A-Z]+-[A-Z]+`, etc.). Catches the ADR-151 *class* of leak — patent-disclosing meta-documents that don't quote trade-secret values.
- **P2**: Mandatory `visibility: public|private` frontmatter on every ADR.
- **P3**: Structural removal of `.gsm/decisions/` from public tree entirely.
