### PR TITLE
feat(v0.59.0 PR-1): RFC 8785 canonicalization (Layer 5 Task 1.1)

### DIFF
--- a/graqle/governance/tamper_evidence/__init__.py
+++ b/graqle/governance/tamper_evidence/__init__.py
@@ -1,0 +1,5 @@
+"""Layer 5 cryptographic tamper-evidence (R25-EU01).
+
+RFC 6962 Merkle commitments over RFC 8785-canonicalised governed-trace records,
+anchored to Sigstore Rekor. Built incrementally across v0.59.0 PR-1..PR-7.
+"""

--- a/graqle/governance/tamper_evidence/canonicalize.py
+++ b/graqle/governance/tamper_evidence/canonicalize.py
@@ -1,0 +1,131 @@
+"""RFC 8785 JSON Canonicalization Scheme (JCS) wrapper.
+
+R25-EU01 Task 1.1. Produces the deterministic canonical byte serialization that
+the Merkle leaf hash (PR-2) is computed over. Built on the ``rfc8785`` library
+(pure-Python, Apache-2.0, no transitive deps) for spec-conformant JCS.
+
+Two guarantees this module enforces beyond raw JCS:
+
+1. **Float safety (C-P0-2):** NaN, +/-Infinity, and -0.0 are rejected at the
+   ingestion boundary with :class:`InvalidFloatValueError` — never coerced.
+   These values have no canonical JSON representation (RFC 8785 follows
+   ECMAScript ``JSON.stringify`` which cannot represent them), so allowing them
+   would make the leaf hash non-deterministic across runtimes.
+
+2. **Leaf-input projection (C-P1-2):** :func:`canon_leaf` canonicalizes only the
+   frozen leaf-hash-input field allowlist (see :mod:`leaf_input_schema`), so
+   additive wrapper fields can never change the bytes that enter the Merkle leaf.
+   :func:`canon` canonicalizes a full record (used for the wrapper/signature
+   path, not the leaf).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import rfc8785
+
+from graqle.governance.tamper_evidence.errors import (
+    InvalidFloatValueError,
+    MissingLeafFieldError,
+    NonCanonicalTypeError,
+)
+from graqle.governance.tamper_evidence.leaf_input_schema import (
+    project_leaf_input,
+)
+
+# JSON-native types permitted in a tamper-evidence record. Anything else
+# (Decimal, numpy scalars, datetime, sets, custom __float__ objects, etc.) has
+# no stable canonical JSON form and is rejected at the boundary rather than
+# being coerced — coercion would make the leaf hash non-deterministic.
+# NOTE: bool is a subclass of int; both are allowed (JSON true/false and number).
+_JSON_NATIVE = (dict, list, str, int, float, bool, type(None))
+
+
+# Defense against stack-exhaustion DoS via maliciously deep nested input at the
+# tamper-evidence ingestion boundary. Records are governed traces, not arbitrary
+# user JSON, so legitimate nesting is shallow; 64 is generous headroom.
+_MAX_SCAN_DEPTH = 64
+
+
+def _validate_canonical(obj: Any, _key_path: tuple[Any, ...] = (), depth: int = 0) -> None:
+    """Validate that ``obj`` is safe to canonicalize deterministically.
+
+    Two checks at every node:
+    1. **Type allowlist:** only JSON-native types (dict/list/str/int/float/bool/
+       None) are permitted. Decimal, numpy scalars, datetime, sets, and objects
+       with custom ``__float__`` are rejected with :class:`NonCanonicalTypeError`
+       — they have no stable canonical JSON form and must not reach the hash.
+    2. **Float safety:** NaN, +/-Infinity, and -0.0 are rejected with
+       :class:`InvalidFloatValueError`.
+
+    Bounded by ``_MAX_SCAN_DEPTH`` against stack-exhaustion DoS. The path is
+    tracked as a lightweight tuple and only rendered to a string lazily when an
+    error is actually raised (no per-node string allocation on the happy path).
+    """
+    if depth > _MAX_SCAN_DEPTH:
+        raise InvalidFloatValueError(
+            value=float("nan"),  # sentinel; real cause is over-deep nesting
+            field_path=f"{_render_path(_key_path)} (nesting exceeds {_MAX_SCAN_DEPTH})",
+        )
+    # Type allowlist FIRST (bool/int/float are all instances of the tuple;
+    # exact-type check rejects subclasses like numpy.float64 / IntEnum that could
+    # serialize non-deterministically).
+    if type(obj) not in _JSON_NATIVE:
+        raise NonCanonicalTypeError(
+            type_name=type(obj).__name__, field_path=_render_path(_key_path)
+        )
+    if isinstance(obj, float):  # bool excluded: bool is not float
+        if math.isnan(obj) or math.isinf(obj):
+            raise InvalidFloatValueError(value=obj, field_path=_render_path(_key_path))
+        if obj == 0.0 and math.copysign(1.0, obj) < 0:  # -0.0
+            raise InvalidFloatValueError(value=obj, field_path=_render_path(_key_path))
+    elif isinstance(obj, dict):
+        for key, value in obj.items():
+            _validate_canonical(value, _key_path + (key,), depth + 1)
+    elif isinstance(obj, list):
+        for index, value in enumerate(obj):
+            _validate_canonical(value, _key_path + (index,), depth + 1)
+
+
+def _render_path(key_path: tuple[Any, ...]) -> str:
+    """Render a key-path tuple to a dotted string. Called only on the error path."""
+    if not key_path:
+        return "<root>"
+    parts: list[str] = []
+    for key in key_path:
+        if isinstance(key, int):
+            parts.append(f"[{key}]")
+        else:
+            parts.append(f".{key}" if parts else str(key))
+    return "".join(parts)
+
+
+def canon(record: dict[str, Any]) -> bytes:
+    """Canonicalize a full record to RFC 8785 JCS bytes.
+
+    Rejects non-finite floats first (C-P0-2). Use for wrapper/signature
+    canonicalization. For the Merkle leaf, use :func:`canon_leaf`.
+    """
+    _validate_canonical(record)
+    return rfc8785.dumps(record)
+
+
+def canon_leaf(record: dict[str, Any]) -> bytes:
+    """Canonicalize ONLY the leaf-hash-input field subset (C-P1-2).
+
+    Projects ``record`` onto the frozen LEAF_HASH_FIELDS allowlist, then
+    canonicalizes. Wrapper fields outside the allowlist are excluded, so they
+    can never alter the bytes the Merkle leaf hash is computed over.
+
+    ``proof_format_version`` MUST be present: the replay-attack defense (R25-EU08
+    open question #4) depends on the version being inside the leaf hash. A
+    versionless leaf could be replayed under any version banner, so its absence
+    is rejected here rather than silently producing an unversioned leaf.
+    """
+    leaf = project_leaf_input(record)
+    if "proof_format_version" not in leaf:
+        raise MissingLeafFieldError("proof_format_version")
+    _validate_canonical(leaf)
+    return rfc8785.dumps(leaf)

--- a/graqle/governance/tamper_evidence/errors.py
+++ b/graqle/governance/tamper_evidence/errors.py
@@ -1,0 +1,70 @@
+"""Exceptions for the Layer 5 tamper-evidence module (R25-EU01)."""
+
+from __future__ import annotations
+
+
+class TamperEvidenceError(Exception):
+    """Base class for all Layer 5 tamper-evidence errors."""
+
+
+class InvalidFloatValueError(TamperEvidenceError, ValueError):
+    """A non-finite or non-canonical float reached the canonicalization boundary.
+
+    Raised for NaN, +/-Infinity, and -0.0 (C-P0-2). These values have no stable
+    canonical JSON representation across runtimes, so they are rejected rather
+    than coerced — coercion would silently break cross-implementation leaf-hash
+    determinism.
+
+    Subclasses ``ValueError`` so callers using ``except ValueError`` (and
+    Pydantic validators) catch it naturally.
+    """
+
+    def __init__(self, value: float, field_path: str) -> None:
+        self.value = value
+        self.field_path = field_path
+        super().__init__(
+            f"Non-canonical float {value!r} at field '{field_path}': NaN, "
+            f"Infinity, and -0.0 are not permitted in tamper-evidence records "
+            f"(no stable canonical JSON form). Remove or replace the value."
+        )
+
+
+class NonCanonicalTypeError(TamperEvidenceError, TypeError):
+    """A value of a non-JSON-native type reached the canonicalization boundary.
+
+    Only dict/list/str/int/float/bool/None are permitted. Decimal, numpy
+    scalars, datetime, sets, and objects with custom ``__float__`` are rejected
+    (C-P0-2 hardening) because they have no stable canonical JSON representation
+    and would make the leaf hash non-deterministic if coerced.
+
+    Subclasses ``TypeError`` so ``except (ValueError, TypeError)`` catches the
+    full canonicalization-rejection family.
+    """
+
+    def __init__(self, type_name: str, field_path: str) -> None:
+        self.type_name = type_name
+        self.field_path = field_path
+        super().__init__(
+            f"Non-canonical type {type_name!r} at field '{field_path}': only "
+            f"JSON-native types (object, array, string, number, bool, null) are "
+            f"permitted in tamper-evidence records. Convert the value first."
+        )
+
+
+class MissingLeafFieldError(TamperEvidenceError, ValueError):
+    """A required leaf-hash-input field is absent from a record.
+
+    Currently raised when ``proof_format_version`` is missing from a record
+    passed to ``canon_leaf``: the version must be inside the leaf hash so an old
+    proof cannot be replayed under a new version banner (R25-EU08 open question
+    #4). A versionless leaf is rejected rather than silently produced.
+    """
+
+    def __init__(self, field_name: str) -> None:
+        self.field_name = field_name
+        super().__init__(
+            f"Required leaf-hash-input field '{field_name}' is missing. It is "
+            f"part of the frozen leaf-input subset; its absence would weaken the "
+            f"replay-attack defense (a leaf without it is replayable under any "
+            f"version banner)."
+        )

--- a/graqle/governance/tamper_evidence/leaf_input_schema.py
+++ b/graqle/governance/tamper_evidence/leaf_input_schema.py
@@ -1,0 +1,49 @@
+"""Frozen leaf-hash-input schema for Merkle leaves (R25-EU01 / R25-EU08).
+
+C-P1-2. The Merkle leaf hash (PR-2) is computed over the canonical bytes of a
+RECORD PROJECTED ONTO THIS FROZEN FIELD ALLOWLIST — never over the full record.
+This is the "leaf-hash-input schema vs wrapper schema" separation from R25-EU08:
+
+- Adding a field to the WRAPPER (e.g. created_at_iso, rekor_signed_tree_head) is
+  a MINOR, additive change — safe, because wrapper fields never enter the leaf.
+- Adding/removing/reordering a field in THIS allowlist changes the leaf bytes for
+  every record, breaking forward-compat (an old verifier computes a different
+  leaf hash than a new producer). Such a change is therefore a MAJOR bump that
+  ships with migration tooling — NEVER additive.
+
+``proof_format_version`` is intentionally IN the leaf input (per ADR-RT-002 §3.2
+Q1 / R25-EU08 open question #4 ratification): including it inside the hash defeats
+replay attacks that re-label an old proof under a new version banner.
+
+The allowlist uses an EXPLICIT tuple (not struct/dataclass serialization) so the
+frozen field set is auditable in one place and cannot drift implicitly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# FROZEN. Changing this tuple is a MAJOR proof-format bump requiring migration
+# tooling (R25-EU08). Order is part of the contract — do not reorder.
+LEAF_HASH_FIELDS: tuple[str, ...] = (
+    "proof_format_version",
+    "record_id",
+    "content_hash",
+    "timestamp_unix",
+    "governance_metadata",
+)
+
+# The leaf-hash-input schema version. Bump (MAJOR) only when LEAF_HASH_FIELDS
+# changes; ship migration tooling in the same release.
+LEAF_INPUT_VERSION = "1.0.0"
+
+
+def project_leaf_input(record: dict[str, Any]) -> dict[str, Any]:
+    """Project ``record`` onto the frozen leaf-hash-input allowlist.
+
+    Returns a new dict containing ONLY the LEAF_HASH_FIELDS keys that are
+    present in ``record``. Wrapper fields outside the allowlist are dropped, so
+    they cannot influence the Merkle leaf hash. Keys absent from ``record`` are
+    simply omitted (RFC 8785 canonicalization handles key ordering downstream).
+    """
+    return {key: record[key] for key in LEAF_HASH_FIELDS if key in record}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "pydantic>=2.0",
     "pydantic-settings>=2.0",
     "pyyaml>=6.0",
+    "rfc8785==0.1.4",
     "typer[all]>=0.9",
     "rich>=13.0",
     "fastapi>=0.100",

--- a/tests/test_tamper_evidence/test_canonicalize.py
+++ b/tests/test_tamper_evidence/test_canonicalize.py
@@ -1,0 +1,348 @@
+"""Tests for RFC 8785 canonicalization + leaf-input projection (v0.59.0 PR-1)."""
+
+from __future__ import annotations
+
+import copy
+import math
+
+import pytest
+
+from graqle.governance.tamper_evidence.canonicalize import canon, canon_leaf
+from graqle.governance.tamper_evidence.errors import (
+    InvalidFloatValueError,
+    MissingLeafFieldError,
+    NonCanonicalTypeError,
+    TamperEvidenceError,
+)
+from graqle.governance.tamper_evidence.leaf_input_schema import (
+    LEAF_HASH_FIELDS,
+    project_leaf_input,
+)
+
+try:
+    from hypothesis import given
+    from hypothesis import strategies as st
+
+    _HAS_HYPOTHESIS = True
+except ImportError:  # pragma: no cover - hypothesis is a dev dep
+    _HAS_HYPOTHESIS = False
+
+
+# ---- determinism --------------------------------------------------------------
+
+
+def test_canon_deterministic_key_order():
+    """Same data, different key insertion order -> identical canonical bytes."""
+    a = {"b": 1, "a": 2, "c": 3}
+    b = {"c": 3, "a": 2, "b": 1}
+    assert canon(a) == canon(b)
+
+
+def test_canon_deepcopy_identity():
+    """canon(deepcopy(R)) == canon(R) for a representative record."""
+    record = {
+        "proof_format_version": "1.0.0",
+        "record_id": "tr_01HXJK",
+        "content_hash": "abcdef",
+        "timestamp_unix": 1779000000,
+        "governance_metadata": {"gate": "shacl", "decision": "CLEAR"},
+        "wrapper_only": {"created_at_iso": "2026-05-21T00:00:00Z"},
+    }
+    assert canon(copy.deepcopy(record)) == canon(record)
+
+
+def test_canon_returns_bytes():
+    assert isinstance(canon({"a": 1}), bytes)
+    assert isinstance(
+        canon_leaf({"proof_format_version": "1.0.0", "record_id": "x"}), bytes
+    )
+
+
+if _HAS_HYPOTHESIS:
+    _json_scalars = st.one_of(
+        st.none(),
+        st.booleans(),
+        st.integers(min_value=-(10**12), max_value=10**12),
+        st.text(max_size=40),
+    )
+    _json_values = st.recursive(
+        _json_scalars,
+        lambda children: st.one_of(
+            st.lists(children, max_size=4),
+            st.dictionaries(st.text(min_size=1, max_size=12), children, max_size=4),
+        ),
+        max_leaves=12,
+    )
+
+    @given(st.dictionaries(st.text(min_size=1, max_size=12), _json_values, max_size=5))
+    def test_canon_property_deepcopy_invariant(record):
+        """Property: canonicalization is stable under deep copy (no float NaN/Inf
+        in the strategy, so no rejection path)."""
+        assert canon(copy.deepcopy(record)) == canon(record)
+
+
+# ---- float safety (C-P0-2) ----------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_rejects_nan_and_infinity(bad):
+    with pytest.raises(InvalidFloatValueError):
+        canon({"x": bad})
+
+
+def test_rejects_negative_zero():
+    neg_zero = math.copysign(0.0, -1.0)
+    assert neg_zero == 0.0 and math.copysign(1.0, neg_zero) < 0  # sanity
+    with pytest.raises(InvalidFloatValueError):
+        canon({"x": neg_zero})
+
+
+def test_positive_zero_is_allowed():
+    # Plain 0.0 has a stable canonical form and must NOT be rejected.
+    assert isinstance(canon({"x": 0.0}), bytes)
+
+
+def test_rejects_nested_nonfinite():
+    with pytest.raises(InvalidFloatValueError):
+        canon({"a": {"b": [1, 2, float("inf")]}})
+
+
+def test_invalid_float_error_carries_path_and_is_valueerror():
+    with pytest.raises(InvalidFloatValueError) as exc:
+        canon({"outer": {"inner": float("nan")}})
+    assert "outer.inner" in exc.value.field_path
+    assert isinstance(exc.value, ValueError)
+    assert isinstance(exc.value, TamperEvidenceError)
+
+
+def test_canon_leaf_also_rejects_nonfinite():
+    with pytest.raises(InvalidFloatValueError):
+        canon_leaf(
+            {"proof_format_version": "1.0.0", "timestamp_unix": float("nan")}
+        )
+
+
+def test_rejects_pathologically_deep_nesting():
+    """Stack-exhaustion DoS guard: input nested past _MAX_SCAN_DEPTH raises
+    InvalidFloatValueError (not a bare RecursionError)."""
+    deep: dict = {}
+    node = deep
+    for _ in range(200):  # well past the 64 limit
+        child: dict = {}
+        node["n"] = child
+        node = child
+    with pytest.raises(InvalidFloatValueError):
+        canon(deep)
+
+
+def test_normal_nesting_depth_allowed():
+    """Legitimate shallow nesting is unaffected by the depth guard."""
+    record = {"a": {"b": {"c": {"d": {"e": 1}}}}}
+    assert isinstance(canon(record), bytes)
+
+
+# ---- leaf-input projection (C-P1-2) -------------------------------------------
+
+
+def test_project_leaf_input_drops_wrapper_fields():
+    record = {
+        "proof_format_version": "1.0.0",
+        "record_id": "r1",
+        "content_hash": "h",
+        "timestamp_unix": 1,
+        "governance_metadata": {"k": "v"},
+        "created_at_iso": "2026-01-01T00:00:00Z",  # wrapper - must be dropped
+        "rekor_signed_tree_head": "sth",          # wrapper - must be dropped
+    }
+    projected = project_leaf_input(record)
+    assert set(projected.keys()) == set(LEAF_HASH_FIELDS)
+    assert "created_at_iso" not in projected
+    assert "rekor_signed_tree_head" not in projected
+
+
+def test_project_leaf_input_omits_absent_fields():
+    projected = project_leaf_input({"record_id": "only"})
+    assert projected == {"record_id": "only"}
+
+
+def test_canon_leaf_excludes_wrapper_from_bytes():
+    """A wrapper field added to the record must NOT change the leaf bytes."""
+    base = {
+        "proof_format_version": "1.0.0",
+        "record_id": "r1",
+        "content_hash": "h",
+        "timestamp_unix": 1,
+        "governance_metadata": {"k": "v"},
+    }
+    with_wrapper = {**base, "created_at_iso": "2026-01-01T00:00:00Z"}
+    assert canon_leaf(base) == canon_leaf(with_wrapper)
+
+
+def test_proof_format_version_is_in_leaf_subset():
+    """Replay-attack defense: version must be inside the leaf hash input."""
+    assert "proof_format_version" in LEAF_HASH_FIELDS
+
+
+def test_canon_leaf_rejects_missing_proof_format_version():
+    """canon_leaf MUST reject a record lacking proof_format_version (replay
+    defense — graq_predict chain #2). A versionless leaf would be replayable
+    under any version banner."""
+    with pytest.raises(MissingLeafFieldError):
+        canon_leaf({"record_id": "r1", "content_hash": "h"})  # no version
+
+
+# ---- non-canonical type rejection (security hardening) ------------------------
+
+
+def test_rejects_decimal():
+    """Decimal has no stable canonical JSON form -> NonCanonicalTypeError."""
+    from decimal import Decimal
+
+    with pytest.raises(NonCanonicalTypeError):
+        canon({"x": Decimal("1.5")})
+
+
+def test_rejects_decimal_nan_does_not_slip_through():
+    """A Decimal('NaN') must be rejected by the TYPE check before any float
+    logic (it is not a Python float, so the old isinstance(float) guard would
+    have missed it)."""
+    from decimal import Decimal
+
+    with pytest.raises(NonCanonicalTypeError):
+        canon({"x": Decimal("NaN")})
+
+
+def test_rejects_set_and_datetime():
+    import datetime
+
+    with pytest.raises(NonCanonicalTypeError):
+        canon({"x": {1, 2, 3}})
+    with pytest.raises(NonCanonicalTypeError):
+        canon({"x": datetime.datetime(2026, 1, 1)})
+
+
+def test_rejects_custom_float_object():
+    class Sneaky:
+        def __float__(self):
+            return float("nan")
+
+    with pytest.raises(NonCanonicalTypeError):
+        canon({"x": Sneaky()})
+
+
+def test_non_canonical_type_error_is_typeerror():
+    from decimal import Decimal
+
+    with pytest.raises(NonCanonicalTypeError) as exc:
+        canon({"a": {"b": Decimal("1")}})
+    assert isinstance(exc.value, TypeError)
+    assert isinstance(exc.value, TamperEvidenceError)
+    assert "a.b" in exc.value.field_path
+
+
+def test_bool_and_int_and_str_allowed():
+    """JSON-native types pass the type check."""
+    out = canon({"flag": True, "n": 5, "s": "ok", "nil": None, "f": 1.5})
+    assert isinstance(out, bytes)
+
+
+def test_bool_distinct_and_deterministic_from_int():
+    """bool is a subclass of int but must canonicalize to JSON true/false
+    (distinct from 1/0) and do so deterministically. Confirms no bool/int
+    canonicalization ambiguity in the hash (security sentinel round-2 ask)."""
+    true_bytes = canon({"v": True})
+    one_bytes = canon({"v": 1})
+    false_bytes = canon({"v": False})
+    zero_bytes = canon({"v": 0})
+    # JSON distinguishes true/false from 1/0.
+    assert true_bytes == b'{"v":true}'
+    assert false_bytes == b'{"v":false}'
+    assert one_bytes == b'{"v":1}'
+    assert zero_bytes == b'{"v":0}'
+    assert true_bytes != one_bytes and false_bytes != zero_bytes
+    # Deterministic across repeated calls.
+    assert canon({"v": True}) == true_bytes
+
+
+def test_int_and_float_valued_int_canonicalize_identically():
+    """graq_predict chain #1 (verified safe): an integer and the same
+    integer-valued float produce identical canonical bytes (RFC 8785 / JCS
+    number normalization), so a producer passing 1779000000 vs 1779000000.0
+    does not break cross-record determinism."""
+    as_int = canon_leaf(
+        {"proof_format_version": "1.0.0", "timestamp_unix": 1779000000}
+    )
+    as_float = canon_leaf(
+        {"proof_format_version": "1.0.0", "timestamp_unix": 1779000000.0}
+    )
+    assert as_int == as_float
+
+
+def test_leaf_fields_frozen_order():
+    """Guards accidental reorder/edit of the frozen allowlist (would be a MAJOR
+    proof-format bump requiring migration tooling)."""
+    assert LEAF_HASH_FIELDS == (
+        "proof_format_version",
+        "record_id",
+        "content_hash",
+        "timestamp_unix",
+        "governance_metadata",
+    )
+
+
+# ---- canonical output properties + golden ------------------------------------
+
+
+def test_canonical_output_jcs_properties():
+    """JCS structural guarantees the M3 cross-implementation verifiers rely on:
+    keys are lexicographically sorted, there is no insignificant whitespace, and
+    the output is valid UTF-8 that round-trips to the same data."""
+    import json
+
+    record = {
+        "proof_format_version": "1.0.0",
+        "record_id": "tr_golden_0001",
+        "content_hash": "0" * 64,
+        "timestamp_unix": 1779000000,
+        "governance_metadata": {"gate": "shacl", "decision": "CLEAR"},
+    }
+    out = canon_leaf(record)
+    assert isinstance(out, bytes)
+    text = out.decode("utf-8")  # must be valid UTF-8
+    # No insignificant whitespace (JCS is compact).
+    assert ", " not in text and ": " not in text
+    # Top-level keys are sorted.
+    reparsed = json.loads(text)
+    assert list(reparsed.keys()) == sorted(reparsed.keys())
+    # Round-trips to the same projected data.
+    assert reparsed == {
+        "content_hash": "0" * 64,
+        "governance_metadata": {"decision": "CLEAR", "gate": "shacl"},
+        "proof_format_version": "1.0.0",
+        "record_id": "tr_golden_0001",
+        "timestamp_unix": 1779000000,
+    }
+
+
+def test_golden_vector_frozen():
+    """Capture-and-freeze golden vector: canonicalizing a re-ordered copy of a
+    fixed record yields identical bytes. Catches future JCS-output drift without
+    hardcoding a literal that can't be verified until the dep is installed.
+    A frozen byte literal ships in tests/test_tamper_evidence/golden/ once
+    captured (M3 cross-impl corpus seed)."""
+    record = {
+        "proof_format_version": "1.0.0",
+        "record_id": "tr_golden_0001",
+        "content_hash": "0" * 64,
+        "timestamp_unix": 1779000000,
+        "governance_metadata": {"decision": "CLEAR", "gate": "shacl"},
+    }
+    out = canon_leaf(record)
+    reordered = {
+        "governance_metadata": {"gate": "shacl", "decision": "CLEAR"},
+        "timestamp_unix": 1779000000,
+        "record_id": "tr_golden_0001",
+        "content_hash": "0" * 64,
+        "proof_format_version": "1.0.0",
+    }
+    assert canon_leaf(reordered) == out


### PR DESCRIPTION
## v0.59.0 PR-1 — RFC 8785 canonicalization (Layer 5 Task 1.1)

Second PR of the v0.59.0 cryptographic tamper-evidence build. The deterministic canonical byte serialization the Merkle leaf hash (PR-2) is computed over. Cherry-picked from merged private PR (`research-development-graqle#137`). **No version bump** (deferred to PR-7).

### What this PR adds

New `graqle/governance/tamper_evidence/` subpackage:
- `canonicalize.py` — `canon()` + `canon_leaf()` over `rfc8785`
- `errors.py` — `TamperEvidenceError` + `InvalidFloatValueError` / `NonCanonicalTypeError` / `MissingLeafFieldError`
- `leaf_input_schema.py` — frozen `LEAF_HASH_FIELDS` allowlist + `project_leaf_input()`
- `tests/test_tamper_evidence/test_canonicalize.py` — **29 tests**
- `pyproject.toml` — `+ rfc8785==0.1.4` (Apache-2.0, pure-Python, no transitive deps)

### Security guarantees (all tested)

- C-P0-2 float safety (NaN/±Inf/-0.0 rejected)
- Type allowlist (Decimal/numpy/datetime/set/custom-`__float__` rejected via exact `type()` check)
- Stack-exhaustion DoS guard (depth 64) + lazy path-rendering
- C-P1-2 leaf-vs-wrapper separation (wrapper fields never alter leaf bytes)
- Replay defense (`canon_leaf` requires `proof_format_version`)
- int/float + bool/int canonicalize deterministically (verified)

### Governance

- ADR-209 Phase 7 triple sentinel: `review(all)` caught a DoS, `graq_predict` caught a replay gap, `review(security)` caught a type bypass → all fixed → **APPROVED 95%, 0 BLOCKERs, OWASP Top 10 clean**.
- 29 tests pass with real `rfc8785==0.1.4`. Private-side CI: **CI GREEN, KG Scan GREEN** (private Deploy Lambda fails pre-existing — unrelated infra drift).
- Cherry-picked from merged private PR #137 per ABSOLUTE RULE #0.

### After you merge

PR-2 (`merkle.py`) begins — RFC 6962 Merkle tree + inclusion proofs over these canonical bytes.

🤖 Governed via GraQle ADR-209. Co-Authored-By: Claude Opus 4.7
