### PR TITLE
v0.57.3: read NEPTUNE_ENDPOINT env for Neo4j Bolt URI (SF-06 / CR-015)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## 0.57.3 (2026-05-17) - [cr-015 Neptune URI from environment variable]
+
+> **Fixes `/studio/api/traversal/hubs` HTTP 500 on the production Lambda.** v0.57.2 added the `neo4j` Bolt driver to the Lambda zip (CR-013), but `graqle.server.app` still passed `graph_cfg.uri = bolt://localhost:7687` to `Neo4jTraversal()`, so every traversal query hit `ConnectionRefusedError: [Errno 111] Connection refused` against localhost on the Lambda. v0.57.3 reads `NEPTUNE_ENDPOINT` + `NEPTUNE_PORT` env vars at app-startup and constructs a proper `bolt+s://endpoint:8182` URI for Neptune. Falls back to `graph_cfg.uri` when `NEPTUNE_ENDPOINT` is empty (local Neo4j + test environments unchanged).
+
+### Fixed
+
+- **`graqle/server/app.py` Neptune URI construction** (SF-06). When `NEPTUNE_ENDPOINT` env var is present, build `bolt+s://{endpoint}:{NEPTUNE_PORT or 8182}` for the `Neo4jTraversal` connector instead of consulting `graph_cfg.uri` (which defaults to `bolt://localhost:7687` from `graqle.yaml`). Restores `/studio/api/traversal/hubs` from HTTP 500 to 200 on AWS Lambda after redeploy.
+
+### Notes
+
+- v0.57.3 is **functionally identical** to v0.57.2 except for the Neptune URI override path. Local development with Neo4j desktop or `docker run neo4j` (no `NEPTUNE_ENDPOINT` env var) continues to use the existing `graph_cfg.uri` flow. No breaking change.
+
+---
+
 ## 0.57.2 (2026-05-17) - [cr-014 Compliance HTTP route surfacing]
 
 > **Surfaces the EU AI Act subsystem envelope as Studio HTTP endpoints.** The `graqle.compliance.switch_status.build_switch_status()` function shipped in v0.57.0 as a Python module + CLI command (`graq compliance switch status`), but there was no HTTP route to expose it to the Studio frontend / graqle.com /security page. v0.57.2 adds two routes that read-only wrap the same builder.

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.57.2"
+__version__ = "0.57.3"

--- a/graqle/server/app.py
+++ b/graqle/server/app.py
@@ -278,17 +278,44 @@ def create_app(
             # Track Neptune availability for cross-project queries
             state["neptune_enabled"] = neptune_enabled or state.get("neptune_project_id") is not None
 
-            # Initialize Neo4j traversal engine if Neo4j is configured
+            # Initialize Neo4j traversal engine if Neo4j is configured.
+            #
+            # SF-06 (CR-015, 2026-05-17): On AWS Lambda the connector points
+            # to Amazon Neptune (Bolt-compatible) via the NEPTUNE_ENDPOINT
+            # environment variable, not localhost. Without this override the
+            # traversal engine connects to bolt://localhost:7687, fails with
+            # ConnectionRefusedError, and /studio/api/traversal/hubs returns
+            # HTTP 500. We construct the Neptune URI from env vars when
+            # NEPTUNE_ENDPOINT is set, falling back to graph_cfg.uri for
+            # local Neo4j + tests.
             connector = getattr(getattr(state["config"], "graph", None), "connector", "networkx")
             if connector == "neo4j":
                 try:
+                    import os as _os
                     from graqle.connectors.neo4j_traversal import Neo4jTraversal
                     graph_cfg = state["config"].graph
+
+                    neptune_endpoint = _os.environ.get("NEPTUNE_ENDPOINT", "").strip()
+                    if neptune_endpoint:
+                        neptune_port = _os.environ.get("NEPTUNE_PORT", "8182").strip() or "8182"
+                        # Neptune Bolt requires TLS (bolt+s://) and IAM auth
+                        # is handled by the AWS SDK / neptune driver layer.
+                        bolt_uri = f"bolt+s://{neptune_endpoint}:{neptune_port}"
+                        bolt_user = ""
+                        bolt_pass = ""
+                        bolt_db = "neo4j"
+                        logger.info("Neo4j traversal using Neptune endpoint: %s", bolt_uri)
+                    else:
+                        bolt_uri = getattr(graph_cfg, "uri", None) or "bolt://localhost:7687"
+                        bolt_user = getattr(graph_cfg, "username", None) or "neo4j"
+                        bolt_pass = getattr(graph_cfg, "password", None) or ""
+                        bolt_db = getattr(graph_cfg, "database", None) or "neo4j"
+
                     state["neo4j_traversal"] = Neo4jTraversal(
-                        uri=getattr(graph_cfg, "uri", None) or "bolt://localhost:7687",
-                        username=getattr(graph_cfg, "username", None) or "neo4j",
-                        password=getattr(graph_cfg, "password", None) or "",
-                        database=getattr(graph_cfg, "database", None) or "neo4j",
+                        uri=bolt_uri,
+                        username=bolt_user,
+                        password=bolt_pass,
+                        database=bolt_db,
                     )
                     logger.info("Neo4j traversal engine initialized")
                 except Exception as te:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.57.2"
+version = "0.57.3"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Proprietary — see LICENSE"}


### PR DESCRIPTION
Single-file fix completing v0.57.x studio backend trilogy. CR-013 (v0.57.2) added neo4j driver to Lambda zip but Neo4jTraversal was still constructed with graph_cfg.uri='bolt://localhost:7687'. CloudWatch confirmed: 'neo4j.exceptions.ServiceUnavailable: ConnectionRefusedError to 127.0.0.1:7687'. v0.57.3 reads NEPTUNE_ENDPOINT + NEPTUNE_PORT env vars and builds bolt+s://endpoint:8182 URI. Falls back to graph_cfg.uri when env empty (local Neo4j + tests unchanged). 4 files, 48 ins / 7 del. Cherry-pick of private PR #124 (commit 624e5329). Branched off origin/master c55f57f9. Will restore /studio/api/traversal/hubs from 500 to 200 after Lambda redeploy. The 6/7 currently-green endpoints will NOT regress (fallback logic identical to current code when env var empty).