### PR TITLE
v0.57.4: SF-07 per-project graph routing across studio routes

### DIFF
--- a/graqle/studio/routes/api.py
+++ b/graqle/studio/routes/api.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import math
+import re
 
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
@@ -130,6 +131,44 @@ async def _load_project_graph(request: Request, project: str):
         return None
 
 
+# Project name validation: reject path traversal, separators, and control chars.
+# Project names are user-supplied (``x-project-name`` header) and are interpolated
+# into an S3 key in :func:`_load_project_graph` — see SF-07 sentinel MAJOR #1.
+_PROJECT_NAME_RE = re.compile(r"\A[A-Za-z0-9._\- ]{1,128}\Z")
+
+
+async def _resolve_graph_for_request(request: Request):
+    """Resolve the appropriate Graqle graph for an HTTP request (SF-07, v0.57.4).
+
+    Reads the ``x-project-name`` header. If present and well-formed, returns
+    the project-specific graph from S3 (cached after first load via
+    :func:`_load_project_graph`). If the header is absent, malformed, or the
+    project load fails for any reason, falls back to the Lambda's default
+    graph at ``state["graph"]``.
+
+    This is the single source of truth for graph routing across all studio
+    routes. Behaviour is byte-identical to the prior ``state.get("graph")``
+    when the header is absent — see SF-07 / CR-022.
+
+    Validation: project name must match ``[A-Za-z0-9._\\- ]{1,128}``.
+    Rejected names log a warning and fall through to the default graph.
+    """
+    state = request.app.state.studio_state
+    project = request.headers.get("x-project-name")
+    if not project:
+        return state.get("graph")
+    if not _PROJECT_NAME_RE.match(project):
+        logger.warning("SF-07: rejecting malformed x-project-name header (%d chars)", len(project))
+        return state.get("graph")
+    try:
+        project_graph = await _load_project_graph(request, project)
+        if project_graph is not None:
+            return project_graph
+    except Exception as exc:
+        logger.warning("SF-07: project graph load failed for %r: %s", project, exc)
+    return state.get("graph")
+
+
 # ---------- Cross-project federation ----------
 
 
@@ -226,7 +265,7 @@ async def project_context(request: Request):
     Used by TopBar badge and Dashboard project card to show which graph is loaded.
     """
     state = request.app.state.studio_state
-    graph = state.get("graph")
+    graph = await _resolve_graph_for_request(request)
     if graph is not None:
         ctx = graph.project_context()
         ctx["graph_loaded"] = True
@@ -308,7 +347,7 @@ async def graph_visualization(
     "viewing N of M" hints to the user.
     """
     state = request.app.state.studio_state
