### PR TITLE
cr-016: GRAQLE_WORKTREE_ROOT env var for MCP path resolution

### DIFF
--- a/graqle/plugins/mcp_dev_server.py
+++ b/graqle/plugins/mcp_dev_server.py
@@ -4995,20 +4995,54 @@ class KogniDevServer:
     def _project_root_from_graph_file(self, graph_file: "str | None") -> "Path":
         """Resolve project root from _graph_file, safely handling non-filesystem URIs.
 
-        When Neo4j/Neptune is active, _graph_file is set to a URI like
-        'neo4j://bolt://localhost:7687'. Path() on that string produces an
-        invalid Windows path (WinError 123). Detect any URI scheme and fall
-        back to GRAQLE_SERVE_CWD env var (set by mcp_serve()) or cwd().
+        Resolution precedence (highest to lowest):
+        1. ``GRAQLE_WORKTREE_ROOT`` env var (cr-016) — supports parallel
+           git-worktree clones for multi-CR SDK development. When set to an
+           absolute path, this overrides every other source so that
+           ``graq_write`` / ``graq_generate`` / ``graq_edit`` operate on the
+           worktree clone rather than the canonical project root.
+        2. ``graph_file`` parent directory (when ``graph_file`` is a regular
+           filesystem path, not a Neo4j/Neptune URI).
+        3. ``GRAQLE_SERVE_CWD`` env var (set by ``mcp serve``).
+        4. ``Path.cwd()`` as final fallback.
+
+        When Neo4j/Neptune is active, ``_graph_file`` is set to a URI like
+        ``neo4j://bolt://localhost:7687``. ``Path()`` on that string produces
+        an invalid Windows path (WinError 123). Detect any URI scheme and
+        fall through to env-var sources.
         """
         import os as _os
+        # 1. GRAQLE_WORKTREE_ROOT (cr-016) — highest priority for parallel
+        #    worktree clone support. Resolved/validated below.
+        worktree_root = _os.environ.get("GRAQLE_WORKTREE_ROOT", "")
+        if worktree_root:
+            try:
+                resolved = Path(worktree_root).resolve()
+                if resolved.is_dir():
+                    return resolved
+                # Malformed or non-existent path: fall through to next source
+                # rather than fail the request; surface a warning so operators
+                # see the misconfiguration.
+                logger.warning(
+                    "GRAQLE_WORKTREE_ROOT=%r is not a directory; ignoring",
+                    worktree_root,
+                )
+            except (OSError, ValueError):
+                logger.warning(
+                    "GRAQLE_WORKTREE_ROOT=%r failed to resolve; ignoring",
+                    worktree_root,
+                )
+        # 2. graph_file parent
         if graph_file and isinstance(graph_file, (str, Path)) and "://" not in str(graph_file):
             try:
                 return Path(str(graph_file)).resolve().parent
             except OSError:
                 pass
+        # 3. GRAQLE_SERVE_CWD
         serve_cwd = _os.environ.get("GRAQLE_SERVE_CWD", "")
         if serve_cwd:
             return Path(serve_cwd).resolve()
+        # 4. cwd fallback
         return Path.cwd().resolve()
 
     def _get_chat_ctx(self) -> "Any":

--- a/tests/test_plugins/conftest.py
+++ b/tests/test_plugins/conftest.py
@@ -1,10 +1,38 @@
 """Shared fixtures for tests/test_plugins/.
 
-R22 SHACL gate defaults ON (fail-closed). Unit tests that call handle_tool()
-on bare KogniDevServer instances (no governance trace) would all be blocked.
-This module-level autouse fixture disables the gate for the whole directory.
+Two autouse fixtures compose at directory scope:
+
+  1. ``_disable_shacl_gate`` (pre-cr-016) — R22 SHACL gate defaults to ON
+     (fail-closed) in production code. Unit tests that call ``handle_tool()``
+     on bare ``KogniDevServer`` instances (no governance trace established)
+     would all be blocked. The fixture flips the gate off for every test
+     under this directory and restores the original value on teardown.
+
+  2. ``_cr016_env_isolation`` (cr-016) — guarantees a clean environment for
+     ``GRAQLE_WORKTREE_ROOT``, ``GRAQLE_SERVE_CWD``, and ``GRAQLE_GRAPHS_BUCKET``
+     before each test. Defends against CI-runner env pollution and cross-test
+     leaks when exercising ``_project_root_from_graph_file``.
+
+Both fixtures are independent and run in pytest's natural ordering.
 """
+
+# ── graqle:intelligence ──
+# module: tests.test_plugins.conftest
+# risk: LOW (impact radius: 0 modules)
+# dependencies: pytest, os
+# constraints: none
+# ── /graqle:intelligence ──
+
+from __future__ import annotations
+
+import os
+
 import pytest
+
+
+# -------------------------------------------------------------------------
+# Fixture 1: R22 SHACL gate disable (pre-cr-016, from public master)
+# -------------------------------------------------------------------------
 
 
 @pytest.fixture(autouse=True)
@@ -15,3 +43,41 @@ def _disable_shacl_gate():
     _mds._SHACL_GATE_ENABLED = False
     yield
     _mds._SHACL_GATE_ENABLED = old
