### PR TITLE
ci(security): add IP Content Gate to catch self-disclosing IP meta-documents

### DIFF
--- a/.github/workflows/ip-content-gate.yml
+++ b/.github/workflows/ip-content-gate.yml
@@ -1,0 +1,85 @@
+# IP Content Gate — block self-disclosing IP/patent meta-documents on PUBLIC.
+#
+# Context: this workflow runs on the PUBLIC repo (quantamixsol/graqle).
+# It complements the existing `IP Gate` (which scans for literal TS-1..TS-6
+# trade-secret values) by catching the *semantic* class of leak — documents
+# that talk *about* patents, IP review status, or trade-secret labels without
+# quoting any actual trade-secret value.
+#
+# The motivating example is ADR-151, removed in PR #130: a 62-line markdown
+# placeholder that referenced patent EP26167849.4 and Claims K-O, framed a
+# pattern as "potentially novel", and named TS-1..TS-4 by label. It passed
+# every existing gate (ip-protection-gate, Governance Gate, PR Guardian,
+# branch protection) because none of them had a check for self-disclosure
+# language. This gate fills that gap.
+#
+# Behaviour:
+#   * Runs on every pull_request and on push to master/main.
+#   * Layer 1: filename pattern check on Added/Modified paths.
+#   * Layer 2: content scan of the first 100 lines of any Added/Modified
+#     markdown/text file for IP-disclosure markers.
+#   * Fails the check if either layer hits.
+#
+# Override path:
+#   No runtime override. Adjusting patterns requires editing this workflow
+#   AND the helper script at scripts/ci/ip_content_scan.py.
+#
+# This is the P1 measure in the leak-prevention rollout (P0 = path-deny;
+# P1 = this; P2 = ADR visibility frontmatter; P3 = structural .gsm/decisions
+# removal).
+
+name: IP Content Gate
+
+on:
+  pull_request:
+    branches: [master, main]
+  push:
+    branches: [master, main]
+
+permissions:
+  contents: read
+
+jobs:
+  ip-content:
+    name: ip-content-gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Compute changed paths
+        id: changed
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          else
+            base="${{ github.event.before }}"
+            head="${{ github.event.after }}"
+            if [ "$base" = "0000000000000000000000000000000000000000" ]; then
+              base=$(git rev-list --max-parents=0 HEAD | head -1)
+            fi
+          fi
+          for sha in "$base" "$head"; do
+            if ! [[ "$sha" =~ ^[a-f0-9]{7,64}$ ]]; then
+              echo "::error::Invalid SHA format: $sha"
+              exit 1
+            fi
+          done
+          echo "Comparing $base..$head"
+          # NUL-delimited, Added or Modified only.
+          git diff --diff-filter=AM --name-only -z "$base...$head" > /tmp/ip-changed.nul
+          count=$(tr -cd '\0' < /tmp/ip-changed.nul | wc -c)
+          echo "Added/modified path count: $count"
+
+      - name: Run IP content scan
+        run: |
+          python scripts/ci/ip_content_scan.py /tmp/ip-changed.nul

