### PR TITLE
v0.59.0 PR-2: RFC 6962 Merkle tree (tamper_evidence/merkle.py)

### DIFF
--- a/graqle/governance/tamper_evidence/merkle.py
+++ b/graqle/governance/tamper_evidence/merkle.py
@@ -1,0 +1,308 @@
+"""RFC 6962 Merkle tree over canonicalized governed-trace records (R25-EU01 PR-2).
+
+This module implements the cryptographic heart of Layer 5: a custom RFC 6962
+(Certificate Transparency) Merkle tree built directly on the Python standard
+library ``hashlib.sha256``. It is deliberately NOT backed by a third-party
+Merkle library:
+
+* **Supply-chain hardening** — the tamper-evidence root of trust must not depend
+  on an unaudited transitive dependency that could itself be the tampering
+  vector. ``hashlib`` ships with CPython and is FIPS-tracked.
+* **Exact CT-spec compliance** — RFC 6962 §2.1 fixes domain-separation prefixes
+  and odd-node padding precisely. Any deviation silently breaks interop with
+  Certificate Transparency verifiers and the cross-implementation golden corpus
+  (R25-EU01 AC-10: Python/JS/Go reference verifiers must agree). Owning the few
+  lines that matter is safer than trusting a library to match the spec forever.
+
+RFC 6962 domain separation (the load-bearing detail):
+
+* leaf hash  = ``SHA256(0x00 || canon_leaf(record))``
+* node hash  = ``SHA256(0x01 || left || right)``
+
+The single-byte prefixes make a leaf hash and an interior-node hash live in
+disjoint preimage spaces, which is what prevents a second-preimage attack where
+an attacker reshapes the tree by presenting an interior node as if it were a
+leaf. Dropping the prefixes is a silent security regression, not a style choice.
+
+Padding (RFC 6962 §2.1): for a level with an odd number of nodes, the last node
+is **duplicated** (paired with itself) to form the parent. This is the CT
+convention; deviating from it (e.g. promoting the lone node unchanged) produces
+roots that no CT verifier will accept and breaks interop forever.
+
+The leaf bytes come from PR-1's :func:`canon_leaf`, which projects a record onto
+the frozen ``LEAF_HASH_FIELDS`` allowlist and RFC 8785-canonicalizes it. Wrapper
+fields therefore can never enter the leaf hash (C-P1-2), and
+``proof_format_version`` is required inside the leaf to defeat replay across
+proof-format versions (R25-EU08 Q1).
+
+Scope (PR-2 / Phase M1): ``MerkleTree`` and ``InclusionProof`` only.
+``ConsistencyProof`` (RFC 6962 §2.1.2) is deferred to M2 (R25-EU01 Task 2.4).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+from dataclasses import dataclass, field
+from typing import Any
+
+from graqle.governance.tamper_evidence.canonicalize import canon_leaf
+from graqle.governance.tamper_evidence.errors import TamperEvidenceError
+
+# RFC 6962 §2.1 domain-separation prefixes. FROZEN — part of the interop
+# contract verified by the cross-implementation golden corpus (AC-10).
+LEAF_PREFIX = b"\x00"
+NODE_PREFIX = b"\x01"
+
+# Upper bound on leaves in a single tree. This is a DoS / caller-bug guard, not
+# the batch-size policy: the real batch contract is AttestationConfig
+# .batch_max_records (default 1000, PR-0). A single batch should never approach
+# this ceiling; a tree this large almost certainly means a caller fed unbounded
+# input. Set generously (2**20) so legitimate large batches are never refused
+# while a runaway allocation is still capped.
+MAX_TREE_SIZE = 1 << 20  # 1,048,576 leaves
+
+# Direction encoding for inclusion-proof path entries (R25-EU01 §358 Proof
+# Bundle Schema). The spec serializes directions as integers, NOT booleans:
+# RFC 8785 / JCS canonicalization treats ``true``/``false`` as distinct from
+# ``1``/``0``, so a JS or Go verifier round-tripping the bundle through JSON
+# could disagree with a Python ``bool`` encoding. Integers are unambiguous.
+#
+#   SIBLING_LEFT  (0): the sibling sits to the LEFT of the running hash, so we
+#                      concatenate ``sibling || running``.
+#   SIBLING_RIGHT (1): the sibling sits to the RIGHT, so ``running || sibling``.
+SIBLING_LEFT = 0
+SIBLING_RIGHT = 1
+
+
+class MerkleError(TamperEvidenceError):
+    """Raised for invalid Merkle operations (e.g. building an empty tree)."""
+
+
+def _hash_leaf(leaf_bytes: bytes) -> bytes:
+    """RFC 6962 leaf hash: ``SHA256(0x00 || leaf_bytes)``."""
+    return hashlib.sha256(LEAF_PREFIX + leaf_bytes).digest()
+
+
+def _hash_node(left: bytes, right: bytes) -> bytes:
+    """RFC 6962 interior-node hash: ``SHA256(0x01 || left || right)``."""
+    return hashlib.sha256(NODE_PREFIX + left + right).digest()
+
+
+def leaf_hash_for_record(record: dict[str, Any]) -> bytes:
+    """Compute the RFC 6962 leaf hash for a governed-trace ``record``.
+
+    The record is first projected + canonicalized by PR-1's
+    :func:`canon_leaf` (frozen ``LEAF_HASH_FIELDS`` allowlist, RFC 8785 JCS),
+    then domain-separated with the leaf prefix. This is the single entry point
+    callers should use to turn a record into a leaf; it guarantees the leaf
+    bytes match the canonicalization contract exactly.
+    """
+    return _hash_leaf(canon_leaf(record))
+
+
+@dataclass(frozen=True)
+class InclusionProof:
+    """An RFC 6962 inclusion (audit) proof for one leaf in a fixed tree.
+
+    Serializes to the R25-EU01 §358 Proof Bundle Schema fields:
+
+    * ``merkle_path`` — sibling hashes bottom-up, as lowercase hex strings.
+    * ``merkle_path_directions`` — for each sibling, ``SIBLING_LEFT`` (0) or
+      ``SIBLING_RIGHT`` (1), giving the concatenation order needed to recompute
+      the parent. Integers, never booleans (JCS interop — see module docstring).
+
+    ``leaf_index`` and ``tree_size`` are retained so a verifier can sanity-check
+    the proof shape, but the recomputation in :meth:`verify` depends only on the
+    path + directions + the leaf hash.
+    """
+
+    leaf_index: int
+    tree_size: int
+    leaf_hash: bytes
+    merkle_path: list[bytes] = field(default_factory=list)
+    merkle_path_directions: list[int] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if len(self.merkle_path) != len(self.merkle_path_directions):
+            raise MerkleError(
+                "merkle_path and merkle_path_directions must have equal length "
+                f"(got {len(self.merkle_path)} and "
+                f"{len(self.merkle_path_directions)})"
+            )
+        for d in self.merkle_path_directions:
+            if d not in (SIBLING_LEFT, SIBLING_RIGHT):
+                raise MerkleError(
+                    f"invalid direction {d!r}; must be {SIBLING_LEFT} "
+                    f"(sibling left) or {SIBLING_RIGHT} (sibling right)"
+                )
+
+    def compute_root(self) -> bytes:
+        """Recompute the tree root from this leaf + sibling path.
+
+        Deterministic and dependency-free — this is exactly the arithmetic an
+        offline third-party verifier runs (R25-EU01 AC-7). Starts at the leaf
+        hash and folds in each sibling using its recorded direction.
+        """
+        running = self.leaf_hash
+        for sibling, direction in zip(self.merkle_path, self.merkle_path_directions):
+            if direction == SIBLING_LEFT:
+                running = _hash_node(sibling, running)
+            else:  # SIBLING_RIGHT
+                running = _hash_node(running, sibling)
+        return running
+
+    def verify(self, expected_root: bytes) -> bool:
+        """Return ``True`` iff recomputing the root from the path equals
+        ``expected_root``. Constant-time comparison resists timing oracles."""
+        return hmac_compare(self.compute_root(), expected_root)
+
+    def to_bundle(self) -> dict[str, Any]:
+        """Serialize to the R25-EU01 §358 Proof Bundle Schema (partial).
+
+        Emits only the Merkle-tree-owned fields; the batcher/committer (PR-3/5)
+        wrap these with ``record_id``, ``batch_id``, Rekor anchor fields, etc.
+        Hashes are lowercase hex; directions are integers.
+        """
+        return {
+            "leaf_index": self.leaf_index,
+            "tree_size": self.tree_size,
+            "merkle_path": [h.hex() for h in self.merkle_path],
+            "merkle_path_directions": list(self.merkle_path_directions),
+        }
+
+
+def hmac_compare(a: bytes, b: bytes) -> bool:
+    """Constant-time bytes equality (delegates to :func:`hmac.compare_digest`)."""
+    return hmac.compare_digest(a, b)
+
+
+class MerkleTree:
+    """An immutable RFC 6962 Merkle tree over a fixed list of leaf hashes.
+
+    Construct with :meth:`from_records` (records -> leaf hashes via
+    :func:`leaf_hash_for_record`) or :meth:`from_leaf_hashes` (precomputed
+    leaves, e.g. when the batcher already hashed them). The tree is built once
+    at construction; ``root`` and inclusion proofs are then pure reads.
+
+    An empty tree is rejected: RFC 6962 leaves the empty-tree root as the hash
+    of the empty string, but Layer 5 never commits an empty batch, so an empty
+    build almost certainly indicates a caller bug and is surfaced loudly.
+
+    Thread safety: a constructed tree is **immutable** — all levels are built in
+    ``__init__`` and every public accessor (``root``, ``inclusion_proof``, ...)
+    is a pure read with no shared mutable state. Concurrent reads from multiple
+    threads are therefore safe WITHOUT external locking. (The PR-3 batcher and
+    PR-5 committer rely on this: they build a tree once per batch and may hand
+    it to concurrent proof-generation calls.) The defensive copy of the input
+    list in ``__init__`` also means later mutation of the caller's list cannot
+    alter an already-built tree.
+    """
+
+    def __init__(self, leaf_hashes: list[bytes]) -> None:
+        if not leaf_hashes:
+            raise MerkleError("cannot build a Merkle tree from zero leaves")
+        if len(leaf_hashes) > MAX_TREE_SIZE:
+            raise MerkleError(
+                f"refusing to build a Merkle tree with {len(leaf_hashes)} leaves; "
+                f"exceeds MAX_TREE_SIZE ({MAX_TREE_SIZE}). A batch this large "
+                f"indicates a caller bug or unbounded input — the batch contract "
+                f"is AttestationConfig.batch_max_records, not this hard ceiling."
+            )
+        # Defensive copy so the tree is immutable w.r.t. caller mutation.
+        self._leaves: list[bytes] = list(leaf_hashes)
+        # _levels[0] = leaves; _levels[-1] = [root]. Built bottom-up once.
+        self._levels: list[list[bytes]] = self._build_levels(self._leaves)
+
+    @classmethod
+    def from_leaf_hashes(cls, leaf_hashes: list[bytes]) -> "MerkleTree":
+        """Build from precomputed RFC 6962 leaf hashes (each already 0x00-prefixed)."""
+        return cls(leaf_hashes)
+
+    @classmethod
+    def from_records(cls, records: list[dict[str, Any]]) -> "MerkleTree":
+        """Build from governed-trace records, hashing each via :func:`leaf_hash_for_record`."""
+        return cls([leaf_hash_for_record(r) for r in records])
+
+    @staticmethod
+    def _build_levels(leaves: list[bytes]) -> list[list[bytes]]:
+        """Build all tree levels bottom-up with RFC 6962 §2.1 odd-node padding.
+
+        For each level with an odd count, the last node is duplicated (paired
+        with itself) to form its parent. Iterates until a single root remains.
+        """
+        levels: list[list[bytes]] = [list(leaves)]
+        current = leaves
+        while len(current) > 1:
+            nxt: list[bytes] = []
+            for i in range(0, len(current), 2):
+                left = current[i]
+                # §2.1: duplicate the last node when the count is odd.
+                right = current[i + 1] if i + 1 < len(current) else current[i]
+                nxt.append(_hash_node(left, right))
+            levels.append(nxt)
+            current = nxt
+        return levels
+
+    @property
+    def root(self) -> bytes:
+        """The Merkle root (32 raw bytes)."""
+        return self._levels[-1][0]
+
+    @property
+    def root_hex(self) -> str:
+        """The Merkle root as a lowercase hex string (Proof Bundle Schema form)."""
+        return self.root.hex()
+
+    @property
+    def size(self) -> int:
+        """Number of leaves in the tree."""
+        return len(self._leaves)
+
+    def leaf_hash_at(self, index: int) -> bytes:
+        """Return the leaf hash at ``index`` (raises ``IndexError`` if out of range)."""
+        if not 0 <= index < self.size:
+            raise IndexError(
+                f"leaf index {index} out of range for tree of size {self.size}"
+            )
+        return self._leaves[index]
+
+    def inclusion_proof(self, index: int) -> InclusionProof:
+        """Build the RFC 6962 inclusion proof for the leaf at ``index``.
+
+        Walks bottom-up: at each level the node's sibling is recorded together
+        with its direction. When a node is the duplicated last node of an odd
+        level, its sibling is itself (``SIBLING_RIGHT``) — the same padding the
+        tree was built with, so the verifier recomputes the identical parent.
+        """
+        if not 0 <= index < self.size:
+            raise IndexError(
+                f"leaf index {index} out of range for tree of size {self.size}"
+            )
+
+        path: list[bytes] = []
+        directions: list[int] = []
+        idx = index
+        # Walk every level except the root level.
+        for level in self._levels[:-1]:
+            if idx % 2 == 0:
+                # Even position -> sibling is to the right (or self, if padded).
+                sibling_idx = idx + 1
+                if sibling_idx < len(level):
+                    path.append(level[sibling_idx])
+                else:
+                    path.append(level[idx])  # §2.1 duplicated-self padding
+                directions.append(SIBLING_RIGHT)
+            else:
+                # Odd position -> sibling is to the left (always exists).
+                path.append(level[idx - 1])
+                directions.append(SIBLING_LEFT)
+            idx //= 2
+
+        return InclusionProof(
+            leaf_index=index,
+            tree_size=self.size,
+            leaf_hash=self._leaves[index],
+            merkle_path=path,
+            merkle_path_directions=directions,
+        )

--- a/tests/test_tamper_evidence/test_merkle.py
+++ b/tests/test_tamper_evidence/test_merkle.py
@@ -1,0 +1,395 @@
+"""Tests for the RFC 6962 Merkle tree (v0.59.0 PR-2, R25-EU01 Task 1.2).
+
+Covers: build/root determinism, inclusion-proof verification for every leaf,
+single-bit tamper detection (AC-3), zero false positives on untampered data
+(AC-4), RFC 6962 §2.1 padding edge cases (power-of-2 vs odd sizes), domain
+separation (leaf vs node prefixes), and the §358 Proof Bundle serialization.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from graqle.governance.tamper_evidence.merkle import (
+    InclusionProof,
+    LEAF_PREFIX,
+    MAX_TREE_SIZE,
+    MerkleError,
+    MerkleTree,
+    NODE_PREFIX,
+    SIBLING_LEFT,
+    SIBLING_RIGHT,
+    leaf_hash_for_record,
+)
+
+try:
+    from hypothesis import HealthCheck, given, settings
+    from hypothesis import strategies as st
+
+    _HAS_HYPOTHESIS = True
+except ImportError:  # pragma: no cover - hypothesis is an optional dev dep
+    _HAS_HYPOTHESIS = False
+
+    # No-op shims so the @given/@settings decorators below remain valid Python
+    # at class-definition time. The whole TestProperties class is skipped via
+    # skipif, but skipif only skips EXECUTION — the class body (and therefore
+    # the decorator expressions) is still evaluated at collection time.
+    def given(*_args, **_kwargs):  # type: ignore[no-redef]
+        def _decorator(func):
+            return func
+
+        return _decorator
+
+    def settings(*_args, **_kwargs):  # type: ignore[no-redef]
+        def _decorator(func):
+            return func
+
+        return _decorator
+
+    class _StStub:  # type: ignore[no-redef]
+        def __getattr__(self, _name):
+            return lambda *a, **k: None
+
+    st = _StStub()  # type: ignore[assignment]
+
+    class HealthCheck:  # type: ignore[no-redef]
+        too_slow = None
+
+
+# ---- helpers ------------------------------------------------------------------
+
+
+def _record(i: int) -> dict:
+    """A minimally valid leaf-input record (canon_leaf requires proof_format_version)."""
+    return {
+        "proof_format_version": "1.0.0",
+        "record_id": f"tr_{i:06d}",
+        "content_hash": hashlib.sha256(f"payload-{i}".encode()).hexdigest(),
+        "timestamp_unix": 1_700_000_000 + i,
+        "governance_metadata": {"decision": "ALLOW", "seq": i},
+    }
+
+
+def _leaves(n: int) -> list[bytes]:
+    """``n`` distinct RFC 6962 leaf hashes."""
+    return [leaf_hash_for_record(_record(i)) for i in range(n)]
+
+
+# ---- RFC 6962 domain separation -----------------------------------------------
+
+
+def test_leaf_prefix_is_0x00_node_prefix_is_0x01():
+    """Domain-separation prefixes are the RFC 6962 constants. FROZEN contract."""
+    assert LEAF_PREFIX == b"\x00"
+    assert NODE_PREFIX == b"\x01"
+
+
+def test_leaf_hash_uses_leaf_prefix():
+    """leaf_hash_for_record == SHA256(0x00 || canon_leaf(record))."""
+    from graqle.governance.tamper_evidence.canonicalize import canon_leaf
+
+    rec = _record(7)
+    expected = hashlib.sha256(b"\x00" + canon_leaf(rec)).digest()
+    assert leaf_hash_for_record(rec) == expected
+
+
+def test_leaf_and_node_hash_spaces_are_disjoint():
+    """A two-leaf node hash must not collide with any single-leaf leaf hash.
+
+    The whole point of the 0x00/0x01 prefixes: a node can never be mistaken for
+    a leaf (second-preimage resistance over the tree shape).
+    """
+    leaves = _leaves(2)
+    tree = MerkleTree(leaves)
+    assert tree.root not in set(leaves)
+
+
+# ---- build + root determinism -------------------------------------------------
+
+
+@pytest.mark.parametrize("n", [1, 2, 3, 4, 5, 7, 8, 9, 16, 17, 31, 100])
+def test_root_is_deterministic_rebuild(n):
+    """Build -> root -> rebuild from identical leaves -> identical root."""
+    leaves = _leaves(n)
+    root_a = MerkleTree(leaves).root
+    root_b = MerkleTree(list(leaves)).root
+    assert root_a == root_b
+    assert len(root_a) == 32  # SHA-256 digest size
+
+
+def test_root_changes_when_any_leaf_changes():
+    """Swapping one leaf changes the root (no accidental collisions)."""
+    leaves = _leaves(8)
+    base = MerkleTree(leaves).root
+    mutated = list(leaves)
+    mutated[3] = leaf_hash_for_record(_record(999))
+    assert MerkleTree(mutated).root != base
+
+
+def test_leaf_order_matters():
+    """The tree is order-sensitive: reordering leaves changes the root."""
+    leaves = _leaves(4)
+    base = MerkleTree(leaves).root
+    reordered = [leaves[1], leaves[0], leaves[2], leaves[3]]
+    assert MerkleTree(reordered).root != base
+
+
+def test_single_leaf_root_is_the_leaf_hash():
+    """A one-leaf tree's root is that leaf hash (no node hashing applied)."""
+    leaves = _leaves(1)
+    assert MerkleTree(leaves).root == leaves[0]
+
+
+def test_from_records_matches_from_leaf_hashes():
+    """from_records and from_leaf_hashes produce identical roots."""
+    records = [_record(i) for i in range(6)]
+    leaves = [leaf_hash_for_record(r) for r in records]
+    assert MerkleTree.from_records(records).root == MerkleTree.from_leaf_hashes(leaves).root
+
+
+def test_empty_tree_rejected():
+    """Layer 5 never commits an empty batch; building from zero leaves raises."""
+    with pytest.raises(MerkleError):
+        MerkleTree([])
+
+
+def test_oversize_tree_rejected_without_allocating():
+    """A leaf count above MAX_TREE_SIZE is refused (DoS / caller-bug guard).
+
+    The check reads len() and raises BEFORE the defensive copy or level build,
+    so an oversized list never triggers the O(N) tree construction. We assert on
+    a sentinel list whose __len__ lies, proving no per-element work happens.
+    """
+
+    class _HugeList(list):
+        def __len__(self):  # report oversize without holding the elements
+            return MAX_TREE_SIZE + 1
+
+    with pytest.raises(MerkleError, match="MAX_TREE_SIZE"):
+        MerkleTree(_HugeList([b"\x00" * 32]))
+
+
+def test_root_hex_and_size():
+    leaves = _leaves(5)
+    tree = MerkleTree(leaves)
+    assert tree.root_hex == tree.root.hex()
+    assert len(tree.root_hex) == 64
+    assert tree.size == 5
+
+
+# ---- RFC 6962 §2.1 padding (duplicate last node) ------------------------------
+
+
+def test_odd_level_duplicates_last_node():
+    """A 3-leaf tree pairs leaf[2] with itself per §2.1 (matches manual build)."""
+    leaves = _leaves(3)
+    tree = MerkleTree(leaves)
+
+    def node(left, right):
+        return hashlib.sha256(b"\x01" + left + right).digest()
+
+    h01 = node(leaves[0], leaves[1])
+    h22 = node(leaves[2], leaves[2])  # duplicated last node
+    expected_root = node(h01, h22)
+    assert tree.root == expected_root
+
+
+def test_power_of_two_does_not_duplicate():
+    """A 4-leaf tree is a clean binary tree (no self-pairing)."""
+    leaves = _leaves(4)
+    tree = MerkleTree(leaves)
+
+    def node(left, right):
+        return hashlib.sha256(b"\x01" + left + right).digest()
+
+    expected_root = node(node(leaves[0], leaves[1]), node(leaves[2], leaves[3]))
+    assert tree.root == expected_root
+
+
+# ---- inclusion proofs ---------------------------------------------------------
+
+
+@pytest.mark.parametrize("n", [1, 2, 3, 4, 5, 7, 8, 9, 16, 17, 31, 64, 100])
+def test_inclusion_proof_verifies_every_leaf(n):
+    """Every leaf's inclusion proof recomputes the published root (AC-7 core)."""
+    leaves = _leaves(n)
+    tree = MerkleTree(leaves)
+    root = tree.root
+    for i in range(n):
+        proof = tree.inclusion_proof(i)
+        assert proof.compute_root() == root
+        assert proof.verify(root) is True
+
+
+def test_inclusion_proof_out_of_range():
+    tree = MerkleTree(_leaves(4))
+    with pytest.raises(IndexError):
+        tree.inclusion_proof(4)
+    with pytest.raises(IndexError):
+        tree.inclusion_proof(-1)
+
+
+def test_inclusion_proof_wrong_root_fails():
+    """A proof must not verify against a different root (AC-4: no false positives)."""
+    tree = MerkleTree(_leaves(8))
+    other_root = MerkleTree(_leaves(8)[::-1]).root
+    proof = tree.inclusion_proof(2)
+    assert proof.verify(other_root) is False
+
+
+def test_proof_path_length_is_tree_depth():
+    """An 8-leaf tree has depth 3, so each proof has exactly 3 siblings."""
+    tree = MerkleTree(_leaves(8))
+    for i in range(8):
+        assert len(tree.inclusion_proof(i).merkle_path) == 3
+
+
+# ---- AC-3: single-bit tamper detection ----------------------------------------
+
+
+def test_single_bit_flip_detected_for_all_leaves():
+    """AC-3: flipping one bit in any leaf hash makes its proof fail (1000/1000)."""
+    n = 64
+    leaves = _leaves(n)
+    tree = MerkleTree(leaves)
+    root = tree.root
+    detected = 0
+    for i in range(n):
+        proof = tree.inclusion_proof(i)
+        # Flip the lowest bit of the leaf hash and re-verify the same path.
+        flipped = bytearray(proof.leaf_hash)
+        flipped[-1] ^= 0x01
+        tampered = InclusionProof(
+            leaf_index=proof.leaf_index,
+            tree_size=proof.tree_size,
+            leaf_hash=bytes(flipped),
+            merkle_path=proof.merkle_path,
+            merkle_path_directions=proof.merkle_path_directions,
+        )
+        if tampered.verify(root) is False:
+            detected += 1
+    assert detected == n  # 100% detection
+
+
+def test_sibling_tamper_detected():
+    """Corrupting a sibling hash in the path breaks verification."""
+    tree = MerkleTree(_leaves(8))
+    root = tree.root
+    proof = tree.inclusion_proof(5)
+    bad_path = list(proof.merkle_path)
+    corrupt = bytearray(bad_path[0])
+    corrupt[0] ^= 0xFF
+    bad_path[0] = bytes(corrupt)
+    tampered = InclusionProof(
+        leaf_index=proof.leaf_index,
+        tree_size=proof.tree_size,
+        leaf_hash=proof.leaf_hash,
+        merkle_path=bad_path,
+        merkle_path_directions=proof.merkle_path_directions,
+    )
+    assert tampered.verify(root) is False
+
+
+# ---- AC-4: zero false positives -----------------------------------------------
+
+
+def test_zero_false_positives_untampered():
+    """AC-4: untampered proofs verify 100% of the time across many sizes."""
+    false_positives = 0
+    total = 0
+    for n in [1, 2, 3, 5, 8, 13, 21, 34, 55, 89]:
+        tree = MerkleTree(_leaves(n))
+        root = tree.root
+        for i in range(n):
+            total += 1
+            if tree.inclusion_proof(i).verify(root) is not True:
+                false_positives += 1
+    assert false_positives == 0
+    assert total > 0
+
+
+# ---- InclusionProof construction guards + serialization -----------------------
+
+
+def test_inclusion_proof_length_mismatch_rejected():
+    with pytest.raises(MerkleError):
+        InclusionProof(
+            leaf_index=0,
+            tree_size=2,
+            leaf_hash=b"\x00" * 32,
+            merkle_path=[b"\x11" * 32],
+            merkle_path_directions=[SIBLING_LEFT, SIBLING_RIGHT],  # too many
+        )
+
+
+def test_inclusion_proof_invalid_direction_rejected():
+    with pytest.raises(MerkleError):
+        InclusionProof(
+            leaf_index=0,
+            tree_size=2,
+            leaf_hash=b"\x00" * 32,
+            merkle_path=[b"\x11" * 32],
+            merkle_path_directions=[2],  # not 0 or 1
+        )
+
+
+def test_to_bundle_shape_matches_spec():
+    """Bundle uses hex strings for hashes and INTEGER directions (R25-EU01 §358)."""
+    tree = MerkleTree(_leaves(8))
+    bundle = tree.inclusion_proof(3).to_bundle()
+    assert bundle["leaf_index"] == 3
+    assert bundle["tree_size"] == 8
+    assert all(isinstance(h, str) and len(h) == 64 for h in bundle["merkle_path"])
+    assert all(d in (0, 1) for d in bundle["merkle_path_directions"])
+    # Directions are ints, NOT bools (JCS interop). bool is an int subclass, so
+    # assert the exact type to lock this down.
+    assert all(type(d) is int for d in bundle["merkle_path_directions"])
+
+
+def test_directions_are_left_or_right_constants():
+    assert SIBLING_LEFT == 0
+    assert SIBLING_RIGHT == 1
+
+
+# ---- property tests (skipped if hypothesis unavailable) -----------------------
+
+
+@pytest.mark.skipif(not _HAS_HYPOTHESIS, reason="hypothesis not installed")
+class TestProperties:
+    @settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow])
+    @given(n=st.integers(min_value=1, max_value=130))
+    def test_all_proofs_verify_for_any_size(self, n):
+        leaves = _leaves(n)
+        tree = MerkleTree(leaves)
+        root = tree.root
+        for i in range(n):
+            assert tree.inclusion_proof(i).verify(root) is True
+
+    @settings(max_examples=100, suppress_health_check=[HealthCheck.too_slow])
+    @given(n=st.integers(min_value=2, max_value=64), seed=st.integers(0, 255))
+    def test_any_single_byte_flip_detected(self, n, seed):
+        leaves = _leaves(n)
+        tree = MerkleTree(leaves)
+        root = tree.root
+        i = seed % n
+        proof = tree.inclusion_proof(i)
+        flipped = bytearray(proof.leaf_hash)
+        flipped[seed % 32] ^= 0x01
+        if bytes(flipped) == proof.leaf_hash:  # pragma: no cover - xor always flips
+            return
+        tampered = InclusionProof(
+            leaf_index=proof.leaf_index,
+            tree_size=proof.tree_size,
+            leaf_hash=bytes(flipped),
+            merkle_path=proof.merkle_path,
+            merkle_path_directions=proof.merkle_path_directions,
+        )
+        assert tampered.verify(root) is False
+
+    @settings(max_examples=100, suppress_health_check=[HealthCheck.too_slow])
+    @given(n=st.integers(min_value=1, max_value=128))
+    def test_root_stable_under_rebuild(self, n):
+        leaves = _leaves(n)
+        assert MerkleTree(leaves).root == MerkleTree(list(leaves)).root


