### PR TITLE
v0.57.2: deploy-lambda neo4j fix + compliance HTTP routes (CR-013 + CR-014)

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -131,13 +131,23 @@ jobs:
         run: |
           mkdir -p build/lambda
 
-          # Install deps for Linux Lambda runtime
+          # Install deps for Linux Lambda runtime.
+          # NOTE (CR-013, 2026-05-17): neo4j + cryptography + jsonschema +
+          # pyshacl + rdflib added explicitly. Without neo4j, traversal/hubs
+          # returns 500 (Neptune speaks Bolt). Without the others, v0.57.0
+          # compliance modules silently fail at import time, dropping their
+          # route registration. The graqle[api] extra in pyproject.toml
+          # already declares these, but this workflow hand-rolls a flat
+          # pip-install list and doesn't consult the [api] extra.
+          # TODO: switch to `pip install -e .[api] --target build/lambda`
+          # in a follow-on CR once the manylinux constraints are sorted.
           pip install --target build/lambda \
             --platform manylinux2014_x86_64 --only-binary=:all: \
             --python-version 3.10 --implementation cp \
             mangum fastapi uvicorn jinja2 pydantic pydantic-settings \
             pyyaml typer rich networkx numpy httpx anthropic openai \
-            requests
+            requests \
+            neo4j cryptography jsonschema pyshacl rdflib
 
           # Copy graqle source (not pip-installed — use repo version)
           cp -r graqle/ build/lambda/graqle/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## 0.57.2 (2026-05-17) - [cr-014 Compliance HTTP route surfacing]
+
+> **Surfaces the EU AI Act subsystem envelope as Studio HTTP endpoints.** The `graqle.compliance.switch_status.build_switch_status()` function shipped in v0.57.0 as a Python module + CLI command (`graq compliance switch status`), but there was no HTTP route to expose it to the Studio frontend / graqle.com /security page. v0.57.2 adds two routes that read-only wrap the same builder.
+
+### Added
+
+- **`graqle.studio.routes.compliance` module** (new). Mounts `/studio/api/compliance/switch/status` and `/studio/api/compliance/status` HTTP endpoints. Both call `graqle.compliance.switch_status.build_switch_status()` and return the JSON envelope. Fail-closed exception handler returns `schema_version: "1.0"` + structured error body on any internal failure (never raises). Backs the canonical capability statement on graqle.com that "one switch flips every subsystem at once".
+
+- **Studio app mounts `compliance_router` at `/studio/api/compliance`** in `graqle/studio/app.py`. No other route changes.
+
+### Notes
+
+- v0.57.2 is **functionally identical** to v0.57.1 except for the two new HTTP endpoints. No CLI changes, no compliance semantics changes. The same envelope that `graq compliance switch status --format json` already returned is now also reachable over HTTP.
+
+---
+
 ## 0.57.1 (2026-05-17) - [cr-011 Studio backend restoration]
 
 > **Bundled hotfix for three independent regressions found in the post-v0.57.0 Studio + Lambda audit.** Marketing on graqle.com advertised v0.57.0 + EU AI Act alignment but live curl of the production Lambda found `/studio/api/graph/visualization` returning HTTP 502 (response > 6 MB Lambda sync cap) and `/studio/api/traversal/hubs` returning HTTP 500 (`ModuleNotFoundError: neo4j` — the Neptune/Neo4j Bolt driver missing because v0.57.0 wheel ships `neo4j` only in `[all]`/`[all-gpu]` extras, not `[api]`, while the Lambda installs `[api]`). User-facing graph viz + traversal restored.

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.57.1"
+__version__ = "0.57.2"

--- a/graqle/studio/app.py
+++ b/graqle/studio/app.py
@@ -31,6 +31,7 @@ def mount_studio(app: Any, state: dict) -> None:
     from fastapi.templating import Jinja2Templates
 
     from graqle.studio.routes.api import router as api_router
+    from graqle.studio.routes.compliance import router as compliance_router
     from graqle.studio.routes.control import router as control_router
     from graqle.studio.routes.dashboard import router as dashboard_router
     from graqle.studio.routes.governance import router as governance_router
@@ -56,6 +57,7 @@ def mount_studio(app: Any, state: dict) -> None:
     app.include_router(traversal_router, prefix="/studio/api/traversal")
     app.include_router(control_router, prefix="/studio/api/control")
     app.include_router(learning_router, prefix="/studio/api/learning")
+    app.include_router(compliance_router, prefix="/studio/api/compliance")
     app.include_router(auto_router, prefix="/studio")
 
     # Ring-fence guard: Studio routes are read-only on the knowledge graph.

