### PR TITLE
ci(ip-scan): allowlist EP26166054.2 in scanner negative-lookahead [cr-019c]

### DIFF
--- a/scripts/ci/ip_content_scan.py
+++ b/scripts/ci/ip_content_scan.py
@@ -51,13 +51,15 @@ CONTENT_DENY = [
     (re.compile(r"strengthens\s+the\s+\w+\s+patent\s+narrative", re.IGNORECASE), "strengthens patent narrative"),
 
     # Patent application numbers (EP, WO, US format).
-    # GraQle's own published patent numbers (EP26167849.4 + EP26162901.8)
-    # are intentionally public per ADR-MARKETING-001 — they appear on
-    # README.md, LinkedIn, and the v0.56.0 PyPI wheel since 2026-05-15.
-    # The scanner remains active for ANY OTHER patent number that might
-    # appear (e.g. a draft application or a third-party patent), but
-    # GraQle's own numbers are whitelisted as approved public references.
-    (re.compile(r"\bEP\s?(?!26167849\.4\b|26162901\.8\b)\d{6,}(?:\.\d+)?\b"), "European patent application number (other than GraQle's published EP26167849.4 / EP26162901.8)"),
+    # GraQle's own published patent numbers (EP26167849.4, EP26162901.8,
+    # EP26166054.2) are intentionally public per ADR-MARKETING-001 — they
+    # appear on README.md, LinkedIn, and the v0.56.0+ PyPI wheels since
+    # 2026-05-15. The scanner remains active for ANY OTHER patent number
+    # that might appear (e.g. a draft application or a third-party patent),
+    # but GraQle's own numbers are whitelisted as approved public references.
+    # EP26166054.2 added 2026-05-19 (cr-019c) after cr-019/cr-021 each
+    # tripped this gate on legitimate references to the CogniGraph divisional.
+    (re.compile(r"\bEP\s?(?!26167849\.4\b|26162901\.8\b|26166054\.2\b)\d{6,}(?:\.\d+)?\b"), "European patent application number (other than GraQle's published EP26167849.4 / EP26162901.8 / EP26166054.2)"),
     (re.compile(r"\bWO\s?\d{4}/\d{4,}\b"), "WIPO patent application number"),
     (re.compile(r"\bUS\s?\d{4}/\d{6,}\b"), "US patent application number"),
 


### PR DESCRIPTION
## Summary

Fixes the IP Content Gate scanner to recognise GraQle's third granted patent (**EP26166054.2 — CogniGraph divisional**) alongside the existing allowlisted EP26167849.4 (PSE) and EP26162901.8 (TAMR+).

## Why

The scanner blocked legitimate references to EP26166054.2 on **two separate PRs in one day** (2026-05-19):

1. **cr-019** — `CONTRIBUTING-COMPLIANCE.md` listed all three GraQle patents → blocked → required public commit `aed848f1` dropping the reference + private backfill PR #131.
2. **cr-021** — `CHANGELOG.md` v0.58.0 OPSF cross-reference section mentioned EP26166054.2 three times → blocked → required public commit `803d4793` dropping the references + private backfill PR #133.

Both fixes were necessary but cosmetic — the underlying allowlist gap will trip every future docs/CHANGELOG CR that mentions the CogniGraph divisional. This PR closes the gap properly.

## What changed

**Single 1-line regex change** to `scripts/ci/ip_content_scan.py:60`:

```diff
- (re.compile(r"\bEP\s?(?!26167849\.4\b|26162901\.8\b)\d{6,}(?:\.\d+)?\b"),
+ (re.compile(r"\bEP\s?(?!26167849\.4\b|26162901\.8\b|26166054\.2\b)\d{6,}(?:\.\d+)?\b"),
```

Plus:
- Error-message string updated to list all 3 GraQle patents (CI users see the right reference set when other EP numbers are flagged).
- Comment block updated with provenance: cr-019c, 2026-05-19, motivation (cr-019/cr-021 incidents).

## Test plan

- [x] **Smoke test (regex unit)** — 6 allowlist cases pass (all 3 patents + spacing variants like `EP 26166054.2`, `patent EP26166054.2 covers`); 5 blocklist cases correctly blocked (close-but-different `EP26166054.3` + `EP26167849.5`, plus third-party `EP12345678.9`).
- [x] **End-to-end scanner test** — Ran scanner against a sample CONTRIBUTING-style file listing all 3 patents; exits 0 (`IP Content Gate: PASS — no IP-disclosure markers found.`).
- [x] **No existing test files modified** — there are no dedicated scanner tests under `tests/`, and production test files referencing EP26166054.2 in patent-notice headers (e.g. `tests/test_activation/test_pcst.py:14`) are `.py` and skipped by the `TEXT_EXTENSIONS = {".md", ".txt", ".rst", ".adoc", ".markdown"}` filter on `scripts/ci/ip_content_scan.py:76` — no regression risk.
- [ ] **CI IP Content Gate runs on this PR** — should PASS (PR diff itself contains the 3 allowlisted patent numbers in scanner comments + error string, which is now exactly the allowlist case being added).

## Constitutional note

`scripts/ci/` + `.github/workflows/` exist **only on public master**, not on private (private is configured for a different CI surface). This is therefore the only legitimate **public-only PR** class — no private mirror is needed, and there is no IP risk because the change is to CI tooling, not to product code.

Logged as `V-CR-019c-PUBLIC-ONLY-001` in project memory for the architectural-exception record.

## Risk

**MINIMAL.** Single-character extension of an existing negative-lookahead pattern. No production code touched. No tests modified. Smoke + e2e both PASS locally before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