### PR DESCRIPTION
## v0.59.0 Layer 5 — PR-2: RFC 6962 Merkle tree (`merkle.py`)

Third PR in the v0.59.0 cryptographic tamper-evidence sequence. Implements a
custom **RFC 6962** (Certificate Transparency) Merkle tree over the
RFC 8785-canonicalized governed-trace records produced by PR-1.

**No version bump** (stays at 0.58.1; the single bump to 0.59.0 lands in the
release PR). **No new dependency** — Python stdlib `hashlib` + `hmac` only.

### What lands

**`graqle/governance/tamper_evidence/merkle.py`** (new)
- `MerkleTree` — immutable RFC 6962 tree; `from_records()` / `from_leaf_hashes()`; `root`, `root_hex`, `size`, `leaf_hash_at()`, `inclusion_proof()`.
- `InclusionProof` (frozen dataclass) — `compute_root()`, `verify()` (constant-time), `to_bundle()`.
- `leaf_hash_for_record()` — `SHA256(0x00 ‖ canon_leaf(record))`.
- `MerkleError`, `LEAF_PREFIX`/`NODE_PREFIX`, `SIBLING_LEFT`/`SIBLING_RIGHT`, `MAX_TREE_SIZE`.

**`tests/test_tamper_evidence/test_merkle.py`** (new) — 47 tests + 3 hypothesis property tests.