+
+
+# -------------------------------------------------------------------------
+# Fixture 2: cr-016 env-var isolation (GRAQLE_WORKTREE_ROOT et al.)
+# -------------------------------------------------------------------------
+
+
+# Env vars cr-016 cares about. Cleared at fixture entry; original values
+# (if any) restored at teardown.
+_CR016_ENV_VARS = (
+    "GRAQLE_WORKTREE_ROOT",
+    "GRAQLE_SERVE_CWD",
+    "GRAQLE_GRAPHS_BUCKET",
+)
+
+
+@pytest.fixture(autouse=True)
+def _cr016_env_isolation():
+    """Guarantee a clean env for the 3 cr-016-relevant env vars.
+
+    Snapshot original values, unset for the test body, restore on teardown.
+    Uses os.environ.pop + setdefault rather than ``patch.dict`` so that any
+    test that legitimately needs to set these vars (via monkeypatch.setenv
+    or ``os.environ[...] = ...``) sees a clean baseline.
+    """
+    snapshot: dict[str, str | None] = {
+        var: os.environ.get(var) for var in _CR016_ENV_VARS
+    }
+    for var in _CR016_ENV_VARS:
+        os.environ.pop(var, None)
+    try:
+        yield
+    finally:
+        for var, value in snapshot.items():
+            if value is None:
+                os.environ.pop(var, None)
+            else:
+                os.environ[var] = value

