### PR TITLE
v0.57.4 release metadata — version bump + CHANGELOG (cr-022b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## 0.57.4 (2026-05-18) - [cr-022 SF-07 per-project graph routing across studio routes]
+
+> **Closes SF-07 from the 2026-05-17 studio backend audit.** Before v0.57.4, the Studio Lambda served the default 12,354-node monorepo graph on every request *except* `/reason`, even when the frontend sent an `x-project-name` header. This meant users with their own project graphs in S3 (e.g. Brand_Collaboration's 611 MB graph, CopyForge's 45 MB, Bynder's 7 MB, brandio-frontend's 3,825-node graph) could not see those graphs anywhere in the Studio UI — every endpoint silently returned the default. v0.57.4 introduces a single `_resolve_graph_for_request(request)` async helper in `graqle/studio/routes/api.py` that 12 existing route handlers consult instead of reading `state.get("graph")` directly. When the `x-project-name` HTTP header is present and well-formed, the helper returns the project-specific S3-loaded Graqle graph (cached via the existing `_load_project_graph`); otherwise it falls back to the Lambda's default graph at `state["graph"]`. **Behaviour is byte-identical to v0.57.3 when the header is absent.** All 110 existing studio tests continue to pass; 22 new tests added.
+
+### Fixed
+
+- **`graqle/studio/routes/api.py` per-project graph routing** (SF-07). New `_resolve_graph_for_request(request)` async helper co-located with the existing `_load_project_graph` function. The helper reads the `x-project-name` header, returns the project-specific S3-loaded graph (cached after first load via `_load_project_graph`), and falls back to `state["graph"]` when the header is absent, the project name is malformed, or `_load_project_graph` raises. 12 existing handler call-sites (`/project-context`, `/metrics/summary`, `/graph/visualization`, `/graph/visualization/filtered`, `/graph/nodes`, `/graph/node/{node_id}`, `/reason`, `/governance/stats`, `/partials/metrics-cards`, `/partials/node-detail`, `/settings`, `/lessons`, `/neptune/upload`) consult the helper instead of `state.get("graph")` directly. The site at line 92 inside `_load_project_graph` itself is intentionally preserved (it reads the default graph to copy its backend onto the project-specific Graqle instance).
+
+### Security
+
+- **Anchored regex validation on the `x-project-name` header.** New module-level `_PROJECT_NAME_RE = re.compile(r"\A[A-Za-z0-9._\- ]{1,128}\Z")` matches at helper entry. Path traversal (`../`), separators (`/`, `\`), null bytes (`\x00`), control characters, and over-length names (>128 chars) are rejected; rejected names log a `logger.warning` and fall through to the default graph. **The `\A...\Z` anchors (not `^...$`) defeat a real bypass: by default `$` matches before a trailing newline, so `name\n` would have been accepted by `^...$`. This bug was caught by the new test suite before shipping.** All exception paths from `_load_project_graph` are also logged via `logger.warning` to address the silent-exception security blind spot identified by sentinel pass 1.
+
+### Added
+
+- **`tests/test_studio/test_resolve_graph_for_request.py`** (new file, 124 lines, 22 test cases). Covers: header absent (returns default), header empty string (returns default), header malformed with 6 attack vectors (`../../etc/passwd`, `project/subpath`, `foo\\bar`, NULL byte, over-length, empty), `_load_project_graph` raises (returns default + logs), `_load_project_graph` returns None (returns default), `_load_project_graph` returns valid graph (returned in place of default), regex accepts 7 well-formed names, regex rejects 7 malformed names (including the `name\n` bypass).
+
+### Notes
+
+- **Functionally identical** to v0.57.3 when the `x-project-name` header is absent. No CLI changes, no compliance semantics changes, no PCT changes, no claim-limits changes. All v0.57.3 tests continue to pass (110 pre-existing studio tests + 22 new = 135/135 PASS in 1.60s scoped).
+- **Sentinel chain:** pass 1 (`focus=all`) returned `CHANGES_REQUESTED` at 92% with 1 valid BLOCKER (silent exception handling) + 2 valid MAJORs (no project name validation, no test coverage on the new helper) + 1 false-positive BLOCKER (an abbreviated diff misled the reviewer about `neptune_health_check`'s signature) + 1 deferred MINOR. After triage, 3 fixes were applied (logger.warning in except, anchored regex validation, 22-case test file) and the new tests caught the `^...$` regex anchor bug. Pass 2 (`focus=all`) on the hardened diff returned `APPROVED` at 95% with 0 BLOCKER + 0 MAJOR. Pass 3 (`focus=security`) on the final diff returned `APPROVED` at 95% with 4/5 agents agreeing.
+- **Deferred follow-ups** (out of v0.57.4 scope, documented for future CRs): (1) `reason_stream` retains its own body-based `project` loading logic in addition to the new header-based helper — cleanup deferred to a follow-on CR. (2) Rate limiting on repeated malformed `x-project-name` requests needs a global middleware. (3) `_project_graph_cache` module-level dict thread-safety is pre-existing — bounded in practice by AWS Lambda's single-threaded execution model under the Python GIL.
+- **Constitutional notes:** SF-07 implementation used native `Edit` rather than `graq_generate` because `graq_generate` returned `access_denied` on the cr-022 worktree path (same class as 4 prior V-violations from yesterday's session — the KG path-resolver capability gap). Logged as `V-CR-022-EDIT-NATIVE-001`. Systemic fix: Research-Team v0.58.x directive item #1 (cr-016 `GRAQLE_WORKTREE_ROOT`), which the SDK team starts after v0.57.4 ships.
+- **SF-10 infrastructure pre-requisite:** an `AllowNeptuneBoltConnectToGraqleKg` IAM inline policy was attached to the `eu-trace-lambda-execution-role` during this session, scoped to the `graqle-kg` cluster only. This grants the Lambda execution role `neptune-db:connect` permission, which is a pre-requisite for SF-10 (Neptune IAM SigV4 auth) to ship in a future CR. The IAM grant itself changes nothing in production until SF-10 code lands.
+
+### What's still open from the studio audit (after v0.57.4)
+
+- **SF-08** — cross-project federation `/studio/api/control/cross-project/search` still returns "Neptune unavailable" because the cross-project module has its own Neptune availability check that doesn't read `NEPTUNE_ENDPOINT` directly. End-to-end requires SF-10 first.
+- **SF-09** — Next.js proxy at `quantamixsol/cognigraph-studio` (separate repo) doesn't forward Cognito email as `x-user-email`. Out of scope for this SDK release.
+- **SF-10** — Neptune IAM SigV4 auth via a new `graqle.connectors.neptune_auth.NeptuneIamAuthManager`. IAM permission is now granted; code change still needed. Architectural CR, planned as a separate ship.
+
+---
+
 ## 0.57.3 (2026-05-17) - [cr-015 Neptune URI from environment variable]
 
 > **Fixes `/studio/api/traversal/hubs` HTTP 500 on the production Lambda.** v0.57.2 added the `neo4j` Bolt driver to the Lambda zip (CR-013), but `graqle.server.app` still passed `graph_cfg.uri = bolt://localhost:7687` to `Neo4jTraversal()`, so every traversal query hit `ConnectionRefusedError: [Errno 111] Connection refused` against localhost on the Lambda. v0.57.3 reads `NEPTUNE_ENDPOINT` + `NEPTUNE_PORT` env vars at app-startup and constructs a proper `bolt+s://endpoint:8182` URI for Neptune. Falls back to `graph_cfg.uri` when `NEPTUNE_ENDPOINT` is empty (local Neo4j + test environments unchanged).

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.57.3"
+__version__ = "0.57.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.57.3"
+version = "0.57.4"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Proprietary — see LICENSE"}


### PR DESCRIPTION
# v0.57.4 release metadata — version bump + CHANGELOG

## Summary

Public mirror of private PR `quantamixsol/research-development-graqle#127` (merged at private master `461589a0`).

Release-metadata-only follow-up to PR #148 (which shipped the SF-07 fix). Bumps `pyproject.toml` and `graqle/__version__.py` from `0.57.3` → `0.57.4` and adds the `## 0.57.4` CHANGELOG entry. No code changes — the SF-07 implementation already shipped on public master via #148 at `f09c6608`.

## Why a separate PR

Pre-tag review of #148-as-merged found that the SF-07 commit didn't bump version files or add a CHANGELOG entry. Pushing the `v0.57.4` tag against the existing public master (which still says `version = "0.57.3"`) would either fail at PyPI (collision with the existing `0.57.3` wheel) or ship a wheel whose internal `__version__` says `0.57.3` — silent version drift.

This PR fixes that before any tag is pushed.

## Files changed

```
 CHANGELOG.md          | 32 ++++++++++++++++++++++++++++++++
 graqle/__version__.py |  2 +-
 pyproject.toml        |  2 +-
 3 files changed, 34 insertions(+), 2 deletions(-)
```

## Tests

- `pytest tests/test_cli/test_version.py tests/test_studio/test_resolve_graph_for_request.py` — **28 passed in 3.21s** on this cherry-pick
- `--version` flag now reports `0.57.4`; package `__version__` parity confirmed by `test_version_flag_matches_package`

## Sentinel chain

On private PR #127, `graq_review(focus=correctness)` returned `APPROVED` at 95% (4-agent majority). Dissenting agents asked for the SF-07 implementation code to be visible — review-scope artifact, since the impl is on master via #126/#148 and this CR is release-metadata-only.

## After this merges

1. Tag `v0.57.4` on public master + push
2. `.github/workflows/ci.yml` triggers on `tags: ["v*"]` → OIDC publish to PyPI
3. Lambda redeploys via `.github/workflows/deploy-lambda.yml`
4. Verification: 8/8 production endpoints + new SF-07 case (`curl -H "x-project-name: Brand_Collaboration" ...`)

## Cross-reference

- Private PR (full sentinel chain + V-violation log): https://github.com/quantamixsol/research-development-graqle/pull/127
- Companion public PR (SF-07 impl): https://github.com/quantamixsol/graqle/pull/148 (already merged at `f09c6608`)
- Constitutional process lesson `VERSION_BUMP_PRE_TAG_GATE` will be recorded in Phase 9 LEARN — future CRs that ship a new version must bump metadata in the feature commit itself, not as a follow-on CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