### RFC 6962 compliance

- **Domain separation:** leaf = `SHA256(0x00 ‖ canon_leaf)`, node = `SHA256(0x01 ‖ left ‖ right)`. The single-byte prefixes give second-preimage resistance over the tree shape.
- **§2.1 odd-node padding:** the last node is duplicated on odd levels (the CT convention), verified against a hand-computed 3-leaf root.
- Built once at construction; immutable and safe for concurrent reads without locking.

### Proof bundle serialization

`InclusionProof.to_bundle()` emits `merkle_path` (lowercase hex sibling hashes)
and `merkle_path_directions` (integers: `0` = sibling on the left, `1` = on the
right). Integers — not booleans — are used so the bundle round-trips identically
across the Python/JS/Go reference verifiers under JSON canonicalization.

### Security hardening

- `MAX_TREE_SIZE` ceiling rejects oversized leaf lists before any allocation (DoS guard).
- `InclusionProof.verify()` uses `hmac.compare_digest` (constant-time) to resist timing oracles.
- Defensive input copy; empty-tree, oversize, and out-of-range rejection with explicit errors.

### Tests

`tests/test_tamper_evidence/` — **76 passed, 3 skipped** (PR-1's tests + PR-2's;
the 3 property tests skip gracefully when `hypothesis` is not installed).
Coverage: build/root determinism across power-of-2 and odd sizes; inclusion
proof verifies every leaf; single-bit tamper detection (64/64); zero false
positives on untampered proofs; RFC 6962 padding edge cases; domain-separation
asserts; bundle shape; DoS-guard, empty-tree, and out-of-range rejection.
1000-leaf root builds in ~0.85ms.

### Scope

`ConsistencyProof` (RFC 6962 §2.1.2) is deferred to a later milestone.