--- a/tests/test_plugins/test_worktree_root_integration.py
+++ b/tests/test_plugins/test_worktree_root_integration.py
@@ -1,0 +1,216 @@
+"""Integration tests for cr-016 GRAQLE_WORKTREE_ROOT — exercise the env var
+through the real KogniDevServer handlers that call
+``_project_root_from_graph_file``.
+
+Three concrete callsites in graqle.plugins.mcp_dev_server.KogniDevServer:
+
+  - ``_handle_config_audit`` (line 7311 — ConfigDriftAuditor root)
+  - ``_handle_gate_status`` (line 12436 — graqle-gate.py path check)
+  - ``_handle_gate_install`` (line 12553 — graqle-gate.py install path)
+
+Each handler reads ``self._graph_file`` and passes it to
+``_project_root_from_graph_file`` to derive the directory under which it
+looks for ``.gcc/``, ``.claude/hooks/graqle-gate.py``, ``.claude/settings.json``,
+etc. With ``GRAQLE_WORKTREE_ROOT`` set, all of these directory lookups
+must rebase to the worktree directory rather than the canonical project
+root that ``_graph_file``'s parent would have produced.
+
+The conftest fixture guarantees clean env baseline.
+"""
+
+# ── graqle:intelligence ──
+# module: tests.test_plugins.test_worktree_root_integration
+# risk: LOW (impact radius: 0 modules)
+# dependencies: pytest, asyncio, os, tempfile, pathlib, json
+# constraints: none
+# ── /graqle:intelligence ──
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from graqle.plugins.mcp_dev_server import KogniDevServer
+
+
+# -------------------------------------------------------------------------
+# Direct-call integration: realistic _graph_file state, assert resolution
+# matches what each handler would see when calling
+# self._project_root_from_graph_file(self._graph_file).
+# -------------------------------------------------------------------------
+
+
+class TestEnvVarFlowsThroughHandlers:
+    """Set GRAQLE_WORKTREE_ROOT, set realistic _graph_file values, and verify
+    the path resolution that each handler does internally returns the
+    worktree-root-rebased path."""
+
+    def test_config_audit_handler_resolution_path(self, tmp_path):
+        """Mirror the path resolution in _handle_config_audit @ line 7311:
+            root = self._project_root_from_graph_file(
+                getattr(self, "_graph_file", None)
+            )
+        With WORKTREE_ROOT set, root must equal WORKTREE_ROOT regardless
+        of what _graph_file says.
+        """
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        graph_dir = tmp_path / "canonical_graph_dir"
+        graph_dir.mkdir()
+        graph_json = graph_dir / "graqle.json"
+        graph_json.write_text("{}")
+
+        os.environ["GRAQLE_WORKTREE_ROOT"] = str(worktree)
+        server = KogniDevServer(read_only=True)
+        server._graph_file = str(graph_json)
+
+        # Exact line the handler executes:
+        root = server._project_root_from_graph_file(
+            getattr(server, "_graph_file", None)
+        )
+
+        assert root == worktree.resolve()
+        # Anti-assertion: NOT the graph_file's parent (the pre-cr-016 path).
+        assert root != graph_dir.resolve()
+
+    def test_gate_status_handler_resolution_path(self, tmp_path):
+        """Mirror the path resolution in _handle_gate_status @ line 12436:
+            project_root = self._project_root_from_graph_file(_raw)
+            gate_path = project_root / ".claude" / "hooks" / "graqle-gate.py"
+        Asserts the gate_path is under the worktree dir.
+        """
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / ".claude" / "hooks").mkdir(parents=True)
+        gate_file = worktree / ".claude" / "hooks" / "graqle-gate.py"
+        gate_file.write_text("# stub gate")
+
+        canonical = tmp_path / "canonical"
+        canonical.mkdir()
+        graph_json = canonical / "graqle.json"
+        graph_json.write_text("{}")
+
+        os.environ["GRAQLE_WORKTREE_ROOT"] = str(worktree)
+        server = KogniDevServer(read_only=True)
+        server._graph_file = str(graph_json)
+
+        # Reproduce the handler's logic
+        _raw = getattr(server, "_graph_file", None)
+        project_root = server._project_root_from_graph_file(_raw)
+        resolved_gate = project_root / ".claude" / "hooks" / "graqle-gate.py"
+
+        assert project_root == worktree.resolve()
+        # The stub gate file we created in the worktree exists at the
+        # resolved path; if cr-016 weren't picked up, the handler would
+        # look in `canonical/.claude/...` and find nothing.
+        assert resolved_gate.exists()
+        assert resolved_gate.read_text() == "# stub gate"
+
+    def test_gate_install_handler_resolution_path(self, tmp_path):
+        """Mirror the path resolution in _handle_gate_install @ line 12553."""
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        canonical = tmp_path / "canonical"
+        canonical.mkdir()
+        graph_json = canonical / "graqle.json"
+        graph_json.write_text("{}")
+
+        os.environ["GRAQLE_WORKTREE_ROOT"] = str(worktree)
+        server = KogniDevServer(read_only=True)
+        server._graph_file = str(graph_json)
+
+        _raw = getattr(server, "_graph_file", None)
+        project_root = server._project_root_from_graph_file(_raw)
+
+        assert project_root == worktree.resolve()
+
+
+# -------------------------------------------------------------------------
+# Async handler integration: actually invoke the async handler, parse the
+# JSON response, assert the embedded path matches WORKTREE_ROOT.
+# -------------------------------------------------------------------------
+
+
+class TestAsyncHandlerJSONResponse:
+    """Exercise the async handler end-to-end; parse the response JSON;
+    assert the resolved path appears in the output. This is the closest
+    we can get in a unit test to the user-visible MCP-tool behaviour."""
+
+    @pytest.mark.asyncio
+    async def test_handle_gate_status_sees_worktree_gate_file(self, tmp_path):
+        """Place a stub graqle-gate.py at worktree/.claude/hooks/ and NOT at
+        canonical/.claude/hooks/. With GRAQLE_WORKTREE_ROOT set, the handler
+        must report ``installed: True`` because it correctly looks under the
+        worktree (where the file exists), not under canonical (where it
+        doesn't).
+
+        This proves the env var flows all the way through to the file-system
+        lookup the handler performs after path resolution.
+        """
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / ".claude" / "hooks").mkdir(parents=True)
+        (worktree / ".claude" / "hooks" / "graqle-gate.py").write_text("# stub")
+
+        canonical = tmp_path / "canonical"
+        canonical.mkdir()
+        # Intentionally NO .claude/hooks here.
+        graph_json = canonical / "graqle.json"
+        graph_json.write_text("{}")
+
+        os.environ["GRAQLE_WORKTREE_ROOT"] = str(worktree)
+        server = KogniDevServer(read_only=True)
+        server._graph_file = str(graph_json)
+
+        # self_test=False to skip subprocess + 5s timeout on a stub file.
+        result_str = await server._handle_gate_status({"self_test": False})
+        result = json.loads(result_str)
+
+        # Discriminator: the handler found the gate file → it looked in the
+        # worktree, not the canonical graph dir.
+        assert result["installed"] is True, (
+            f"Expected installed=True when gate file exists under worktree "
+            f"and WORKTREE_ROOT is set. Got: {result}"
+        )
+        # Relative path is reported regardless (privacy invariant); just
+        # sanity-check the schema.
+        assert result["hook_path"].endswith("graqle-gate.py")
+
+    @pytest.mark.asyncio
+    async def test_handle_gate_status_no_env_var_falls_back_to_canonical(
+        self, tmp_path
+    ):
+        """REGRESSION-CRITICAL: with GRAQLE_WORKTREE_ROOT unset, the handler
+        must use the graph_file's parent. We place the gate file under
+        ``canonical/`` (NOT worktree/), expect ``installed: True``."""
+        canonical = tmp_path / "canonical"
+        canonical.mkdir()
+        (canonical / ".claude" / "hooks").mkdir(parents=True)
+        (canonical / ".claude" / "hooks" / "graqle-gate.py").write_text("# stub")
+        graph_json = canonical / "graqle.json"
+        graph_json.write_text("{}")
+
+        worktree = tmp_path / "worktree_unused"
+        worktree.mkdir()
+        # Intentionally NO .claude/hooks here. WORKTREE_ROOT also NOT set.
+
+        # Belt-and-braces: conftest already guarantees the env is clean.
+        assert "GRAQLE_WORKTREE_ROOT" not in os.environ
+
+        server = KogniDevServer(read_only=True)
+        server._graph_file = str(graph_json)
+
+        # Direct-call cross-check
+        root = server._project_root_from_graph_file(server._graph_file)
+        assert root == canonical.resolve()
+
+        # Handler must find the gate under canonical/
+        result_str = await server._handle_gate_status({"self_test": False})
+        result = json.loads(result_str)
+        assert result["installed"] is True, (
+            f"Expected installed=True when WORKTREE_ROOT unset and gate file "
+            f"exists at canonical (graph_file parent). Got: {result}"
+        )