--- a/graqle/studio/routes/compliance.py
+++ b/graqle/studio/routes/compliance.py
@@ -1,0 +1,79 @@
+"""Studio compliance routes — HTTP wrappers for EU AI Act subsystem status.
+
+Surface the `graq compliance switch status` CLI output as JSON endpoints
+so the graqle.com /security page and Studio dashboard can show the
+live armed/disarmed state of every EU AI Act subsystem.
+
+Backs the canonical capability statement on graqle.com:
+"EU AI Act-aligned by design - every shipped capability traces to a
+specific Article. One switch flips every subsystem at once."
+
+Module: graqle.studio.routes.compliance
+Risk: LOW (read-only, no graph state, no LLM calls)
+"""
+
+# graqle:intelligence
+# module: graqle.studio.routes.compliance
+# risk: LOW (impact radius: 0 modules)
+# constraints: none
+# /graqle:intelligence
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@router.get("/switch/status")
+async def switch_status() -> JSONResponse:
+    """Return the EU AI Act master-switch + 7-subsystem envelope.
+
+    Wraps graqle.compliance.switch_status.build_switch_status(). Every
+    probe is fail-closed inside the module - this endpoint must never raise.
+    """
+    try:
+        from graqle.compliance.switch_status import build_switch_status
+        envelope = build_switch_status()
+        return JSONResponse(envelope)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("switch_status failed unexpectedly")
+        return JSONResponse(
+            {
+                "schema_version": "1.0",
+                "error": "switch_status_unavailable",
+                "detail": str(exc)[:200],
+            },
+            status_code=500,
+        )
+
+
+@router.get("/status")
+async def compliance_status() -> JSONResponse:
+    """Return the consolidated compliance status envelope.
+
+    Currently mirrors switch_status. Reserved for future expansion to
+    include baseline-doc / periodic-assessment / feedback-trend recent
+    activity summaries (per CG-MKT roadmap).
+    """
+    try:
+        from graqle.compliance.switch_status import build_switch_status
+        envelope = build_switch_status()
+        return JSONResponse({
+            "schema_version": "1",
+            "eu_ai_act_subsystems": envelope,
+        })
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("compliance_status failed unexpectedly")
+        return JSONResponse(
+            {
+                "schema_version": "1",
+                "error": "compliance_status_unavailable",
+                "detail": str(exc)[:200],
+            },
+            status_code=500,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.57.1"
+version = "0.57.2"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Proprietary — see LICENSE"}


### PR DESCRIPTION
## Summary

Bundled v0.57.2 release containing two private-merged hotfixes that complete the v0.57.1 audit's remaining findings:

| Private PR | Commit | Purpose |
|---|---|---|
| [#122](https://github.com/quantamixsol/research-development-graqle/pull/122) | `2fac6602` | CR-013: deploy-lambda.yml neo4j + compliance-module deps |
| [#123](https://github.com/quantamixsol/research-development-graqle/pull/123) | `c81cf710` | CR-014: HTTP routes for compliance/switch/status |

## What this fixes

After v0.57.1 + Lambda redeploy (15:18 UTC), only **1 of 3** advertised v0.57.0 features was live:

| Endpoint | After v0.57.1 (now) | After v0.57.2 (this PR) |
|---|---|---|
| `/studio/api/graph/visualization` | ✅ 200 (SF-05 already fixed) | ✅ 200 |
| `/studio/api/traversal/hubs` | ❌ 500 — `ModuleNotFoundError: neo4j` | ✅ 200 |
| `/studio/api/compliance/switch/status` | ❌ 404 — route never existed | ✅ 200 with 7-subsystem envelope |
| `/studio/api/compliance/status` | ❌ 404 | ✅ 200 (wrapped envelope) |

## Root causes (caught in v0.57.1 post-deploy verification)

**CR-013:** `deploy-lambda.yml` hand-rolls a flat `pip install` list at line 138 and does **NOT** consult any `graqle[api]` extra. So CR-011's `neo4j>=5.0` addition to `[api]` had **zero effect** on the deployed Lambda. Same applies to `cryptography`, `jsonschema`, `pyshacl`, `rdflib` — all required at import time by the v0.57.0 compliance modules; without them, route registration silently fails and endpoints return 404.

**CR-014:** `graqle.compliance.switch_status.build_switch_status()` shipped in v0.57.0 as a Python module + Typer CLI command, but **no HTTP route file ever existed**. The 404 wasn't a bug — the endpoint just didn't exist. This CR adds `graqle/studio/routes/compliance.py` (2 routes, 79 LOC) that wrap the existing builder.

## Changes (6 files, 111 ins / 4 del)

| File | Change |
|---|---|
| `.github/workflows/deploy-lambda.yml` | +5 packages on pip-install line (CR-013) |
| `graqle/studio/routes/compliance.py` | NEW — 79 LOC, 2 read-only routes |
| `graqle/studio/app.py` | +2 lines (import + include_router) |
| `pyproject.toml` | 0.57.1 → 0.57.2 |
| `graqle/__version__.py` | 0.57.1 → 0.57.2 |
| `CHANGELOG.md` | +16 lines (v0.57.2 entry) |

## Test plan

- [x] Cherry-pick verified clean (6 files, 111 ins / 4 del)
- [x] Local smoke test of compliance routes: 200 OK + 7 subsystems present
- [x] Lambda deploy workflow change verified (neo4j present on pip-install line)
- [x] Studio app.py mounts `compliance_router` at `/studio/api/compliance`
- [ ] CI green on this PR
- [ ] After merge: tag v0.57.2, PyPI OIDC publishes, Lambda auto-redeploy
- [ ] After redeploy: `python graqle-sdk/.gcc/verify_studio_backend.py --version 0.57.2` returns **8/8 PASS**

## ABSOLUTE RULE #0 compliance

- Private merges first: CR-013 `d625139f` (15:36:23 UTC), CR-014 `6686c91c` (15:36:42 UTC)
- This public PR is a clean cherry-pick of those two private commits
- Public master not touched until this PR merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)