-    graph = state.get("graph")
+    graph = await _resolve_graph_for_request(request)
     if not graph:
         return {
             "nodes": [],
@@ -421,7 +460,7 @@ async def graph_visualization_filtered(
     from pathlib import Path
 
     state = request.app.state.studio_state
-    graph = state.get("graph")
+    graph = await _resolve_graph_for_request(request)
     if not graph:
         return {"nodes": [], "links": [], "strategy": strategy, "total_before": 0}
 
@@ -619,7 +658,7 @@ async def graph_nodes(
 ):
     """Paginated node list with search and type filter."""
     state = request.app.state.studio_state
-    graph = state.get("graph")
+    graph = await _resolve_graph_for_request(request)
     if not graph:
         return {"nodes": [], "total": 0}
 
@@ -651,7 +690,7 @@ async def graph_nodes(
 async def graph_node_detail(request: Request, node_id: str):
     """Single node detail with neighbors."""
     state = request.app.state.studio_state
-    graph = state.get("graph")
+    graph = await _resolve_graph_for_request(request)
     if not graph or node_id not in graph.nodes:
         return {"error": "Node not found"}
 
@@ -720,7 +759,7 @@ async def reason_stream(request: Request):
     project = body.get("project")  # User's selected project
 
     state = request.app.state.studio_state
-    graph = state.get("graph")
+    graph = await _resolve_graph_for_request(request)
 
     # Per-project graph loading: if a project is specified and we have S3 access,
     # load that project's graph instead of the default Lambda graph.
@@ -866,7 +905,7 @@ async def governance_stats(request: Request):
         violation_count = None
         auto_correction_rate = None
 
-    graph = state.get("graph")
+    graph = await _resolve_graph_for_request(request)
     protected_files_count = None
     try:
         if graph is not None and hasattr(graph, "nodes"):
@@ -896,7 +935,7 @@ async def governance_stats(request: Request):
 async def partial_metrics_cards(request: Request):
     """Auto-refreshing metrics cards fragment."""
     state = request.app.state.studio_state
-    graph = state.get("graph")
+    graph = await _resolve_graph_for_request(request)
     metrics = state.get("metrics")
 
     node_count = len(graph.nodes) if graph else 0
@@ -944,7 +983,7 @@ async def partial_metrics_cards(request: Request):
 async def partial_node_detail(request: Request, node_id: str):
     """Node detail panel for HTMX."""
     state = request.app.state.studio_state
-    graph = state.get("graph")
+    graph = await _resolve_graph_for_request(request)
     if not graph or node_id not in graph.nodes:
         return "<div class='node-detail'><p>Node not found</p></div>"
 
@@ -1026,7 +1065,7 @@ async def settings_view(request: Request):
     """Return read-only config for the Studio settings page."""
     state = request.app.state.studio_state
     config = state.get("config")
-    graph = state.get("graph")
+    graph = await _resolve_graph_for_request(request)
 
     node_count = len(getattr(graph, "nodes", {})) if graph else 0
     edge_count = len(getattr(graph, "edges", {})) if graph else 0
@@ -1092,7 +1131,7 @@ async def lessons(
     Free plan: lessons from local graph only.
     """
     state = request.app.state.studio_state
-    graph = state.get("graph")
+    graph = await _resolve_graph_for_request(request)
     if not graph:
         return JSONResponse({"lessons": [], "count": 0, "source": "no_graph"})
 
@@ -1160,7 +1199,7 @@ async def neptune_upload(request: Request):
     """
     import time
     state = request.app.state.studio_state
-    graph = state.get("graph")
+    graph = await _resolve_graph_for_request(request)
     if not graph:
         return JSONResponse({"error": "No graph loaded in memory"}, status_code=400)
 

--- a/tests/test_studio/test_resolve_graph_for_request.py
+++ b/tests/test_studio/test_resolve_graph_for_request.py
@@ -1,0 +1,124 @@
+"""Tests for the SF-07 _resolve_graph_for_request helper (CR-022, v0.57.4)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from graqle.studio.routes.api import _PROJECT_NAME_RE, _resolve_graph_for_request
+
+
+def _make_request(headers: dict | None = None, default_graph=None):
+    """Build a minimal request mock with studio_state attached to app.state."""
+    request = MagicMock()
+    request.headers = headers or {}
+    request.app.state.studio_state = {"graph": default_graph}
+    return request
+
+
+class TestResolveGraphForRequest:
+
+    @pytest.mark.asyncio
+    async def test_no_header_returns_default_graph(self):
+        sentinel = object()
+        request = _make_request(headers={}, default_graph=sentinel)
+        result = await _resolve_graph_for_request(request)
+        assert result is sentinel
+
+    @pytest.mark.asyncio
+    async def test_empty_header_returns_default_graph(self):
+        sentinel = object()
+        request = _make_request(headers={"x-project-name": ""}, default_graph=sentinel)
+        result = await _resolve_graph_for_request(request)
+        assert result is sentinel
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad_name",
+        [
+            "../../etc/passwd",
+            "project/subpath",
+            "foo\\bar",
+            "name\x00null",
+            "x" * 200,  # too long
+            "",  # zero length (also caught by "not project" guard)
+        ],
+    )
+    async def test_malformed_header_falls_back_to_default(self, bad_name):
+        sentinel = object()
+        request = _make_request(headers={"x-project-name": bad_name}, default_graph=sentinel)
+        result = await _resolve_graph_for_request(request)
+        assert result is sentinel
+
+    @pytest.mark.asyncio
+    async def test_load_raises_falls_back_to_default(self):
+        sentinel = object()
+        request = _make_request(
+            headers={"x-project-name": "Brand_Collaboration"}, default_graph=sentinel
+        )
+        with patch(
+            "graqle.studio.routes.api._load_project_graph",
+            new=AsyncMock(side_effect=RuntimeError("S3 IAM denied")),
+        ):
+            result = await _resolve_graph_for_request(request)
+        assert result is sentinel
+
+    @pytest.mark.asyncio
+    async def test_load_returns_none_falls_back_to_default(self):
+        sentinel = object()
+        request = _make_request(
+            headers={"x-project-name": "Brand_Collaboration"}, default_graph=sentinel
+        )
+        with patch(
+            "graqle.studio.routes.api._load_project_graph",
+            new=AsyncMock(return_value=None),
+        ):
+            result = await _resolve_graph_for_request(request)
+        assert result is sentinel
+
+    @pytest.mark.asyncio
+    async def test_load_returns_graph_used_in_place_of_default(self):
+        default_graph = object()
+        project_graph = object()
+        request = _make_request(
+            headers={"x-project-name": "Brand_Collaboration"}, default_graph=default_graph
+        )
+        with patch(
+            "graqle.studio.routes.api._load_project_graph",
+            new=AsyncMock(return_value=project_graph),
+        ):
+            result = await _resolve_graph_for_request(request)
+        assert result is project_graph
+        assert result is not default_graph
+
+
+class TestProjectNameRegex:
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Brand_Collaboration",
+            "CopyForge",
+            "graqle-sdk",
+            "brandio frontend",
+            "A.B-C_D",
+            "a",
+            "x" * 128,  # max length
+        ],
+    )
+    def test_accepts_well_formed(self, name):
+        assert _PROJECT_NAME_RE.match(name)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "../../etc",
+            "foo/bar",
+            "foo\\bar",
+            "name\x00null",
+            "name\n",
+            "x" * 129,  # one over max
+            "",
+        ],
+    )
+    def test_rejects_malformed(self, name):
+        assert not _PROJECT_NAME_RE.match(name)


### PR DESCRIPTION
# v0.57.4 — SF-07 per-project graph routing across studio routes

## Summary

Public mirror of private PR `quantamixsol/research-development-graqle#126` (merged at private master `6c032bf7`).

Closes **SF-07** from the 2026-05-17 studio audit. Adds `_resolve_graph_for_request(request)` async helper in `graqle/studio/routes/api.py`; wraps 12 existing `state.get("graph")` call-sites in studio route handlers to consult the helper instead. When the `x-project-name` HTTP header is present and well-formed, the helper returns the project-specific S3-loaded Graqle graph (cached via the existing `_load_project_graph`); otherwise it falls back to the Lambda's default graph at `state["graph"]`.

**Behaviour is byte-identical to v0.57.3 when `x-project-name` is absent** — verified by all 110 existing studio tests continuing to pass.

## Headline impact

Before v0.57.4, the studio Lambda served the default 12,354-node monorepo graph on every request except `/reason`, even when the frontend sent a project header. After v0.57.4, every studio endpoint that consults the graph honours the `x-project-name` header consistently.

The user-visible regression this closes: Brand_Collaboration's 611 MB graph (and CopyForge's, Bynder's, brandio-frontend's) becomes accessible via `/studio/api/graph/visualization`, `/project-context`, `/metrics/summary`, etc. when the frontend sets the header.

## Files changed

```
 graqle/studio/routes/api.py                         | 51 ++++++++++++++++++++++++++++++++++-----------
 tests/test_studio/test_resolve_graph_for_request.py | 124 ++++++++++++++++ (new file)
 2 files changed, 51 insertions(+), 12 deletions(-) + 1 new file
```

## Tests

- `pytest tests/test_studio/ -x -q` — **135 passed in 1.60s** scoped (110 pre-existing + 22 new + 3 framework-counted)
- Zero regressions on any pre-existing studio route test
- New helper test file covers: header absent, empty, malformed (6 attack vectors), `_load_project_graph` raises, returns None, returns valid graph, plus regex accept/reject parametrise

## Security

The `x-project-name` header is user-supplied and is interpolated into an S3 key by `_load_project_graph`. v0.57.4 adds anchored regex validation `\A[A-Za-z0-9._\- ]{1,128}\Z` at the helper entry point. Rejected names log a warning and fall through to the default graph. Path traversal (`../`), separators (`/`, `\`), null bytes, and over-length names are rejected.

(A regex anchor bug — `^...$` would have accepted `name\n` due to default `$` semantics — was caught by the new test file before this PR and fixed via `\A...\Z`.)

## Sentinel chain (on private PR #126, prior to merge)

| Pass | Focus | Verdict | Confidence |
|---|---|---|---|
| 1 | all (6-agent) | CHANGES_REQUESTED | 92% |
| 2 | all (after triage + 3 fixes) | APPROVED | 95% |
| 3 | security (final) | APPROVED | 95% |

## Release

After this public PR merges:
- Tag `v0.57.4` on public master
- OIDC publishes wheel to PyPI
- Lambda auto-redeploys via `.github/workflows/deploy-lambda.yml`
- Production verification: 8/8 backend endpoints + new SF-07 header-based routing case

## Cross-reference

- Private PR (full sentinel chain, V-violation log, deferred follow-up items): https://github.com/quantamixsol/research-development-graqle/pull/126
- Yesterday's audit handoff: `.gcc/branches/studio-audit-2026-05-17/HANDOFF-2026-05-17-EOD.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