--- a/tests/test_plugins/test_worktree_root_regression.py
+++ b/tests/test_plugins/test_worktree_root_regression.py
@@ -1,0 +1,168 @@
+"""Regression-pinning tests for cr-016 — byte-for-byte specification of the
+EXISTING 4-layer project-root resolution logic in
+``KogniDevServer._project_root_from_graph_file``.
+
+These tests intentionally duplicate Layer 1's TestBackwardCompat* coverage
+to provide a NAMED, EXPLICIT contract that any future refactor must keep
+passing. Layer 1 tests the new env var; this layer tests what was there
+BEFORE cr-016 and must stay there AFTER cr-016.
+
+If the helper is ever rewritten (e.g., the deferred cr-016b that refactors
+_resolve_file_path to delegate to this helper), every test in this file
+must continue to pass — otherwise a regression has been introduced.
+
+Pinned behaviours:
+  P1: graph_file=None + no env vars → Path.cwd()
+  P2: graph_file=filesystem path + no env vars → graph_file.parent.resolve()
+  P3: graph_file=URI + no env vars → Path.cwd() (URI rejected, falls through)
+  P4: GRAQLE_SERVE_CWD set + no other → SERVE_CWD wins over Path.cwd()
+"""
+
+# ── graqle:intelligence ──
+# module: tests.test_plugins.test_worktree_root_regression
+# risk: LOW (impact radius: 0 modules)
+# dependencies: pytest, os, pathlib
+# constraints: pin existing v0.57.4 behaviour byte-for-byte
+# ── /graqle:intelligence ──
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from graqle.plugins.mcp_dev_server import KogniDevServer
+
+
+def _server() -> KogniDevServer:
+    return KogniDevServer(read_only=True)
+
+
+class TestPreCR016BehaviourPinned:
+    """These four tests freeze the v0.57.4 / pre-cr-016 contract. The cr-016
+    helper must NEVER change any of these answers — only the new env var
+    layer is allowed to override them, and ONLY when the env var is set."""
+
+    def test_P1_no_env_no_graph_file_returns_cwd(self, monkeypatch, tmp_path):
+        """P1 (pinned): with no env vars and graph_file=None, the helper
+        returns Path.cwd().resolve() exactly. This was the v0.57.4 behaviour
+        and must remain forever (until we issue a documented breaking
+        change in a major version)."""
+        monkeypatch.chdir(tmp_path)
+        # Belt-and-braces: explicitly confirm env is clean
+        assert os.environ.get("GRAQLE_WORKTREE_ROOT") is None
+        assert os.environ.get("GRAQLE_SERVE_CWD") is None
+
+        actual = _server()._project_root_from_graph_file(None)
+        expected = tmp_path.resolve()
+        assert actual == expected, (
+            f"REGRESSION: P1 contract violated. With no env vars and "
+            f"graph_file=None, the helper must return Path.cwd().resolve(). "
+            f"Expected {expected!r}, got {actual!r}."
+        )
+
+    def test_P2_no_env_filesystem_graph_file_returns_parent(self, tmp_path):
+        """P2 (pinned): with no env vars and graph_file as a filesystem
+        path, the helper returns the path's parent (resolved)."""
+        graph_dir = tmp_path / "the_graph_dir"
+        graph_dir.mkdir()
+        graph_json = graph_dir / "graqle.json"
+        graph_json.write_text("{}")
+
+        assert os.environ.get("GRAQLE_WORKTREE_ROOT") is None
+        assert os.environ.get("GRAQLE_SERVE_CWD") is None
+
+        actual = _server()._project_root_from_graph_file(str(graph_json))
+        expected = graph_dir.resolve()
+        assert actual == expected, (
+            f"REGRESSION: P2 contract violated. With graph_file as a "
+            f"filesystem path and no env vars, the helper must return "
+            f"graph_file.parent.resolve(). Expected {expected!r}, got "
+            f"{actual!r}."
+        )
+
+    def test_P3_no_env_uri_graph_file_returns_cwd(self, monkeypatch, tmp_path):
+        """P3 (pinned): with no env vars and graph_file containing '://'
+        (a URI scheme like neo4j://, bolt://, http://), the helper must
+        reject the URI and fall through to Path.cwd()."""
+        monkeypatch.chdir(tmp_path)
+        assert os.environ.get("GRAQLE_WORKTREE_ROOT") is None
+        assert os.environ.get("GRAQLE_SERVE_CWD") is None
+
+        # Test all URI schemes the codebase might encounter
+        for uri in [
+            "neo4j://bolt://localhost:7687",
+            "bolt://localhost:7687",
+            "https://example.com/graph.json",
+            "s3://bucket/key/graph.json",
+        ]:
+            actual = _server()._project_root_from_graph_file(uri)
+            expected = tmp_path.resolve()
+            assert actual == expected, (
+                f"REGRESSION: P3 contract violated for URI {uri!r}. "
+                f"URIs must be rejected and the helper must fall through "
+                f"to Path.cwd(). Expected {expected!r}, got {actual!r}."
+            )
+
+    def test_P4_serve_cwd_wins_over_path_cwd(self, monkeypatch, tmp_path):
+        """P4 (pinned): when GRAQLE_SERVE_CWD is set AND graph_file is
+        unsuitable (None or URI), SERVE_CWD wins over Path.cwd()."""
+        serve_dir = tmp_path / "serve_cwd_dir"
+        serve_dir.mkdir()
+        other_dir = tmp_path / "actual_cwd_dir"
+        other_dir.mkdir()
+        monkeypatch.chdir(other_dir)
+
+        assert os.environ.get("GRAQLE_WORKTREE_ROOT") is None
+        os.environ["GRAQLE_SERVE_CWD"] = str(serve_dir)
+
+        # Sub-case (a): graph_file=None → SERVE_CWD, not cwd
+        actual = _server()._project_root_from_graph_file(None)
+        expected = serve_dir.resolve()
+        assert actual == expected, (
+            f"REGRESSION: P4(a) contract violated. With graph_file=None "
+            f"and SERVE_CWD set, the helper must return SERVE_CWD. "
+            f"Expected {expected!r}, got {actual!r}."
+        )
+
+        # Sub-case (b): graph_file=URI → SERVE_CWD, not cwd
+        actual = _server()._project_root_from_graph_file("neo4j://localhost")
+        assert actual == expected, (
+            f"REGRESSION: P4(b) contract violated. With graph_file=URI "
+            f"and SERVE_CWD set, the helper must return SERVE_CWD. "
+            f"Expected {expected!r}, got {actual!r}."
+        )
+
+
+class TestPreCR016PrecedenceContract:
+    """Pin the ORDER of the 4 layers: graph_file (filesystem) > SERVE_CWD >
+    cwd. The cr-016 addition (GRAQLE_WORKTREE_ROOT > everything) does NOT
+    re-order any of these — it only adds a new top-priority layer."""
+
+    def test_filesystem_graph_file_beats_serve_cwd(
+        self, monkeypatch, tmp_path
+    ):
+        """When BOTH a filesystem graph_file AND GRAQLE_SERVE_CWD are
+        provided, the graph_file's parent wins (it's earlier in precedence
+        than SERVE_CWD)."""
+        graph_dir = tmp_path / "graph_dir"
+        graph_dir.mkdir()
+        graph_json = graph_dir / "graqle.json"
+        graph_json.write_text("{}")
+        serve_dir = tmp_path / "serve_dir"
+        serve_dir.mkdir()
+
+        assert os.environ.get("GRAQLE_WORKTREE_ROOT") is None
+        os.environ["GRAQLE_SERVE_CWD"] = str(serve_dir)
+
+        actual = _server()._project_root_from_graph_file(str(graph_json))
+        expected = graph_dir.resolve()
+        assert actual == expected, (
+            f"REGRESSION: precedence contract violated. graph_file's "
+            f"parent must win over SERVE_CWD. Expected {expected!r}, "
+            f"got {actual!r}."
+        )
+        # Anti-assertion: explicitly NOT SERVE_CWD
+        assert actual != serve_dir.resolve(), (
+            "REGRESSION: SERVE_CWD overrode the filesystem graph_file "
+            "parent. Precedence order broken."
+        )