--- a/scripts/ci/ip_content_scan.py
+++ b/scripts/ci/ip_content_scan.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""IP Content Scanner — fail fast on self-disclosing IP/patent meta-documents.
+
+Used by .github/workflows/ip-content-gate.yml. Reads NUL-delimited Added/Modified
+paths from the file given as argv[1], scans each one against a filename deny-list
+and a first-100-lines content deny-list, and exits non-zero on any match.
+
+Motivating example: ADR-151 (removed in PR #130). 62-line markdown placeholder
+that named patent EP26167849.4, called a pattern "potentially novel", and listed
+TS-1..TS-4 by label — all in the first 5 lines. Existing IP gate checked for
+literal TS values, missed it. This scanner catches the meta-disclosure class.
+
+Patterns are intentionally conservative: each one targets a phrase that would
+not normally appear in legitimate public-facing markdown. False positives are
+preferable to false negatives for IP risk.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+# Layer 1: filename patterns. Case-insensitive on the basename.
+# Any match → block.
+FILENAME_DENY = [
+    re.compile(r"-ip-flag", re.IGNORECASE),
+    re.compile(r"\bip[-_]review\b", re.IGNORECASE),
+    re.compile(r"\bpatent[-_]?(draft|claim|filing|note)", re.IGNORECASE),
+    re.compile(r"\btrade[-_]secret", re.IGNORECASE),
+    re.compile(r"\bts[-_]\d+\b", re.IGNORECASE),
+]
+
+
+# Layer 2: content patterns. Scanned against the first 100 lines of any
+# Added/Modified text file (extensions: .md .txt .rst .adoc, plus README*).
+# Any single match → block.
+CONTENT_DENY = [
+    # Patent-document self-references
+    (re.compile(r"^\s*\*?\*?Patent Reference:\*?\*?", re.MULTILINE), "Patent Reference: header"),
+    (re.compile(r"FLAGGED\s+FOR\s+IP\s+REVIEW", re.IGNORECASE), "FLAGGED FOR IP REVIEW status"),
+    (re.compile(r"\bClaims?\s+[A-Z]+(?:[-,]\s*[A-Z]+)+\b"), "Claim-letter range (e.g. Claims K-O)"),
+    (re.compile(r"\bpending\s+counsel\b", re.IGNORECASE), "pending counsel"),
+    (re.compile(r"\bpatent\s+counsel\b", re.IGNORECASE), "patent counsel"),
+    (re.compile(r"\bdefensive\s+publication\b", re.IGNORECASE), "defensive publication"),
+
+    # Self-disclosing novelty language (the ADR-151 fingerprint)
+    (re.compile(r"\bpotentially\s+novel\b", re.IGNORECASE), "potentially novel"),
+    (re.compile(r"\bnovel\s+architectural\s+pattern\b", re.IGNORECASE), "novel architectural pattern"),
+    (re.compile(r"strengthens\s+the\s+\w+\s+patent\s+narrative", re.IGNORECASE), "strengthens patent narrative"),
+
+    # Patent application numbers (EP, WO, US format)
+    (re.compile(r"\bEP\s?\d{6,}(?:\.\d+)?\b"), "European patent application number"),
+    (re.compile(r"\bWO\s?\d{4}/\d{4,}\b"), "WIPO patent application number"),
+    (re.compile(r"\bUS\s?\d{4}/\d{6,}\b"), "US patent application number"),
+
+    # Trade-secret label by name (without quoting any value)
+    (re.compile(r"\bTS-[1-9]\b(?:\s*\.\.\s*TS-[1-9]\b)?"), "TS-N trade-secret label"),
+    (re.compile(r"\btrade[-\s]?secret\s+(label|boundary|protection)\b", re.IGNORECASE), "trade-secret label/boundary/protection"),
+
+    # Internal classification keywords that should never be on public
+    (re.compile(r"\bINTERNAL\s+ONLY\b"), "INTERNAL ONLY classification"),
+    (re.compile(r"\bCONFIDENTIAL\s*[—-]\s*DO\s+NOT\s+DISTRIBUTE\b", re.IGNORECASE), "CONFIDENTIAL — DO NOT DISTRIBUTE"),
+]
+
+
+# File extensions the content scan applies to. Other extensions skip Layer 2
+# (Layer 1 still applies to any extension).
+TEXT_EXTENSIONS = {".md", ".txt", ".rst", ".adoc", ".markdown"}
+
+CONTENT_SCAN_LINES = 100
+
+# Cap content reads at 1 MB. A markdown header/metadata block does not need
+# more than this. Bounds CI cost and prevents resource-exhaustion if a path
+# from `git diff` somehow points to a very large file.
+MAX_FILE_SIZE_BYTES = 1 * 1024 * 1024
+
+
+def iter_paths(nul_file: Path) -> list[str]:
+    """Read NUL-delimited paths from a file."""
+    raw = nul_file.read_bytes()
+    return [p.decode("utf-8", errors="replace") for p in raw.split(b"\x00") if p]
+
+
+def check_filename(path: str) -> list[str]:
+    """Return list of FILENAME_DENY pattern descriptions that match this path."""
+    name = Path(path).name
+    return [pat.pattern for pat in FILENAME_DENY if pat.search(name)]
+
+
+def _is_safe_repo_path(path: str, repo_root: Path) -> bool:
+    """Reject paths that escape the repo root or are absolute.
+
+    Defensive: `git diff --diff-filter=AM --name-only` should only emit
+    repo-relative paths for tracked files, but anchor explicitly so that
+    a malicious or malformed path cannot reach outside the repo.
+    """
+    p = Path(path)
+    if p.is_absolute():
+        return False
+    try:
+        resolved = (repo_root / p).resolve(strict=False)
+        return resolved.is_relative_to(repo_root.resolve())
+    except (OSError, ValueError):
+        return False
+
+
+def check_content(path: str, repo_root: Path) -> list[tuple[str, int]]:
+    """Return list of (description, line_number) for content matches.
+
+    Returns empty list if file unreadable, escapes repo root, exceeds size
+    cap, or extension not in TEXT_EXTENSIONS.
+    """
+    if not _is_safe_repo_path(path, repo_root):
+        return []
+    p = repo_root / path
+    if p.suffix.lower() not in TEXT_EXTENSIONS:
+        return []
+    if not p.exists():
+        # Path may be added in the diff but not on disk yet (rare in CI checkout
+        # since fetch-depth: 0 should have it). Treat as empty.
+        return []
+    try:
+        size = p.stat().st_size
+    except OSError:
+        return []
+    if size > MAX_FILE_SIZE_BYTES:
+        # Refuse to scan oversized files. Block-by-default would be too noisy
+        # for legitimate large docs; Layer 1 (filename) still applies to them.
+        print(f"  (skipped content scan: {path} exceeds {MAX_FILE_SIZE_BYTES} bytes)")
+        return []
+    try:
+        text = p.read_text(encoding="utf-8", errors="replace")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    head = "\n".join(text.splitlines()[:CONTENT_SCAN_LINES])
+    hits: list[tuple[str, int]] = []
+    for pat, desc in CONTENT_DENY:
+        for m in pat.finditer(head):
+            line_no = head.count("\n", 0, m.start()) + 1
+            hits.append((desc, line_no))
+    return hits
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: ip_content_scan.py <nul-delimited-paths-file>", file=sys.stderr)
+        return 2
+
+    repo_root = Path.cwd().resolve()
+
+    paths = iter_paths(Path(argv[1]))
+    if not paths:
+        print("IP Content Gate: no Added/Modified paths to scan.")
+        return 0
+
+    print(f"IP Content Gate: scanning {len(paths)} path(s)")
+
+    violations: list[str] = []
+
+    for path in paths:
+        # Layer 1
+        fname_hits = check_filename(path)
+        for hit in fname_hits:
+            violations.append(f"FILENAME: '{path}' matches deny pattern /{hit}/")
+
+        # Layer 2
+        content_hits = check_content(path, repo_root)
+        for desc, line_no in content_hits:
+            violations.append(f"CONTENT:  '{path}' line {line_no}: {desc}")
+
+    if violations:
+        print()
+        print("::error::IP Content Gate BLOCKED — IP-disclosure markers detected:")
+        for v in violations:
+            print(f"::error::  {v}")
+        print()
+        print("These markers indicate the file may be an internal IP/patent")
+        print("meta-document that should not be on a public repo. Common cases:")
+        print("  - ADR with 'FLAGGED FOR IP REVIEW' header")
+        print("  - Patent application reference (EP/WO/US numbers)")
+        print("  - Self-disclosing novelty language ('potentially novel', etc.)")
+        print("  - Trade-secret labels (TS-1..TS-N) named without quoting values")
+        print()
+        print("Resolution:")
+        print("  1. If the document is internal: move it to the private repo.")
+        print("  2. If the language is overstated: rephrase without IP markers.")
+        print("  3. If counsel has cleared this content: contact repo maintainer")
+        print("     to record the exception in scripts/ci/ip_content_scan.py.")
+        return 1
+
+    print("IP Content Gate: PASS — no IP-disclosure markers found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
# P1 — IP Content Gate (filename + content scan)

Adds a CI gate that catches the **semantic class** of IP leak that all existing gates miss: meta-documents that talk *about* patents, IP review status, or trade-secret labels without quoting any actual trade-secret value.

## Motivating example

ADR-151 (removed in PR #130). 62-line markdown placeholder with:
- patent reference `EP26167849.4`
- "FLAGGED FOR IP REVIEW" status field
- "potentially novel" language
- TS-1..TS-4 listed by label

All in the **first 5 lines**. Existing `ip-protection-gate` scanned for *literal* TS-1..TS-6 values; ADR-151 mentioned the labels but never quoted a value. It passed every gate. This PR closes that gap.

## What lands

| File | Lines | Purpose |
|---|---|---|
| `.github/workflows/ip-content-gate.yml` | +85 | CI entry point — SHA validation, NUL-delimited diff, invokes the helper |
| `scripts/ci/ip_content_scan.py` | +199 | Two-layer scan: filename regex + first-100-lines content regex |

Total: 2 new files, +284 lines, 0 deletions, 0 modifications to existing files.

## Two-layer scan

**Layer 1 — filename regex (case-insensitive):**
- `*-ip-flag*`
- `*ip-review*`
- `patent-draft|patent-claim|patent-filing|patent-note`
- `trade-secret`
- `ts-N` (where N is 1-9)

**Layer 2 — first-100-lines content scan** (`.md`/`.txt`/`.rst`/`.adoc`/`.markdown` only):
- `Patent Reference:` header
- `FLAGGED FOR IP REVIEW` status
- `Claim-letter ranges` (`Claims K-O`, etc.)
- `pending counsel` / `patent counsel`
- `defensive publication`
- `potentially novel` / `novel architectural pattern`
- `strengthens [X] patent narrative`
- EP/WO/US patent application numbers
- `TS-N` labels named without context
- `trade-secret label/boundary/protection` phrases
- `INTERNAL ONLY` classification
- `CONFIDENTIAL — DO NOT DISTRIBUTE`

## Self-test results

| Input | Hits | Exit |
|---|---|---|
| ADR-151 (full content) | 15 markers across 7 patterns | 1 (BLOCKED) ✅ |
| 16 legitimate public md files (README, CHANGELOG, GRAQ, QUICKSTART, MIGRATION, SECURITY, CLAUDE, …) | 0 | 0 (PASS) ✅ |
| Adversarial path-traversal (`../../../etc/passwd`, `/etc/shadow`) | silently skipped | 0 (PASS) ✅ |

**Zero false positives across the entire current public tree.**

## Hardening applied (sentinel-driven)

`graq_review focus=security` raised 5 findings; 2 were legitimate and addressed in this version:

1. **Path-traversal defensive anchor** — `_is_safe_repo_path()` rejects absolute paths and paths that resolve outside repo root via `Path.resolve().is_relative_to(repo_root.resolve())`. Layer 1 (filename) still applies; only Layer 2 (content read) is gated.
2. **1 MB content-scan size cap** — bounds CI cost and removes any DoS vector from oversized files.

The other 3 findings were either already addressed (SHA validation lines 71-76, `permissions: contents: read` line 35, exception handling for OSError/UnicodeDecodeError) or sentinel hallucinations ("source code wasn't provided" — full diff was supplied).

## Scope guarantees

- **Public-only gate.** NOT mirrored to private (where IP-flagged R&D docs legitimately exist).
- No code change in any package file. No test change. No PyPI artefact change.
- No version bump. No release implication.
- Layer 2 only reads files; never writes anything anywhere.

## Process exception (ABSOLUTE RULE #0)

Direct public PR. Same exception class as PR #131 (cleanup batch) and PR #133 (P0 path-deny). Public-only by design — installing on private would block legitimate IP/patent R&D documentation. Logged in OPEN-TRACKER.

## What this enables

After merge, the next ADR-151-class document — patent-disclosing markdown without TS-value strings — will be **caught at PR time**, before merge. Combined with P0 (path-deny on `.claude/.gcc/.gsm/.graqle/`), the two gates cover both *where* and *what*.

## Follow-ups

- **P2** — ADR visibility frontmatter requirement (`visibility: public|private` mandatory header on every ADR file)
- **P3** — structural removal of `.gsm/decisions/` from public tree entirely

## Verification path

After merge, the gate runs on every subsequent PR. The first real test is its own merge commit — should be `success` (no IP markers in this PR's content).