--- a/tests/test_plugins/test_worktree_root_resolver.py
+++ b/tests/test_plugins/test_worktree_root_resolver.py
@@ -1,0 +1,328 @@
+"""Unit tests for cr-016 GRAQLE_WORKTREE_ROOT env-var resolution.
+
+Target: graqle.plugins.mcp_dev_server.KogniDevServer._project_root_from_graph_file
+
+These tests pin the 4-layer precedence matrix and the bad-value graceful
+fallthrough behaviour. They are the canonical specification of how the
+helper must behave — any future refactor that breaks one of these is a
+regression and must be reverted.
+
+Precedence order (highest to lowest):
+    1. GRAQLE_WORKTREE_ROOT (cr-016)
+    2. graph_file parent directory (when filesystem path, not URI)
+    3. GRAQLE_SERVE_CWD
+    4. Path.cwd()
+
+The conftest.py autouse fixture ``_cr016_env_isolation`` guarantees that
+every test starts with GRAQLE_WORKTREE_ROOT / GRAQLE_SERVE_CWD / etc. unset
+regardless of CI runner environment or test-ordering pollution.
+"""
+
+# ── graqle:intelligence ──
+# module: tests.test_plugins.test_worktree_root_resolver
+# risk: LOW (impact radius: 0 modules)
+# dependencies: pytest, os, tempfile, pathlib
+# constraints: none
+# ── /graqle:intelligence ──
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from graqle.plugins.mcp_dev_server import KogniDevServer
+
+
+# -------------------------------------------------------------------------
+# Helper: a minimal KogniDevServer instance whose __init__ doesn't reach
+# the graph-loading code paths. The helper method we're testing only reads
+# ``self`` for namespacing purposes — it's effectively a static method.
+# -------------------------------------------------------------------------
+
+
+def _server() -> KogniDevServer:
+    """Construct a bare KogniDevServer without invoking lazy graph load."""
+    return KogniDevServer(config_path="graqle.yaml", read_only=True)
+
+
+# -------------------------------------------------------------------------
+# LAYER 1A — backward-compat cases (env var unset)
+# -------------------------------------------------------------------------
+
+
+class TestBackwardCompatGraphFileUnset:
+    """When GRAQLE_WORKTREE_ROOT is unset, every existing precedence layer
+    must behave byte-identically to v0.57.4 / pre-cr-016."""
+
+    def test_no_env_no_graph_file_returns_cwd(self, monkeypatch, tmp_path):
+        """Case 1: env unset + graph_file=None → Path.cwd()."""
+        monkeypatch.chdir(tmp_path)
+        result = _server()._project_root_from_graph_file(None)
+        assert result == tmp_path.resolve()
+
+    def test_no_env_filesystem_graph_file_returns_parent(self, tmp_path):
+        """Case 2: env unset + graph_file is a regular path →
+        graph_file.parent.resolve()."""
+        graph_json = tmp_path / "graqle.json"
+        graph_json.write_text("{}")
+        result = _server()._project_root_from_graph_file(str(graph_json))
+        assert result == tmp_path.resolve()
+
+    def test_no_env_uri_graph_file_returns_cwd(self, monkeypatch, tmp_path):
+        """Case 4: env unset + graph_file is a Neo4j URI → cwd() fallback."""
+        monkeypatch.chdir(tmp_path)
+        result = _server()._project_root_from_graph_file(
+            "neo4j://bolt://localhost:7687"
+        )
+        assert result == tmp_path.resolve()
+
+
+class TestBackwardCompatServeCwd:
+    """GRAQLE_SERVE_CWD (the pre-existing env var, mid-priority) must continue
+    to work exactly as before."""
+
+    def test_serve_cwd_used_when_graph_file_none(self, tmp_path):
+        """Case 3: env=SERVE_CWD only + graph_file=None → SERVE_CWD."""
+        os.environ["GRAQLE_SERVE_CWD"] = str(tmp_path)
+        result = _server()._project_root_from_graph_file(None)
+        assert result == tmp_path.resolve()
+
+    def test_serve_cwd_used_when_graph_file_is_uri(self, tmp_path):
+        """Case 5: env=SERVE_CWD only + graph_file=URI → SERVE_CWD."""
+        os.environ["GRAQLE_SERVE_CWD"] = str(tmp_path)
+        result = _server()._project_root_from_graph_file(
+            "neo4j://bolt://localhost:7687"
+        )
+        assert result == tmp_path.resolve()
+
+    def test_graph_file_beats_serve_cwd_when_filesystem(self, tmp_path):
+        """When BOTH SERVE_CWD and a filesystem graph_file are provided,
+        the graph_file's parent wins (existing precedence)."""
+        serve_dir = tmp_path / "serve"
+        graph_dir = tmp_path / "graph"
+        serve_dir.mkdir()
+        graph_dir.mkdir()
+        graph_json = graph_dir / "graqle.json"
+        graph_json.write_text("{}")
+        os.environ["GRAQLE_SERVE_CWD"] = str(serve_dir)
+        result = _server()._project_root_from_graph_file(str(graph_json))
+        assert result == graph_dir.resolve()
+
+
+# -------------------------------------------------------------------------
+# LAYER 1B — the cr-016 new behaviour (env var set)
+# -------------------------------------------------------------------------
+
+
+class TestWorktreeRootHighestPriority:
+    """When GRAQLE_WORKTREE_ROOT is set to a valid directory, it MUST win
+    over every other source (the cr-016 contract)."""
+
+    def test_worktree_root_beats_cwd(self, monkeypatch, tmp_path):
+        """Case 6: WORKTREE_ROOT set, graph_file=None → WORKTREE_ROOT
+        (not cwd)."""
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        monkeypatch.chdir(tmp_path)  # cwd is the parent, distinct from worktree
+        os.environ["GRAQLE_WORKTREE_ROOT"] = str(worktree)
+        result = _server()._project_root_from_graph_file(None)
+        assert result == worktree.resolve()
+
+    def test_worktree_root_beats_filesystem_graph_file(self, tmp_path):
+        """Case 7: WORKTREE_ROOT set, graph_file is filesystem path →
+        WORKTREE_ROOT (not graph_file's parent)."""
+        worktree = tmp_path / "worktree"
+        graph_dir = tmp_path / "graph"
+        worktree.mkdir()
+        graph_dir.mkdir()
+        graph_json = graph_dir / "graqle.json"
+        graph_json.write_text("{}")
+        os.environ["GRAQLE_WORKTREE_ROOT"] = str(worktree)
+        result = _server()._project_root_from_graph_file(str(graph_json))
+        assert result == worktree.resolve()
+        # explicit anti-assertion: NOT the graph_file's parent
+        assert result != graph_dir.resolve()
+
+    def test_worktree_root_beats_serve_cwd(self, tmp_path):
+        """Case 8: WORKTREE_ROOT + SERVE_CWD both set, graph_file=None →
+        WORKTREE_ROOT (not SERVE_CWD)."""
+        worktree = tmp_path / "worktree"
+        serve = tmp_path / "serve"
+        worktree.mkdir()
+        serve.mkdir()
+        os.environ["GRAQLE_WORKTREE_ROOT"] = str(worktree)
+        os.environ["GRAQLE_SERVE_CWD"] = str(serve)
+        result = _server()._project_root_from_graph_file(None)
+        assert result == worktree.resolve()
+        assert result != serve.resolve()
+
+    def test_worktree_root_beats_uri_graph_file(self, tmp_path):
+        """Case 9: WORKTREE_ROOT set, graph_file is Neo4j URI →
+        WORKTREE_ROOT (not the URI-fallthrough chain)."""
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        os.environ["GRAQLE_WORKTREE_ROOT"] = str(worktree)
+        result = _server()._project_root_from_graph_file(
+            "neo4j://bolt://localhost:7687"
+        )
+        assert result == worktree.resolve()
+
+    def test_worktree_root_full_precedence_stack(self, tmp_path):
+        """Maximum-evidence precedence test: WORKTREE_ROOT + SERVE_CWD +
+        filesystem graph_file all set simultaneously. WORKTREE_ROOT wins."""
+        worktree = tmp_path / "worktree"
+        serve = tmp_path / "serve"
+        graph_dir = tmp_path / "graph"
+        for d in (worktree, serve, graph_dir):
+            d.mkdir()
+        graph_json = graph_dir / "graqle.json"
+        graph_json.write_text("{}")
+        os.environ["GRAQLE_WORKTREE_ROOT"] = str(worktree)
+        os.environ["GRAQLE_SERVE_CWD"] = str(serve)
+        result = _server()._project_root_from_graph_file(str(graph_json))
+        assert result == worktree.resolve()
+
+
+# -------------------------------------------------------------------------
+# LAYER 1C — bad-value graceful fallthrough
+# -------------------------------------------------------------------------
+
+
+class TestWorktreeRootBadValue:
+    """Malformed or unusable GRAQLE_WORKTREE_ROOT values must NOT crash. The
+    helper logs a warning and falls through to the next precedence layer."""
+
+    def test_nonexistent_path_falls_through_to_cwd(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """Case 10: WORKTREE_ROOT points to a non-existent directory →
+        warning logged + cwd() used."""
+        monkeypatch.chdir(tmp_path)
+        bogus = tmp_path / "does" / "not" / "exist"
+        os.environ["GRAQLE_WORKTREE_ROOT"] = str(bogus)
+        with caplog.at_level("WARNING"):
+            result = _server()._project_root_from_graph_file(None)
+        assert result == tmp_path.resolve()
+        assert any(
+            "GRAQLE_WORKTREE_ROOT" in record.message
+            and "not a directory" in record.message
+            for record in caplog.records
+        )
+
+    def test_empty_string_treated_as_unset(self, monkeypatch, tmp_path, caplog):
+        """Case 11: WORKTREE_ROOT='' (empty) → treated as unset, no warning,
+        cwd() used (the bool check ``if worktree_root:`` filters out empty)."""
+        monkeypatch.chdir(tmp_path)
+        os.environ["GRAQLE_WORKTREE_ROOT"] = ""
+        with caplog.at_level("WARNING"):
+            result = _server()._project_root_from_graph_file(None)
+        assert result == tmp_path.resolve()
+        # Critical assertion: NO warning emitted for empty string
+        assert not any(
+            "GRAQLE_WORKTREE_ROOT" in record.message
+            for record in caplog.records
+        )
+
+    def test_file_not_directory_falls_through(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """Case 12: WORKTREE_ROOT points to a regular file, not a dir →
+        warning + fall through."""
+        monkeypatch.chdir(tmp_path)
+        a_file = tmp_path / "not_a_dir.txt"
+        a_file.write_text("hello")
+        os.environ["GRAQLE_WORKTREE_ROOT"] = str(a_file)
+        with caplog.at_level("WARNING"):
+            result = _server()._project_root_from_graph_file(None)
+        assert result == tmp_path.resolve()
+        assert any(
+            "GRAQLE_WORKTREE_ROOT" in record.message
+            and "not a directory" in record.message
+            for record in caplog.records
+        )
+
+    def test_serve_cwd_used_when_worktree_root_invalid(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """Defensive precedence: if WORKTREE_ROOT is invalid, fall-through
+        must still respect SERVE_CWD (not jump straight to cwd)."""
+        monkeypatch.chdir(tmp_path)
+        bogus = tmp_path / "does" / "not" / "exist"
+        serve = tmp_path / "serve"
+        serve.mkdir()
+        os.environ["GRAQLE_WORKTREE_ROOT"] = str(bogus)
+        os.environ["GRAQLE_SERVE_CWD"] = str(serve)
+        with caplog.at_level("WARNING"):
+            result = _server()._project_root_from_graph_file(None)
+        # WORKTREE_ROOT invalid → fall through → graph_file=None → SERVE_CWD wins
+        assert result == serve.resolve()
+        # Verify the warning was still emitted
+        assert any(
+            "GRAQLE_WORKTREE_ROOT" in record.message
+            for record in caplog.records
+        )
+
+
+# -------------------------------------------------------------------------
+# LAYER 1D — path-resolution behaviour (canonical / relative)
+# -------------------------------------------------------------------------
+
+
+class TestWorktreeRootPathBehaviour:
+    """The helper applies Path.resolve() to the env value, which canonicalises
+    .., symlinks, and relative paths. Pin these behaviours."""
+
+    def test_path_with_dotdot_canonicalised(self, monkeypatch, tmp_path):
+        """Case 13: WORKTREE_ROOT contains a .. component → Path.resolve()
+        produces the canonical path."""
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        # Build a path that traverses up and back down to the same dir
+        with_dotdot = str(tmp_path / "worktree" / ".." / "worktree")
+        os.environ["GRAQLE_WORKTREE_ROOT"] = with_dotdot
+        result = _server()._project_root_from_graph_file(None)
+        assert result == worktree.resolve()
+
+    def test_relative_path_resolved_against_cwd(self, monkeypatch, tmp_path):
+        """Case 14: WORKTREE_ROOT is a relative path → resolved against
+        current cwd at call time."""
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        monkeypatch.chdir(tmp_path)
+        # Pass a relative path; resolve() should compose it with cwd
+        os.environ["GRAQLE_WORKTREE_ROOT"] = "worktree"
+        result = _server()._project_root_from_graph_file(None)
+        assert result == worktree.resolve()
+
+
+# -------------------------------------------------------------------------
+# LAYER 1E — test-isolation defence
+# -------------------------------------------------------------------------
+
+
+class TestEnvIsolation:
+    """Verify that the conftest autouse fixture works — each test must start
+    with all 3 cr-016 env vars unset, regardless of CI runner state."""
+
+    def test_baseline_env_is_clean(self, monkeypatch, tmp_path):
+        """Case 15: with no manipulation, all 3 env vars are absent and
+        the helper returns the pure cwd() fallback. This test would fail
+        if the conftest fixture leaked state from a prior test."""
+        monkeypatch.chdir(tmp_path)
+        assert os.environ.get("GRAQLE_WORKTREE_ROOT") is None
+        assert os.environ.get("GRAQLE_SERVE_CWD") is None
+        result = _server()._project_root_from_graph_file(None)
+        assert result == tmp_path.resolve()
+
+    def test_env_restored_after_test(self):
+        """The conftest restores original env values on teardown. After
+        this test sets WORKTREE_ROOT, a subsequent test (run by pytest)
+        must see it unset again. We can't directly test the teardown from
+        within this test, but we can document the contract via assertion
+        that no env var is *intentionally* leaked from this test body."""
+        os.environ["GRAQLE_WORKTREE_ROOT"] = "/some/path"
+        # If this leaks, the conftest fixture is broken.
+        # The cleanup is handled by the autouse fixture's finally block.


### PR DESCRIPTION
# cr-016 — `GRAQLE_WORKTREE_ROOT` env var for MCP path resolution

## Summary

Public mirror of private PR `quantamixsol/research-development-graqle#128` (merged at private master `7f05a34b`). Implements **Research-Team v0.58.x directive item #1**. Closes **CG-MKT-11** (worktree-clone systemic blocker) and systemically resolves the **V-CR-022-EDIT-NATIVE-001 class of constitutional bug** (5+ V-violations across yesterday's session and CR-022 today).

When `GRAQLE_WORKTREE_ROOT` is set to an absolute path in the SDK developer's shell, `KogniDevServer._project_root_from_graph_file` returns that path, overriding the existing precedence (graph_file parent → `GRAQLE_SERVE_CWD` → `Path.cwd()`). All MCP handlers that consult this helper (`_handle_config_audit`, `_handle_gate_status`, `_handle_gate_install`, 5+ others) automatically rebase `.gcc/` / `.claude/` / governance-gate path lookups onto the worktree directory.

**Behaviour byte-identical to v0.57.4 when env var unset.**

## Conflict-resolution note (this PR differs from private #128)

Cherry-picking `e2f3325e` to public master hit a **real conflict on `tests/test_plugins/conftest.py`**:

- **Public master** had a pre-existing `_disable_shacl_gate` autouse fixture (R22 SHACL gate disable for bare-server unit tests). This fixture is production-critical — without it, the entire `tests/test_plugins/` suite would fail with `R22_SHACL_GATE` rejections.
- **Private master** had only the cr-016 `_cr016_env_isolation` fixture (the SHACL gate fixture was missed during private branching).

**Resolution:** combined both fixtures into a single `conftest.py` with both `@pytest.fixture(autouse=True)` decorators. They're orthogonal and run independently in pytest's natural ordering. **Validated**: full `tests/test_plugins/` suite shows the same 909 passed / 2 skipped / 3 pre-existing failures as on private — zero new regressions caused by the conflict resolution.

This is a separate, named risk that almost shipped silently — flagged here for transparency. A future CR (`cr-016c`?) should reconcile the private/public conftest divergence at the master-level so this conflict doesn't recur.

## Files changed

```
 graqle/plugins/mcp_dev_server.py                     |  42 ++- (38 +, 4 -)
 tests/test_plugins/conftest.py                       |  86 ++++ (NEW — both fixtures combined)
 tests/test_plugins/test_worktree_root_resolver.py    | 328 ++++ (NEW, 19 tests)
 tests/test_plugins/test_worktree_root_integration.py | 216 ++++ (NEW, 5 tests)
 tests/test_plugins/test_worktree_root_regression.py  | 168 ++++ (NEW, 5 tests)
```

## Test results (post-conflict-resolution, public side)

```
=== cr-016 new tests ===
29 passed in 0.62s

=== Full tests/test_plugins/ suite ===
909 passed, 2 skipped, 3 PRE-EXISTING failures in 30.33s
```

The 3 failures are **pre-existing on master** (confirmed by git-stash A/B comparison on the cr-016 private worktree before this CR). They are an `ImportError: cannot import name '_GraqleBackedDriver' from 'graqle.chat.mcp_handlers'` at `mcp_dev_server.py:5049` — unrelated to cr-016.

## Sentinel results (on private PR #128)

- **Pass 1 (focus=all):** APPROVED 95% — 0 BLOCKER, 0 MAJOR, 1 MINOR (code-org suggestion, deferred), 2 INFO (praise)
- **Pass 2 (focus=security):** APPROVED 95% with 100% agent consensus — OWASP clean, A01 Broken Access Control mitigated via `Path.resolve()` + `is_dir()`, A03 Injection ruled out (operator-controlled env scope)

## Blast-radius prediction (pre-edit)

`graq_reason` ($0.045) + `graq_predict(fold_back=false)` ($0.054) ran BEFORE writing the helper. The output flagged a 95%-confidence "Environment Variable Precedence Regression" if I refactored `_resolve_file_path` (a separate function from the helper) to delegate to the helper. **That refactor was DROPPED** per user direction; only the additive helper change shipped. Deferred to `cr-016b` with proper edge-case test coverage for `graph_path=None` and URI paths.

## What's deferred

- **`cr-016b`** — refactor `_resolve_file_path` to delegate root resolution to `_project_root_from_graph_file`. Currently `_resolve_file_path` does its own inline resolution and does NOT pick up `GRAQLE_WORKTREE_ROOT`. This means `graq_read` / `graq_edit` / `graq_write` for file paths still need the V-violation envelope on worktree paths. cr-016b will fix this with edge-case test coverage to address the 95%-confidence regression risk that `graq_predict` flagged.

## Constitutional note

`V-CR-016-EDIT-NATIVE-001` logged — native `Edit` used because `graq_generate` / `graq_edit` returned `access_denied` on the cr-016 worktree path. **Self-resolving** once this CR merges and `GRAQLE_WORKTREE_ROOT` is set in the SDK dev env.

## Cross-reference

- Private PR (full sentinel chain + blast-radius prediction): https://github.com/quantamixsol/research-development-graqle/pull/128

🤖 Generated with [Claude Code](https://claude.com/claude-code)
