### PR TITLE
v0.59.0 Layer 5: batcher coverage (PR-3b) + Rekor anchor & replay queue (PR-4)

### DIFF
--- a/graqle/governance/tamper_evidence/anchors/__init__.py
+++ b/graqle/governance/tamper_evidence/anchors/__init__.py
@@ -1,0 +1,7 @@
+"""External anchor backends for Layer 5 tamper-evidence (R25-EU01).
+
+An anchor submits a Merkle batch root to an external append-only transparency
+log and returns a receipt proving the root was logged. Phase 1 ships the
+Sigstore Rekor anchor (:mod:`graqle.governance.tamper_evidence.anchors
+.sigstore_rekor`); PCT-compatible logs follow in Phase 2.
+"""

--- a/graqle/governance/tamper_evidence/anchors/sigstore_rekor.py
+++ b/graqle/governance/tamper_evidence/anchors/sigstore_rekor.py
@@ -1,0 +1,286 @@
+"""Sigstore Rekor anchor for Layer 5 tamper-evidence (R25-EU01 Task 1.4).
+
+The batcher (PR-3) builds an RFC 6962 Merkle root over each batch of governed
+records. To make that root externally verifiable — so a third party with zero
+GraQle knowledge can confirm the batch existed at a point in time — the root is
+submitted to **Sigstore Rekor**, a public append-only transparency log. Rekor
+returns a *log inclusion certificate*: the log index, log id, signed tree head,
+and inclusion proof that together prove the root was logged.
+
+    anchor(root_bytes) -> RekorReceipt(log_index, log_id, signed_tree_head, cert)
+
+This module is deliberately structured so the heavy ``sigstore`` package (a
+network + crypto dependency, pinned ``>=3.0,<3.1``) is **optional**:
+
+* ``sigstore`` is imported lazily and guarded — importing this module never
+  requires it, so the rest of Layer 5 (and the whole SDK) loads without it.
+* :class:`RekorAnchor` takes an injectable ``transport`` (anything implementing
+  :class:`RekorTransport`). Tests inject a fake transport and exercise every
+  branch — retries, backoff, success, permanent failure — with no network and
+  no ``sigstore`` installed.
+* The real ``sigstore``-backed transport is constructed only when no transport
+  is injected AND an anchor is actually attempted. If ``sigstore`` is missing at
+  that point, a clear :class:`AnchorUnavailableError` explains the
+  ``pip install graqle[attestation]`` remedy.
+
+Install the optional dependency with ``pip install graqle[attestation]``.
+
+Retry policy: bounded exponential backoff (default 3 attempts). A transient
+transport error is retried; once attempts are exhausted the error is surfaced as
+:class:`AnchorError` — never swallowed (fail-closed; see ``AttestationConfig
+.security.fail_open_on_anchor_error``, which defaults to ``False``). The caller
+(PR-5 committer / the replay queue) decides whether to queue for later or pause
+writes.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol, runtime_checkable
+
+from graqle.config.attestation_config import RekorConfig
+from graqle.governance.tamper_evidence.errors import TamperEvidenceError
+
+# The optional dependency name, surfaced in the remediation message.
+_OPTIONAL_EXTRA = "graqle[attestation]"
+
+
+class AnchorError(TamperEvidenceError):
+    """A batch root could not be anchored after exhausting the retry budget."""
+
+
+class AnchorUnavailableError(AnchorError):
+    """The Sigstore anchor cannot run because ``sigstore`` is not installed.
+
+    Distinct from :class:`AnchorError` (a transport/availability failure of an
+    installed backend): this means the optional dependency itself is absent, so
+    the remedy is ``pip install graqle[attestation]`` rather than a retry.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            "the Sigstore Rekor anchor requires the optional 'sigstore' package "
+            f"(>=3.0,<3.1). Install it with: pip install {_OPTIONAL_EXTRA}"
+        )
+
+
+@dataclass(frozen=True)
+class RekorReceipt:
+    """A Rekor log inclusion certificate for one anchored Merkle root.
+
+    These are the externally-verifiable fields a third party uses to confirm the
+    root was logged (R25-EU01 §358 Proof Bundle Schema, anchor section):
+
+    * ``log_index`` — the root's position in the Rekor log.
+    * ``log_id`` — identifies which Rekor log instance.
+    * ``signed_tree_head`` — Rekor's signed commitment to its log state.
+    * ``inclusion_cert`` — the inclusion proof / certificate bytes (opaque here;
+      verified by ``graqle.verify`` / an external auditor against the Rekor
+      public key).
+    * ``integrated_time`` — Rekor's record of when the root was logged (unix s).
+    """
+
+    log_index: int
+    log_id: str
+    signed_tree_head: str
+    inclusion_cert: str
+    integrated_time: int
+
+
+@runtime_checkable
+class RekorTransport(Protocol):
+    """The minimal surface :class:`RekorAnchor` needs from a Rekor backend.
+
+    Implemented by the real ``sigstore``-backed transport and by test fakes.
+    Keeping it this narrow is what makes the anchor fully testable without the
+    network: a fake transport returns a canned :class:`RekorReceipt` or raises.
+    """
+
+    def submit(self, root_bytes: bytes) -> RekorReceipt:
+        """Submit a Merkle root, returning its inclusion certificate, or raise."""
+        ...
+
+
+class RekorAnchor:
+    """Anchors Merkle batch roots to Sigstore Rekor with bounded retry.
+
+    Parameters
+    ----------
+    config:
+        :class:`RekorConfig` — supplies ``url``, ``public_key_path``, and
+        ``retry_max_attempts`` (1..10). Defaults to ``RekorConfig()``.
+    transport:
+        An object satisfying :class:`RekorTransport`. If omitted, a real
+        ``sigstore``-backed transport is built lazily on first anchor; if
+        ``sigstore`` is not installed at that point, :class:`AnchorUnavailableError`
+        is raised. Injecting a fake transport here is how tests avoid the
+        network and the optional dependency entirely.
+    sleep:
+        Injectable sleep (defaults to :func:`time.sleep`) so retry backoff is
+        deterministically testable without real delays.
+    """
+
+    def __init__(
+        self,
+        config: RekorConfig | None = None,
+        transport: RekorTransport | None = None,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self._config = config or RekorConfig()
+        self._transport = transport
+        self._sleep = sleep
+
+    @property
+    def available(self) -> bool:
+        """True if an anchor attempt could proceed (transport injected or sigstore importable).
+
+        A pure capability probe — it does not anchor anything. Used by the
+        committer / replay queue to decide between anchoring now and degrading to
+        the local replay queue without triggering an exception.
+        """
+        if self._transport is not None:
+            return True
+        return _sigstore_importable()
+
+    def anchor(self, root_bytes: bytes) -> RekorReceipt:
+        """Anchor ``root_bytes`` to Rekor, retrying transient failures.
+
+        Tries up to ``config.retry_max_attempts`` times with exponential backoff
+        (1s, 2s, 4s, ... via the injectable ``sleep``). On success returns the
+        :class:`RekorReceipt`. If every attempt fails, raises :class:`AnchorError`
+        chaining the last transport error — the failure is surfaced, never
+        silently dropped (fail-closed).
+        """
+        if not isinstance(root_bytes, (bytes, bytearray)):
+            raise AnchorError(
+                f"root_bytes must be bytes, got {type(root_bytes).__name__}"
+            )
+        # A Merkle root is a single SHA-256 digest (32 bytes). Anything wildly
+        # larger is a caller bug, not a root — reject it before it reaches the
+        # network (defence-in-depth size guard). A small upper bound (not exactly
+        # 32) tolerates future digest sizes while still refusing absurd input.
+        if not 0 < len(root_bytes) <= 64:
+            raise AnchorError(
+                f"root_bytes has implausible length {len(root_bytes)} for a Merkle "
+                f"root (expected a single hash digest, <= 64 bytes)"
+            )
+        transport = self._get_transport()
+        attempts = self._config.retry_max_attempts
+        last_error: Exception | None = None
+        for attempt in range(attempts):
+            try:
+                return transport.submit(bytes(root_bytes))
+            except AnchorUnavailableError:
+                # The dependency is absent — retrying cannot help; surface now.
+                raise
+            except Exception as exc:  # transport/transient failure: retry
+                last_error = exc
+                if attempt + 1 < attempts:
+                    # Exponential backoff: 1, 2, 4, ... seconds (injectable sleep).
+                    self._sleep(float(2**attempt))
+        raise AnchorError(
+            f"failed to anchor batch root to Rekor after {attempts} attempt(s): "
+            f"{last_error}"
+        ) from last_error
+
+    def _get_transport(self) -> RekorTransport:
+        """Return the injected transport, or lazily build the real sigstore one."""
+        if self._transport is not None:
+            return self._transport
+        self._transport = _build_sigstore_transport(self._config)
+        return self._transport
+
+
+def _sigstore_importable() -> bool:
+    """True iff the optional ``sigstore`` package can be imported (no network)."""
+    import importlib.util
+
+    return importlib.util.find_spec("sigstore") is not None
+
+
+def _build_sigstore_transport(config: RekorConfig) -> RekorTransport:
+    """Construct the real ``sigstore``-backed transport, or raise if unavailable.
+
+    The ``sigstore`` import lives here — the only place that touches the optional
+    dependency — so importing this module never pulls it in. The concrete wiring
+    to the ``sigstore`` 3.x API is intentionally minimal and isolated behind the
+    :class:`RekorTransport` Protocol; it is exercised in integration (not unit)
+    tests, since unit tests inject a fake transport.
+
+    The configured Rekor URL is validated here (SSRF guard): a misconfigured or
+    malicious ``graqle.yaml`` must not be able to point the anchor at an internal
+    service. Only ``https://`` URLs are accepted, and obvious loopback/internal
+    hosts are rejected.
+    """
+    if not _sigstore_importable():
+        raise AnchorUnavailableError()
+    _validate_rekor_url(config.url)
+    return _SigstoreRekorTransport(config)
+
+
+# Hostnames that must never be a Rekor endpoint (SSRF guard). A transparency log
+# is an external public service; a loopback/metadata target indicates an attack
+# or a serious misconfiguration.
+_BLOCKED_HOSTS = frozenset({
+    "localhost", "127.0.0.1", "::1", "0.0.0.0",
+    "169.254.169.254",  # cloud instance metadata endpoint
+    "metadata.google.internal",
+})
+
+
+def _validate_rekor_url(url: str) -> None:
+    """Reject non-HTTPS or internal-target Rekor URLs (SSRF defence).
+
+    Raises :class:`AnchorError` for a URL that is not ``https://`` or that points
+    at a loopback / link-local / cloud-metadata host. This runs before any real
+    network client is constructed, so a bad ``rekor.url`` can never trigger a
+    request to an internal service.
+    """
+    from urllib.parse import urlparse
+
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise AnchorError(
+            f"Rekor URL must use https:// (got scheme {parsed.scheme!r}); "
+            f"refusing to anchor over an untrusted scheme"
+        )
+    host = (parsed.hostname or "").lower()
+    if not host:
+        raise AnchorError(f"Rekor URL {url!r} has no host")
+    if host in _BLOCKED_HOSTS:
+        raise AnchorError(
+            f"Rekor URL host {host!r} is a loopback/internal target; "
+            f"a transparency log must be an external service (SSRF guard)"
+        )
+
+
+class _SigstoreRekorTransport:
+    """Real Rekor transport backed by the ``sigstore`` package.
+
+    Thin adapter: translates a Merkle root into a Rekor submission and the Rekor
+    response into a :class:`RekorReceipt`. Constructed only when ``sigstore`` is
+    installed and no fake transport was injected. Not unit-tested (it requires
+    the optional dependency + network); covered by the optional integration
+    suite. Kept tiny so the untested surface is minimal.
+    """
+
+    def __init__(self, config: RekorConfig) -> None:
+        self._config = config
+        self._client: Any = None  # lazily created on first submit
+
+    def submit(self, root_bytes: bytes) -> RekorReceipt:  # pragma: no cover - needs sigstore + network
+        # Import inside the method so even constructing the adapter never imports
+        # sigstore unless an actual submission is attempted.
+        from sigstore._internal.rekor import client as _rekor_client  # type: ignore
+
+        if self._client is None:
+            self._client = _rekor_client.RekorClient(self._config.url)
+        entry = self._client.log.entries.create(root_bytes)
+        return RekorReceipt(
+            log_index=int(entry.log_index),
+            log_id=str(entry.log_id),
+            signed_tree_head=str(getattr(entry, "signed_tree_head", "")),
+            inclusion_cert=str(getattr(entry, "inclusion_proof", "")),
+            integrated_time=int(getattr(entry, "integrated_time", 0)),
+        )

--- a/graqle/governance/tamper_evidence/batcher.py
+++ b/graqle/governance/tamper_evidence/batcher.py
@@ -458,8 +458,11 @@ class WalBatcher:
             if parsed is None:
                 continue  # corrupt/mismatched: skip, leave on disk
             key, record = parsed
-            if key in self._pending:
-                continue  # already recovered (duplicate on disk)
+            # No dedup check is needed here: _read_wal_entry enforces
+            # key == filename-stem, and directory filenames are unique, so each
+            # recovered key is necessarily distinct within this loop. (The
+            # exactly-once guarantee against the LIVE path is enforced separately
+            # by the `key in self._pending` check in enqueue().)
             leaf = leaf_hash_for_record(record)
             self._pending[key] = _PendingRecord(key=key, record=record, leaf_hash=leaf)
             if self._oldest_pending_at is None:

--- a/graqle/governance/tamper_evidence/local_replay_queue.py
+++ b/graqle/governance/tamper_evidence/local_replay_queue.py
@@ -1,0 +1,580 @@
+"""Durable local replay queue — Rekor-availability fallback (R25-EU01 CONDITION-3).
+
+When Sigstore Rekor (PR-4 anchor) is unreachable, a committed batch root still
+needs to be anchored *eventually* — dropping it would break the tamper-evidence
+chain (AC-2: every committed batch root is anchored). This module is the
+ADR-RT-003 §3.1 CONDITION-3 fallback: roots that cannot be anchored right now are
+**durably queued** here and replayed when Rekor recovers.
+
+This is NOT the PR-3 write-ahead log. They occupy disjoint directories and
+lifecycle phases and never collide:
+
+* **WAL** (``.graqle/uncommitted/``, PR-3) — individual *records* pending their
+  FIRST commit (Merkle build + downstream commit).
+* **Replay queue** (``.graqle/replay_queue/``, this module) — committed batch
+  *roots* pending a Rekor *anchor*.
+
+Each queued entry is one JSON file ``<seq>-<root_hex>.json`` holding the root,
+its receipt-less metadata, an attempt counter, and a SHA-256 integrity checksum
+over the canonical payload (verified on read when ``integrity_check`` is on).
+
+**5-state overflow protocol** (ADR-RT-003 §3.1). The queue is bounded
+(``max_entries``); as it fills while Rekor stays down, it escalates through:
+
+    NORMAL  ──fill≥degraded_ratio──▶  DEGRADED  ──fill≥alert_ratio──▶  ALERT
+       ▲                                                                  │
+       │ drain back below                                          fill≥1.0
+       │ recovery_ratio                                                   ▼
+    RECOVERY ◀──Rekor returns, draining──  PAUSE ◀───── queue full ───────┘
+
+* NORMAL — anchoring works (or queue is shallow); business as usual.
+* DEGRADED — Rekor is failing and the queue is filling; log at WARNING.
+* ALERT — queue near full; structured operator alert (+ optional webhook).
+* PAUSE — queue full; per ``on_queue_full`` either reject new roots or signal
+  the caller to pause accepting writes (AC-9). NEVER silently drop a root.
+* RECOVERY — Rekor is back and the backlog is draining; returns to NORMAL once
+  the queue falls below ``recovery_ratio``.
+
+An **independent circuit-breaker** tracks Rekor health separately from the
+overflow state: consecutive anchor failures open the breaker (stop hammering a
+dead Rekor); a cooldown half-opens it to probe; a success closes it. The
+overflow state reflects the QUEUE; the breaker reflects the ANCHOR — orthogonal.
+
+An **audited operator override** lets an operator force-drain or force-resume
+past the protocol; every override is recorded (structured WARNING) so it appears
+in the audit trail.
+
+Everything is deterministically unit-testable: inject ``clock`` (for backoff +
+breaker cooldown) and ``anchor`` (a :class:`RekorAnchor` or any object with
+``anchor(bytes)->RekorReceipt`` + ``available``). No network, no real sleeps.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Protocol
+
+from graqle.config.attestation_config import ReplayQueueConfig
+from graqle.governance.tamper_evidence.anchors.sigstore_rekor import (
+    AnchorError,
+    RekorReceipt,
+)
+from graqle.governance.tamper_evidence.errors import TamperEvidenceError
+
+logger = logging.getLogger(__name__)
+
+# Entry filename: <zero-padded seq>-<root hex>.json. The seq prefix gives a
+# stable FIFO replay order independent of filesystem listing order; the root hex
+# makes the filename self-describing and collision-free.
+_ENTRY_SUFFIX = ".json"
+_SEQ_WIDTH = 12  # zero-pad sequence so lexical sort == numeric sort
+
+# Fill-ratio thresholds for the 5-state overflow protocol. These are operational
+# tuning knobs (NOT TS-2): they describe the PUBLIC overflow contract.
+_DEGRADED_RATIO = 0.50
+_ALERT_RATIO = 0.80
+_RECOVERY_RATIO = 0.25
+
+# Circuit-breaker defaults (consecutive failures to open; cooldown seconds to
+# half-open). Operational, not secret.
+_BREAKER_FAIL_THRESHOLD = 3
+_BREAKER_COOLDOWN_SECONDS = 30.0
+
+
+class OverflowState(str, Enum):
+    """The 5 states of the queue overflow protocol (ADR-RT-003 §3.1)."""
+
+    NORMAL = "normal"
+    DEGRADED = "degraded"
+    ALERT = "alert"
+    PAUSE = "pause"
+    RECOVERY = "recovery"
+
+
+class BreakerState(str, Enum):
+    """Circuit-breaker states for Rekor health (independent of overflow)."""
+
+    CLOSED = "closed"  # anchoring allowed
+    OPEN = "open"  # anchoring suppressed (Rekor presumed down)
+    HALF_OPEN = "half_open"  # one probe allowed to test recovery
+
+
+class ReplayQueueError(TamperEvidenceError):
+    """Raised for replay-queue operations that cannot proceed safely."""
+
+
+class QueueFullError(ReplayQueueError):
+    """The queue is full and ``on_queue_full='reject'`` — the root was not queued."""
+
+
+class AnchorLike(Protocol):
+    """The anchor surface the replay queue needs (satisfied by RekorAnchor)."""
+
+    @property
+    def available(self) -> bool: ...
+
+    def anchor(self, root_bytes: bytes) -> RekorReceipt: ...
+
+
+@dataclass(frozen=True)
+class QueuedRoot:
+    """One batch root awaiting a Rekor anchor."""
+
+    seq: int
+    root_hex: str
+    batch_id: str
+    attempts: int = 0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class _Breaker:
+    """Mutable circuit-breaker state. Cooldown uses the injected clock."""
+
+    state: BreakerState = BreakerState.CLOSED
+    consecutive_failures: int = 0
+    opened_at: float | None = None
+
+
+class LocalReplayQueue:
+    """Durable, bounded, FIFO queue of batch roots pending a Rekor anchor.
+
+    Parameters
+    ----------
+    config:
+        :class:`ReplayQueueConfig` — ``directory``, ``max_entries``,
+        ``integrity_check``, ``max_retries``, ``retry_backoff_seconds``,
+        ``on_queue_full``.
+    queue_root:
+        Base directory under which ``replay_queue/`` lives (typically
+        ``.graqle``). The config's ``directory`` is honoured as the subdir name's
+        source; entries live in ``<queue_root>/replay_queue/``.
+    anchor:
+        Object with ``available`` + ``anchor(bytes)->RekorReceipt`` (a
+        :class:`RekorAnchor` in production, a fake in tests). Optional: a
+        queue can be constructed purely to enqueue/inspect without draining.
+    clock:
+        Injectable monotonic clock (defaults to ``time.monotonic``) for breaker
+        cooldown — deterministic in tests.
+    """
+
+    def __init__(
+        self,
+        config: ReplayQueueConfig,
+        queue_root: str | os.PathLike[str],
+        anchor: AnchorLike | None = None,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        import threading
+        import time as _time
+
+        self._config = config
+        self._anchor = anchor
+        self._clock = clock or _time.monotonic
+        # Serializes enqueue/drain/override across threads: the PR-5 committer may
+        # enqueue (commit path) and drain (recovery path) concurrently. All
+        # mutation of _next_seq, the breaker, and the on-disk queue happens under
+        # this lock (reentrant so internal helpers can be called while held).
+        self._lock = threading.RLock()
+        # Use ONLY the LAST path component of config.directory as the subdir name
+        # so config.directory can never escape queue_root (path-traversal guard:
+        # Path("../../etc").name == "etc", Path("..").name == "" -> fallback).
+        subdir = Path(config.directory).name or "replay_queue"
+        if subdir in ("", ".", ".."):  # belt-and-suspenders: never a traversal token
+            subdir = "replay_queue"
+        self._dir = Path(queue_root) / subdir
+        self._dir.mkdir(parents=True, exist_ok=True)
+        # Restrict the queue directory on POSIX (governance artifact; defence in
+        # depth). chmod is a no-op concept on Windows, so guard it; failure to
+        # chmod must not prevent the queue from operating.
+        if os.name == "posix":
+            try:
+                os.chmod(self._dir, 0o700)
+            except OSError:  # pragma: no cover - platform/permission dependent
+                pass
+        self._breaker = _Breaker()
+        # Next sequence number = one past the highest on disk (durable ordering).
+        self._next_seq = self._highest_seq_on_disk() + 1
+
+    # ---- public API -----------------------------------------------------------
+
+    def enqueue(self, root_hex: str, batch_id: str, metadata: dict[str, Any] | None = None) -> OverflowState:
+        """Durably queue a batch root for later anchoring; return the new overflow state.
+
+        Raises :class:`QueueFullError` only when the queue is full AND
+        ``on_queue_full='reject'``. With ``on_queue_full='pause_writes'`` a full
+        queue still persists the root (durability wins) and returns
+        :data:`OverflowState.PAUSE` so the caller can pause accepting writes — a
+        root is NEVER silently dropped (AC-9).
+        """
+        if not isinstance(root_hex, str) or not root_hex:
+            raise ReplayQueueError("root_hex must be a non-empty string")
+        if not _is_hex(root_hex):
+            raise ReplayQueueError(
+                "root_hex must be a hex string (it is decoded with bytes.fromhex "
+                "at anchor time); refusing to queue a non-hex root"
+            )
+        with self._lock:
+            return self._enqueue_locked(root_hex, batch_id, metadata)
+
+    def _enqueue_locked(self, root_hex: str, batch_id: str, metadata: dict[str, Any] | None) -> OverflowState:
+        count = self.depth
+        if count >= self._config.max_entries:
+            if self._config.on_queue_full == "reject":
+                raise QueueFullError(
+                    f"replay queue full ({count}/{self._config.max_entries}); "
+                    f"on_queue_full='reject' — root {root_hex[:12]}… not queued"
+                )
+            # pause_writes: still persist (never drop), but signal PAUSE.
+            self._write_entry(root_hex, batch_id, metadata or {}, attempts=0)
+            logger.error(
+                "replay queue full (%d/%d) — persisted root %s and signalling "
+                "PAUSE; caller should pause accepting writes (AC-9)",
+                count + 1, self._config.max_entries, root_hex[:12],
+            )
+            return OverflowState.PAUSE
+        self._write_entry(root_hex, batch_id, metadata or {}, attempts=0)
+        return self._compute_state(self.depth)
+
+    def drain(self, max_items: int | None = None) -> int:
+        """Attempt to anchor queued roots in FIFO order; return the count anchored.
+
+        Respects the circuit-breaker: if it is OPEN and still in cooldown, drain
+        is a no-op (returns 0) to avoid hammering a down Rekor. When the cooldown
+        elapses the breaker half-opens and a single probe is attempted; success
+        closes it and the full drain proceeds, a failure re-opens it.
+
+        Each anchored root's entry is removed only AFTER the anchor succeeds
+        (durable until externally proven). A per-entry failure increments its
+        attempt counter; once ``max_retries`` is exceeded the entry is left in
+        place and surfaced (never dropped) for operator attention.
+
+        Delivery semantics are **at-least-once**, not exactly-once: if Rekor
+        records the root but the response is lost in transit, the anchor surfaces
+        as :class:`AnchorError`, the entry stays queued, and the next drain
+        re-submits it — producing a second Rekor entry for the same root. This is
+        acceptable for tamper-evidence: the root is content-addressed, so a
+        duplicate Rekor entry is benign (an inclusion proof against either entry
+        validates, and Rekor coalesces identical entries). Exactly-once anchoring
+        is not attempted here; an idempotency token, if ever needed, belongs in
+        the PR-5 committer that owns the batch lifecycle.
+        """
+        if self._anchor is None:
+            raise ReplayQueueError("no anchor configured; cannot drain")
+        with self._lock:
+            return self._drain_locked(max_items)
+
+    def _drain_locked(self, max_items: int | None) -> int:
+        if not self._breaker_allows_attempt():
+            return 0
+
+        entries = self._list_entries()
+        if max_items is not None:
+            entries = entries[:max_items]
+
+        anchored = 0
+        for path in entries:
+            queued = self._read_entry(path)
+            if queued is None:
+                continue  # corrupt entry: skip, leave for operator
+            try:
+                root_bytes = bytes.fromhex(queued.root_hex)
+            except ValueError:
+                # A non-hex root reached disk despite the enqueue guard (tamper /
+                # external write). Skip it — never crash the whole drain.
+                logger.error(
+                    "replay-queue entry %s has a non-hex root; skipping", path.name
+                )
+                continue
+            try:
+                self._anchor.anchor(root_bytes)
+            except AnchorError as exc:
+                self._record_failure()
+                self._bump_attempts(path, queued, exc)
+                # Breaker may have just opened; stop draining this pass.
+                if self._breaker.state == BreakerState.OPEN:
+                    break
+                continue
+            # Success: anchor proven, remove the entry and reset breaker.
+            self._record_success()
+            self._remove_entry(path)
+            anchored += 1
+        return anchored
+
+    @property
+    def depth(self) -> int:
+        """Number of roots currently queued (durably on disk)."""
+        return len(self._list_entries())
+
+    @property
+    def state(self) -> OverflowState:
+        """Current overflow state derived from the queue fill ratio + breaker."""
+        return self._compute_state(self.depth)
+
+    @property
+    def breaker_state(self) -> BreakerState:
+        """Current circuit-breaker state (Rekor health)."""
+        return self._breaker.state
+
+    @property
+    def queue_dir(self) -> Path:
+        """Directory holding queued roots."""
+        return self._dir
+
+    def operator_override(self, action: str, reason: str) -> None:
+        """Audited operator override of the overflow protocol.
+
+        ``action`` is ``'reset_breaker'`` (force the circuit-breaker closed to
+        retry Rekor now) or ``'clear_pause'`` (no-op marker that the operator has
+        acknowledged a PAUSE). Every override is logged at WARNING with the
+        supplied ``reason`` so it appears in the audit trail. Unknown actions
+        raise — an override must be explicit.
+        """
+        with self._lock:
+            if action == "reset_breaker":
+                self._breaker = _Breaker()
+                logger.warning(
+                    "OPERATOR OVERRIDE reset_breaker: circuit-breaker forced CLOSED. "
+                    "reason=%s", reason,
+                )
+            elif action == "clear_pause":
+                logger.warning(
+                    "OPERATOR OVERRIDE clear_pause: operator acknowledged PAUSE. "
+                    "reason=%s", reason,
+                )
+            else:
+                raise ReplayQueueError(
+                    f"unknown operator override action {action!r}; "
+                    f"expected 'reset_breaker' or 'clear_pause'"
+                )
+
+    # ---- overflow state machine -----------------------------------------------
+
+    def _compute_state(self, count: int) -> OverflowState:
+        """Map (fill ratio, breaker) onto the 5-state overflow protocol."""
+        max_entries = self._config.max_entries
+        ratio = count / max_entries if max_entries else 0.0
+        if count >= max_entries:
+            return OverflowState.PAUSE
+        # When the breaker is recovering (half-open/closed after being open) and
+        # the queue is draining below recovery_ratio, we are in RECOVERY.
+        if self._breaker.state in (BreakerState.HALF_OPEN, BreakerState.OPEN):
+            if ratio >= _ALERT_RATIO:
+                return OverflowState.ALERT
+            if ratio >= _DEGRADED_RATIO:
+                return OverflowState.DEGRADED
+            if ratio > _RECOVERY_RATIO:
+                return OverflowState.RECOVERY
+            return OverflowState.RECOVERY if count > 0 else OverflowState.NORMAL
+        if ratio >= _ALERT_RATIO:
+            return OverflowState.ALERT
+        if ratio >= _DEGRADED_RATIO:
+            return OverflowState.DEGRADED
+        return OverflowState.NORMAL
+
+    # ---- circuit-breaker ------------------------------------------------------
+
+    def _breaker_allows_attempt(self) -> bool:
+        """True if an anchor attempt may proceed under the current breaker state."""
+        b = self._breaker
+        if b.state == BreakerState.CLOSED:
+            return True
+        if b.state == BreakerState.OPEN:
+            # Allow a probe once the cooldown has elapsed -> half-open.
+            if b.opened_at is not None and (self._clock() - b.opened_at) >= _BREAKER_COOLDOWN_SECONDS:
+                b.state = BreakerState.HALF_OPEN
+                return True
+            return False
+        # HALF_OPEN: allow the single probe.
+        return True
+
+    def _record_failure(self) -> None:
+        """Register an anchor failure; open the breaker past the threshold."""
+        b = self._breaker
+        b.consecutive_failures += 1
+        if b.state == BreakerState.HALF_OPEN:
+            # Probe failed -> re-open immediately.
+            b.state = BreakerState.OPEN
+            b.opened_at = self._clock()
+        elif b.consecutive_failures >= _BREAKER_FAIL_THRESHOLD:
+            b.state = BreakerState.OPEN
+            b.opened_at = self._clock()
+            logger.error(
+                "Rekor circuit-breaker OPEN after %d consecutive anchor failures",
+                b.consecutive_failures,
+            )
+
+    def _record_success(self) -> None:
+        """Register an anchor success; close the breaker."""
+        if self._breaker.state != BreakerState.CLOSED:
+            logger.warning("Rekor circuit-breaker CLOSED after successful anchor")
+        self._breaker = _Breaker()
+
+    # ---- durable entry persistence --------------------------------------------
+
+    def _entry_path(self, seq: int, root_hex: str) -> Path:
+        return self._dir / f"{seq:0{_SEQ_WIDTH}d}-{root_hex}{_ENTRY_SUFFIX}"
+
+    def _write_entry(self, root_hex: str, batch_id: str, metadata: dict[str, Any], attempts: int) -> None:
+        """Persist a NEW queued root under a freshly-allocated sequence number."""
+        seq = self._next_seq
+        self._next_seq += 1
+        self._persist_entry(seq, root_hex, batch_id, metadata, attempts)
+
+    def _rewrite_entry_atomic(
+        self, path: Path, seq: int, root_hex: str, batch_id: str,
+        metadata: dict[str, Any], attempts: int,
+    ) -> None:
+        """Rewrite an EXISTING entry in place (same seq+root => same filename).
+
+        ``os.replace`` overwrites the original path atomically, so there is no
+        window in which the root is absent from disk (durability under crash).
+        ``path`` is the existing entry's path and equals ``_entry_path(seq,
+        root_hex)``; it is passed for clarity but the write targets that same
+        deterministic path.
+        """
+        self._persist_entry(seq, root_hex, batch_id, metadata, attempts)
+
+    def _persist_entry(
+        self, seq: int, root_hex: str, batch_id: str,
+        metadata: dict[str, Any], attempts: int,
+    ) -> None:
+        """Atomically + durably write the entry for ``seq``/``root_hex``.
+
+        temp -> fsync -> os.replace into the deterministic ``_entry_path``. Because
+        the path is a pure function of (seq, root_hex), writing an existing
+        (seq, root) atomically OVERWRITES it (the bump path) and writing a new one
+        CREATES it (the enqueue path) — both crash-safe, neither leaves a gap.
+        """
+        payload: dict[str, Any] = {
+            "seq": seq,
+            "root_hex": root_hex,
+            "batch_id": batch_id,
+            "attempts": attempts,
+            "metadata": metadata,
+        }
+        if self._config.integrity_check:
+            payload["checksum"] = _checksum(payload)
+        data = json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
+        final_path = self._entry_path(seq, root_hex)
+        tmp_name: str | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="wb", dir=str(self._dir), prefix=f".{seq}.", suffix=".tmp", delete=False
+            ) as tmp:
+                tmp_name = tmp.name
+                tmp.write(data)
+                tmp.flush()
+                os.fsync(tmp.fileno())
+            os.replace(tmp_name, str(final_path))
+            tmp_name = None
+        finally:
+            if tmp_name is not None:
+                try:
+                    os.unlink(tmp_name)
+                except OSError:
+                    pass
+
+    def _bump_attempts(self, path: Path, queued: QueuedRoot, exc: Exception) -> None:
+        """Increment an entry's attempt counter; surface if max_retries exceeded.
+
+        The bump is an ATOMIC in-place rewrite: the entry keeps its original seq
+        and root, so its filename is unchanged, and :meth:`_rewrite_entry_atomic`
+        overwrites it via tempfile -> fsync -> os.replace. Crucially there is NO
+        remove-then-write window — a crash mid-bump leaves either the old entry
+        or the new one fully on disk, never nothing. (graq_predict failure-chain
+        #1: a remove-then-rewrite would lose the root on a crash between the two.)
+        """
+        attempts = queued.attempts + 1
+        if attempts > self._config.max_retries:
+            logger.error(
+                "replay-queue root %s exceeded max_retries (%d); leaving in place "
+                "for operator. last error: %s",
+                queued.root_hex[:12], self._config.max_retries, exc,
+            )
+            return  # leave the entry untouched; never drop a root
+        self._rewrite_entry_atomic(path, queued.seq, queued.root_hex, queued.batch_id, queued.metadata, attempts)
+
+    def _remove_entry(self, path: Path) -> None:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger.warning("failed to remove replay-queue entry %s: %s", path.name, exc)
+
+    def _read_entry(self, path: Path) -> QueuedRoot | None:
+        """Parse + integrity-check one entry; return None if corrupt."""
+        try:
+            data = json.loads(path.read_bytes().decode("utf-8"))
+        except (OSError, ValueError, UnicodeDecodeError) as exc:
+            logger.warning("replay-queue entry %s unreadable/corrupt; skipping: %s", path.name, exc)
+            return None
+        if not isinstance(data, dict):
+            return None
+        if self._config.integrity_check:
+            stored = data.get("checksum")
+            recomputed = _checksum({k: v for k, v in data.items() if k != "checksum"})
+            if stored != recomputed:
+                logger.error("replay-queue entry %s failed integrity check; skipping", path.name)
+                return None
+        try:
+            return QueuedRoot(
+                seq=int(data["seq"]),
+                root_hex=str(data["root_hex"]),
+                batch_id=str(data["batch_id"]),
+                attempts=int(data.get("attempts", 0)),
+                metadata=dict(data.get("metadata", {})),
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
+
+    def _list_entries(self) -> list[Path]:
+        """All queued-root files in FIFO (seq) order."""
+        try:
+            return sorted(
+                p for p in self._dir.iterdir()
+                if p.is_file() and p.name.endswith(_ENTRY_SUFFIX) and not p.name.startswith(".")
+            )
+        except OSError:
+            return []
+
+    def _highest_seq_on_disk(self) -> int:
+        """Highest sequence number among existing entries (0 if empty)."""
+        highest = 0
+        for path in self._list_entries():
+            try:
+                seq = int(path.name.split("-", 1)[0])
+            except (ValueError, IndexError):
+                continue
+            highest = max(highest, seq)
+        return highest
+
+
+def _checksum(payload: dict[str, Any]) -> str:
+    """SHA-256 over the canonical (sorted-key) JSON of ``payload``."""
+    raw = json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _is_hex(s: str) -> bool:
+    """True iff ``s`` is a non-empty, even-length hex string (a valid root_hex).
+
+    The root is decoded with ``bytes.fromhex`` at anchor time, so an odd-length
+    or non-hex string would fail there; validating at enqueue keeps a malformed
+    root out of the durable queue entirely.
+    """
+    if not s or len(s) % 2 != 0:
+        return False
+    try:
+        bytes.fromhex(s)
+        return True
+    except ValueError:
+        return False

--- a/tests/test_tamper_evidence/test_batcher.py
+++ b/tests/test_tamper_evidence/test_batcher.py
@@ -785,6 +785,177 @@ def test_tree_uses_enqueue_time_leaf_hashes_not_recommit_hash(tmp_path):
     assert captured["root"] == expected_root  # tree used enqueue-time hashes
 
 
+# ---- coverage completion: realistic exercise of defensive paths ---------------
+#
+# These cover the remaining defensive branches by triggering the real fault each
+# guards (not by hiding them). Each asserts the GRACEFUL-DEGRADATION behavior the
+# branch exists to provide, so coverage stays meaningful.
+
+
+def test_flush_without_committer_clears_wal(tmp_path):
+    """flush() with committer=None builds the tree, skips commit, clears the WAL.
+
+    Covers the `committer is None` branch: the no-downstream-commit integration
+    point (and the pre-PR-5 default). The records are still drained from the WAL.
+    """
+    b = WalBatcher(_config(), wal_root=tmp_path, committer=None)
+    for i in range(3):
+        b.enqueue(_record(i))
+    assert len(_wal_entries(tmp_path)) == 3
+    committed = b.flush()
+    assert committed == 3
+    assert b.pending_count == 0
+    assert _wal_entries(tmp_path) == []  # WAL cleared even with no committer
+
+
+def test_write_wal_entry_idempotent_when_file_exists(tmp_path):
+    """_write_wal_entry is a no-op if the final path already exists (in-flight retry).
+
+    Covers the `final_path.exists(): return` early return: a second write for an
+    already-persisted key must not rewrite or corrupt the entry.
+    """
+    b = WalBatcher(_config(), wal_root=tmp_path)
+    rec = _record(1)
+    key = b.enqueue(rec)
+    entry = Path(tmp_path) / WAL_SUBDIR / f"{key}.wal.json"
+    before = entry.read_bytes()
+    # Direct second write for the same key: must early-return without touching it.
+    b._write_wal_entry(key, rec)
+    assert entry.read_bytes() == before  # unchanged
+    assert len(_wal_entries(tmp_path)) == 1
+
+
+def test_post_write_stat_oserror_becomes_batcher_error(tmp_path, monkeypatch):
+    """An OSError from the post-write stat() surfaces as a BatcherError (line 409).
+
+    Covers the except-OSError arm of the S-015 size check: if the just-written
+    entry cannot even be stat'd, we refuse to acknowledge it.
+    """
+    b = WalBatcher(_config(), wal_root=tmp_path)
+    real_replace = os.replace
+
+    def replace_then_break_stat(src, dst):
+        real_replace(src, dst)
+        # After the real rename, make the next stat() on the final path raise.
+        orig_stat = Path.stat
+
+        def boom_stat(self, *a, **k):
+            if self.name.endswith(".wal.json"):
+                raise OSError("stat denied")
+            return orig_stat(self, *a, **k)
+
+        monkeypatch.setattr(Path, "stat", boom_stat)
+
+    monkeypatch.setattr(os, "replace", replace_then_break_stat)
+    with pytest.raises(BatcherError, match="could not be stat'd"):
+        b.enqueue(_record(1))
+
+
+def test_temp_cleanup_unlink_failure_is_swallowed(tmp_path, monkeypatch):
+    """If the write fails AND the temp-file cleanup unlink also fails, no crash.
+
+    Covers the finally-block `except OSError: pass` around the orphan temp unlink:
+    a cleanup failure must never mask the original error nor raise on its own.
+    """
+    b = WalBatcher(_config(), wal_root=tmp_path)
+
+    # Make fsync fail (crash before rename) so the finally cleanup path runs...
+    def boom_fsync(fd):
+        raise OSError("fsync failed")
+
+    # ...and make the cleanup unlink ALSO fail.
+    def boom_unlink(self, *a, **k):
+        raise OSError("unlink failed")
+
+    def boom_os_unlink(path):
+        raise OSError("unlink failed")
+
+    monkeypatch.setattr(os, "fsync", boom_fsync)
+    monkeypatch.setattr(os, "unlink", boom_os_unlink)  # cleanup uses os.unlink
+    # The original fsync OSError propagates; the unlink failure is swallowed.
+    with pytest.raises(OSError, match="fsync failed"):
+        b.enqueue(_record(1))
+
+
+def test_remove_wal_entry_missing_file_is_noop(tmp_path):
+    """_remove_wal_entry tolerates an already-deleted entry (FileNotFoundError arm)."""
+    b = WalBatcher(_config(), wal_root=tmp_path)
+    key = "d" * 64  # well-formed but no such file
+    b._remove_wal_entry(key)  # must not raise
+
+
+def test_recovery_rejects_valid_hex_key_not_matching_filename(tmp_path):
+    """A valid-hex stored key that differs from its filename stem is rejected (line 495).
+
+    Both key and filename are well-formed hex (so _is_valid_key passes), but they
+    DISAGREE — the entry was renamed or the filename was tampered. It must be
+    skipped before the content re-hash, so the filename↔key binding is enforced.
+    """
+    import json as _json
+
+    wal_dir = Path(tmp_path) / WAL_SUBDIR
+    wal_dir.mkdir(parents=True, exist_ok=True)
+    rec = _record(1)
+    # Filename stem = all 'a'; stored key = all 'b'. Both valid hex, but unequal.
+    (wal_dir / ("a" * 64 + ".wal.json")).write_text(
+        _json.dumps({"idempotency_key": "b" * 64, "record": rec}), encoding="utf-8"
+    )
+    b = WalBatcher(_config(), wal_root=tmp_path)
+    assert b.pending_count == 0  # stem != key => rejected at the binding check
+
+
+def test_recovery_no_double_leaf_for_same_content_under_two_filenames(tmp_path):
+    """INVARIANT GUARD: the same record under two different filenames cannot yield
+    two pending leaves on recovery.
+
+    This is the test that justifies removing the in-loop dedup branch: the
+    key==filename-stem binding is what guarantees one pending entry per content.
+    The canonical file (stem == content-address) is accepted; any second file
+    carrying the same record under a DIFFERENT stem is rejected because its stem
+    cannot equal the content's true address. So recovery produces exactly one
+    leaf for the content — proven here, not assumed.
+    """
+    import json as _json
+
+    wal_dir = Path(tmp_path) / WAL_SUBDIR
+    wal_dir.mkdir(parents=True, exist_ok=True)
+    rec = _record(9)
+    true_key = _idempotency_key(rec)
+    # File A: canonical (stem == true content-address) -> accepted.
+    (wal_dir / f"{true_key}.wal.json").write_text(
+        _json.dumps({"idempotency_key": true_key, "record": rec}), encoding="utf-8"
+    )
+    # File B: SAME record, but a different valid-hex stem with a matching stored
+    # key. Its stored key == its stem, but that key != the content's true address,
+    # so the content re-hash check rejects it.
+    decoy = "f" * 64
+    (wal_dir / f"{decoy}.wal.json").write_text(
+        _json.dumps({"idempotency_key": decoy, "record": rec}), encoding="utf-8"
+    )
+
+    committer = _RecordingCommitter()
+    b = WalBatcher(_config(), wal_root=tmp_path, committer=committer)
+    # Exactly ONE pending entry for the content (the canonical file); the decoy is
+    # rejected by the content-address re-hash, so no second leaf is produced.
+    assert b.pending_count == 1
+    b.flush()
+    assert committer.committed_record_ids == ["tr_000009"]
+    assert len(committer.batches[0][1]._leaves) == 1  # one leaf, not two
+
+
+def test_recover_from_wal_unreadable_dir_is_noop(tmp_path, monkeypatch):
+    """If the WAL dir cannot be listed, recovery degrades to a no-op (lines 453-454)."""
+    b = WalBatcher(_config(), wal_root=tmp_path)
+
+    def boom_iterdir(self):
+        raise OSError("iterdir denied")
+
+    monkeypatch.setattr(Path, "iterdir", boom_iterdir)
+    # A second batcher over the same root: recovery hits the OSError and returns.
+    b2 = WalBatcher(_config(), wal_root=tmp_path)
+    assert b2.pending_count == 0
+
+
 # ---- crash recovery: REAL process kill (genuine crash semantics) --------------
 
 _WORKER = Path(__file__).with_name("batcher_worker.py")

--- a/tests/test_tamper_evidence/test_local_replay_queue.py
+++ b/tests/test_tamper_evidence/test_local_replay_queue.py
@@ -1,0 +1,676 @@
+"""Tests for the durable local replay queue (v0.59.0 PR-4, R25-EU01 CONDITION-3).
+
+Deterministic + offline: a fake anchor (success / fail / flaky) is injected, and
+the breaker clock is injected so cooldowns are exact. Covers durability + FIFO,
+the 5-state overflow protocol, the independent circuit-breaker, integrity checks,
+on_queue_full policy, audited operator override, and recovery/drain.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from graqle.config.attestation_config import ReplayQueueConfig
+from graqle.governance.tamper_evidence.anchors.sigstore_rekor import (
+    AnchorError,
+    RekorReceipt,
+)
+from graqle.governance.tamper_evidence.local_replay_queue import (
+    BreakerState,
+    LocalReplayQueue,
+    OverflowState,
+    QueueFullError,
+    QueuedRoot,
+    ReplayQueueError,
+    _checksum,
+)
+
+
+# ---- fakes / helpers ----------------------------------------------------------
+
+
+def _receipt() -> RekorReceipt:
+    return RekorReceipt(1, "logid", "sth", "cert", 1_700_000_000)
+
+
+class _OkAnchor:
+    available = True
+
+    def __init__(self):
+        self.anchored: list[bytes] = []
+
+    def anchor(self, root_bytes: bytes) -> RekorReceipt:
+        self.anchored.append(root_bytes)
+        return _receipt()
+
+
+class _FailAnchor:
+    available = True
+
+    def __init__(self):
+        self.calls = 0
+
+    def anchor(self, root_bytes: bytes) -> RekorReceipt:
+        self.calls += 1
+        raise AnchorError("rekor down")
+
+
+class _FlakyAnchor:
+    """Fails until `fail_until` calls have happened, then succeeds."""
+
+    available = True
+
+    def __init__(self, fail_until: int):
+        self.fail_until = fail_until
+        self.calls = 0
+
+    def anchor(self, root_bytes: bytes) -> RekorReceipt:
+        self.calls += 1
+        if self.calls <= self.fail_until:
+            raise AnchorError(f"transient {self.calls}")
+        return _receipt()
+
+
+class _FakeClock:
+    def __init__(self):
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float):
+        self.t += dt
+
+
+def _cfg(**over) -> ReplayQueueConfig:
+    # NOTE: ReplayQueueConfig enforces max_entries >= 100 (PR-0). Tests that
+    # exercise overflow RATIOS use the smallest legal value (100) and fill
+    # proportionally; the pure ratio->state mapping is unit-tested directly via
+    # _compute_state(count) without persisting 100 files.
+    base = dict(
+        directory=".graqle/replay_queue/",
+        max_entries=100,
+        integrity_check=True,
+        max_retries=3,
+        retry_backoff_seconds=[5, 30, 300],
+        on_queue_full="pause_writes",
+    )
+    base.update(over)
+    return ReplayQueueConfig(**base)
+
+
+def _root_hex(i: int) -> str:
+    return f"{i:064x}"
+
+
+def _entries(q_root: Path) -> list[Path]:
+    d = Path(q_root) / "replay_queue"
+    if not d.exists():
+        return []
+    return sorted(p for p in d.iterdir() if p.name.endswith(".json") and not p.name.startswith("."))
+
+
+# ---- separation from the WAL --------------------------------------------------
+
+
+def test_queue_dir_is_replay_queue_not_uncommitted(tmp_path):
+    """The replay queue lives in replay_queue/, never the WAL's uncommitted/."""
+    q = LocalReplayQueue(_cfg(), queue_root=tmp_path)
+    assert q.queue_dir == Path(tmp_path) / "replay_queue"
+    assert q.queue_dir.is_dir()
+    assert "uncommitted" not in str(q.queue_dir)
+
+
+# ---- durable enqueue + FIFO ---------------------------------------------------
+
+
+def test_enqueue_persists_entry(tmp_path):
+    q = LocalReplayQueue(_cfg(), queue_root=tmp_path)
+    state = q.enqueue(_root_hex(1), batch_id="b1")
+    assert state == OverflowState.NORMAL
+    assert q.depth == 1
+    assert len(_entries(tmp_path)) == 1
+
+
+def test_enqueue_rejects_empty_root(tmp_path):
+    q = LocalReplayQueue(_cfg(), queue_root=tmp_path)
+    with pytest.raises(ReplayQueueError, match="non-empty"):
+        q.enqueue("", batch_id="b1")
+
+
+def test_entries_drain_in_fifo_seq_order(tmp_path):
+    anchor = _OkAnchor()
+    q = LocalReplayQueue(_cfg(), queue_root=tmp_path, anchor=anchor)
+    for i in range(5):
+        q.enqueue(_root_hex(i), batch_id=f"b{i}")
+    drained = q.drain()
+    assert drained == 5
+    assert q.depth == 0
+    # FIFO: anchored in enqueue order 0..4
+    assert anchor.anchored == [bytes.fromhex(_root_hex(i)) for i in range(5)]
+
+
+def test_seq_survives_restart(tmp_path):
+    """A new queue instance over the same dir continues the sequence (durable order)."""
+    q1 = LocalReplayQueue(_cfg(), queue_root=tmp_path)
+    q1.enqueue(_root_hex(1), batch_id="b1")
+    q1.enqueue(_root_hex(2), batch_id="b2")
+    q2 = LocalReplayQueue(_cfg(), queue_root=tmp_path)  # "restart"
+    q2.enqueue(_root_hex(3), batch_id="b3")
+    seqs = sorted(int(p.name.split("-", 1)[0]) for p in _entries(tmp_path))
+    assert seqs == [1, 2, 3]  # contiguous, no collision
+
+
+# ---- drain requires an anchor -------------------------------------------------
+
+
+def test_drain_without_anchor_raises(tmp_path):
+    q = LocalReplayQueue(_cfg(), queue_root=tmp_path)  # no anchor
+    q.enqueue(_root_hex(1), batch_id="b1")
+    with pytest.raises(ReplayQueueError, match="no anchor"):
+        q.drain()
+
+
+def test_drain_max_items_limits_batch(tmp_path):
+    anchor = _OkAnchor()
+    q = LocalReplayQueue(_cfg(), queue_root=tmp_path, anchor=anchor)
+    for i in range(5):
+        q.enqueue(_root_hex(i), batch_id=f"b{i}")
+    assert q.drain(max_items=2) == 2
+    assert q.depth == 3
+
+
+# ---- on_queue_full policy -----------------------------------------------------
+
+
+def test_on_queue_full_reject_raises_and_does_not_persist(tmp_path):
+    q = LocalReplayQueue(_cfg(max_entries=100, on_queue_full="reject"), queue_root=tmp_path)
+    for i in range(100):
+        q.enqueue(_root_hex(i), batch_id=f"b{i}")
+    with pytest.raises(QueueFullError):
+        q.enqueue(_root_hex(100), batch_id="b100")
+    assert q.depth == 100  # overflow not persisted
+
+
+def test_on_queue_full_pause_persists_and_signals_pause(tmp_path):
+    """pause_writes NEVER drops a root: it persists AND returns PAUSE (AC-9)."""
+    q = LocalReplayQueue(_cfg(max_entries=100, on_queue_full="pause_writes"), queue_root=tmp_path)
+    for i in range(100):
+        q.enqueue(_root_hex(i), batch_id=f"b{i}")
+    state = q.enqueue(_root_hex(100), batch_id="b100")
+    assert state == OverflowState.PAUSE
+    assert q.depth == 101  # root WAS persisted despite full queue
+
+
+# ---- 5-state overflow protocol (ratio->state mapping, unit-tested directly) ----
+#
+# _compute_state(count) is the pure mapping; testing it directly avoids
+# persisting 100 files per ratio while still exercising every branch realistically.
+
+
+def test_compute_state_ratios_closed_breaker(tmp_path):
+    q = LocalReplayQueue(_cfg(max_entries=100), queue_root=tmp_path)
+    assert q._compute_state(0) == OverflowState.NORMAL
+    assert q._compute_state(40) == OverflowState.NORMAL    # 40% < 50%
+    assert q._compute_state(50) == OverflowState.DEGRADED  # 50%
+    assert q._compute_state(79) == OverflowState.DEGRADED  # <80%
+    assert q._compute_state(80) == OverflowState.ALERT     # 80%
+    assert q._compute_state(99) == OverflowState.ALERT     # <100%
+    assert q._compute_state(100) == OverflowState.PAUSE    # full
+
+
+def test_compute_state_max_entries_zero_is_safe(tmp_path):
+    """Guard the divide-by-zero branch: a 0 ceiling never raises."""
+    q = LocalReplayQueue(_cfg(max_entries=100), queue_root=tmp_path)
+    # Force the ceiling to 0 to hit the `if max_entries else 0.0` guard.
+    object.__setattr__(q._config, "max_entries", 0)
+    # count >= 0 (== max_entries) -> PAUSE per the full check.
+    assert q._compute_state(0) == OverflowState.PAUSE
+
+
+def test_state_reflects_real_depth(tmp_path):
+    """The `state` property uses the real on-disk depth (integration sanity)."""
+    q = LocalReplayQueue(_cfg(max_entries=100), queue_root=tmp_path)
+    for i in range(50):  # 50% -> DEGRADED
+        q.enqueue(_root_hex(i), batch_id=f"b{i}")
+    assert q.state == OverflowState.DEGRADED
+
+
+def test_state_recovery_while_breaker_open_and_draining(tmp_path):
+    """With the breaker tripped and the queue low-but-nonzero, state is RECOVERY."""
+    clock = _FakeClock()
+    anchor = _FailAnchor()
+    q = LocalReplayQueue(_cfg(max_entries=100), queue_root=tmp_path, anchor=anchor, clock=clock)
+    for i in range(20):  # 20% (< recovery_ratio 25%) but nonzero
+        q.enqueue(_root_hex(i), batch_id=f"b{i}")
+    q.drain()  # all fail -> breaker opens after threshold
+    assert q.breaker_state == BreakerState.OPEN
+    # Breaker open + queue nonzero below recovery_ratio -> RECOVERY.
+    assert q.state == OverflowState.RECOVERY
+
+
+def test_compute_state_breaker_open_ratio_bands(tmp_path):
+    """Breaker-open branch covers ALERT/DEGRADED/RECOVERY bands too."""
+    clock = _FakeClock()
+    q = LocalReplayQueue(_cfg(max_entries=100), queue_root=tmp_path, anchor=_FailAnchor(), clock=clock)
+    q._breaker.state = BreakerState.OPEN
+    assert q._compute_state(85) == OverflowState.ALERT      # >=80% while open
+    assert q._compute_state(60) == OverflowState.DEGRADED   # >=50% while open
+    assert q._compute_state(30) == OverflowState.RECOVERY   # >25% while open
+    assert q._compute_state(10) == OverflowState.RECOVERY   # <=25% but nonzero
+    assert q._compute_state(0) == OverflowState.NORMAL      # empty while open
+
+
+# ---- circuit-breaker ----------------------------------------------------------
+
+
+def test_breaker_opens_after_threshold_failures(tmp_path):
+    clock = _FakeClock()
+    anchor = _FailAnchor()
+    q = LocalReplayQueue(_cfg(max_entries=100), queue_root=tmp_path, anchor=anchor, clock=clock)
+    for i in range(5):
+        q.enqueue(_root_hex(i), batch_id=f"b{i}")
+    q.drain()
+    assert q.breaker_state == BreakerState.OPEN
+    # The breaker stops the drain early: not all 5 were attempted.
+    assert anchor.calls >= 3  # opened at the threshold
+
+
+def test_breaker_open_suppresses_drain(tmp_path):
+    clock = _FakeClock()
+    anchor = _FailAnchor()
+    q = LocalReplayQueue(_cfg(), queue_root=tmp_path, anchor=anchor, clock=clock)
+    for i in range(4):
+        q.enqueue(_root_hex(i), batch_id=f"b{i}")
+    q.drain()  # opens breaker
+    calls_after_open = anchor.calls
+    # While still in cooldown, a second drain does nothing (no new anchor calls).
+    assert q.drain() == 0
+    assert anchor.calls == calls_after_open
+
+
+def test_breaker_half_opens_after_cooldown_and_closes_on_success(tmp_path):
+    clock = _FakeClock()
+    anchor = _FlakyAnchor(fail_until=3)  # first 3 fail (open breaker), then succeed
+    q = LocalReplayQueue(_cfg(max_entries=100), queue_root=tmp_path, anchor=anchor, clock=clock)
+    for i in range(5):
+        q.enqueue(_root_hex(i), batch_id=f"b{i}")
+    q.drain()  # 3 failures -> OPEN
+    assert q.breaker_state == BreakerState.OPEN
+    # Advance past cooldown -> next drain half-opens, probe succeeds -> CLOSED.
+    clock.advance(31.0)
+    q.drain()
+    assert q.breaker_state == BreakerState.CLOSED
+    assert q.depth == 0  # remaining roots drained once breaker closed
+
+
+def test_breaker_reopens_if_probe_fails(tmp_path):
+    clock = _FakeClock()
+    anchor = _FailAnchor()
+    q = LocalReplayQueue(_cfg(), queue_root=tmp_path, anchor=anchor, clock=clock)
+    for i in range(4):
+        q.enqueue(_root_hex(i), batch_id=f"b{i}")
+    q.drain()  # OPEN
+    clock.advance(31.0)
+    q.drain()  # half-open probe fails -> re-OPEN
+    assert q.breaker_state == BreakerState.OPEN
+
+
+# ---- per-entry retry / max_retries --------------------------------------------
+
+
+def test_failed_entry_bumps_attempts_and_is_retained(tmp_path):
+    clock = _FakeClock()
+    anchor = _FailAnchor()
+    q = LocalReplayQueue(_cfg(max_entries=100, max_retries=3), queue_root=tmp_path, anchor=anchor, clock=clock)
+    q.enqueue(_root_hex(1), batch_id="b1")
+    q.drain()
+    # The single entry stays (never dropped); its attempt counter incremented.
+    assert q.depth == 1
+    entry = _entries(tmp_path)[0]
+    data = json.loads(entry.read_text())
+    assert data["attempts"] == 1
+
+
+def test_entry_exceeding_max_retries_is_retained_for_operator(tmp_path):
+    clock = _FakeClock()
+    anchor = _FailAnchor()
+    q = LocalReplayQueue(_cfg(max_entries=100, max_retries=1), queue_root=tmp_path, anchor=anchor, clock=clock)
+    q.enqueue(_root_hex(1), batch_id="b1")
+    # Drain repeatedly; reset breaker each time so the entry keeps being tried.
+    for _ in range(3):
+        q.drain()
+        q.operator_override("reset_breaker", reason="test forced retry")
+    # Even past max_retries the root is NEVER dropped.
+    assert q.depth == 1
+
+
+# ---- integrity checks ---------------------------------------------------------
+
+
+def test_integrity_check_skips_tampered_entry(tmp_path):
+    anchor = _OkAnchor()
+    q = LocalReplayQueue(_cfg(integrity_check=True), queue_root=tmp_path, anchor=anchor)
+    q.enqueue(_root_hex(1), batch_id="b1")
+    # Tamper with the persisted entry's root, leaving the stale checksum.
+    entry = _entries(tmp_path)[0]
+    data = json.loads(entry.read_text())
+    data["root_hex"] = _root_hex(999)  # checksum no longer matches
+    entry.write_text(json.dumps(data))
+    # Drain: the tampered entry fails integrity -> skipped, not anchored.
+    assert q.drain() == 0
+    assert anchor.anchored == []
+
+
+def test_integrity_disabled_accepts_entry_without_checksum(tmp_path):
+    anchor = _OkAnchor()
+    q = LocalReplayQueue(_cfg(integrity_check=False), queue_root=tmp_path, anchor=anchor)
+    q.enqueue(_root_hex(1), batch_id="b1")
+    entry = _entries(tmp_path)[0]
+    assert "checksum" not in json.loads(entry.read_text())
+    assert q.drain() == 1
+
+
+def test_corrupt_json_entry_is_skipped(tmp_path):
+    anchor = _OkAnchor()
+    q = LocalReplayQueue(_cfg(), queue_root=tmp_path, anchor=anchor)
+    qdir = Path(tmp_path) / "replay_queue"
+    (qdir / f"{'0'*12}-{_root_hex(1)}.json").write_text("{ not json")
+    assert q.drain() == 0
+    assert anchor.anchored == []
+
+
+def test_read_entry_missing_required_field_skipped(tmp_path):
+    anchor = _OkAnchor()
+    q = LocalReplayQueue(_cfg(integrity_check=False), queue_root=tmp_path, anchor=anchor)
+    qdir = Path(tmp_path) / "replay_queue"
+    (qdir / f"{'0'*12}-{_root_hex(1)}.json").write_text(json.dumps({"seq": 1}))  # no root_hex
+    assert q.drain() == 0
+
+
+# ---- audited operator override ------------------------------------------------
+
+
+def test_operator_override_reset_breaker(tmp_path, caplog):
+    clock = _FakeClock()
+    anchor = _FailAnchor()
+    q = LocalReplayQueue(_cfg(), queue_root=tmp_path, anchor=anchor, clock=clock)
+    for i in range(4):
+        q.enqueue(_root_hex(i), batch_id=f"b{i}")
+    q.drain()
+    assert q.breaker_state == BreakerState.OPEN
+    with caplog.at_level("WARNING"):
+        q.operator_override("reset_breaker", reason="manual recovery")
+    assert q.breaker_state == BreakerState.CLOSED
+    assert any("OPERATOR OVERRIDE reset_breaker" in r.message for r in caplog.records)
+
+
+def test_operator_override_clear_pause_is_audited(tmp_path, caplog):
+    q = LocalReplayQueue(_cfg(), queue_root=tmp_path)
+    with caplog.at_level("WARNING"):
+        q.operator_override("clear_pause", reason="ack")
+    assert any("OPERATOR OVERRIDE clear_pause" in r.message for r in caplog.records)
+
+
+def test_operator_override_unknown_action_raises(tmp_path):
+    q = LocalReplayQueue(_cfg(), queue_root=tmp_path)
+    with pytest.raises(ReplayQueueError, match="unknown operator override"):
+        q.operator_override("delete_everything", reason="nope")
+
+
+# ---- recovery: Rekor returns, queue drains ------------------------------------
+
+
+def test_full_recovery_cycle(tmp_path):
+    """Rekor down -> queue fills -> Rekor up -> queue drains to empty (NORMAL)."""
+    clock = _FakeClock()
+    anchor = _FlakyAnchor(fail_until=3)
+    q = LocalReplayQueue(_cfg(max_entries=100), queue_root=tmp_path, anchor=anchor, clock=clock)
+    for i in range(6):
+        q.enqueue(_root_hex(i), batch_id=f"b{i}")
+    q.drain()  # breaker opens after 3 failures
+    assert q.breaker_state == BreakerState.OPEN
+    clock.advance(31.0)
+    q.drain()  # half-open probe succeeds -> drains the rest
+    assert q.depth == 0
+    assert q.state == OverflowState.NORMAL
+
+
+# ---- checksum helper ----------------------------------------------------------
+
+
+def test_checksum_is_stable_and_order_independent(tmp_path):
+    a = {"seq": 1, "root_hex": "ab", "batch_id": "b"}
+    b = {"batch_id": "b", "root_hex": "ab", "seq": 1}  # different key order
+    assert _checksum(a) == _checksum(b)
+
+
+def test_queued_root_dataclass_defaults():
+    qr = QueuedRoot(seq=1, root_hex="ab", batch_id="b")
+    assert qr.attempts == 0
+    assert qr.metadata == {}
+
+
+# ---- coverage completion: realistic defensive-path exercise -------------------
+
+
+def test_half_open_probe_path_allows_attempt(tmp_path):
+    """A drain while the breaker is already HALF_OPEN proceeds with the probe."""
+    clock = _FakeClock()
+    anchor = _FlakyAnchor(fail_until=3)
+    q = LocalReplayQueue(_cfg(max_entries=100), queue_root=tmp_path, anchor=anchor, clock=clock)
+    for i in range(4):
+        q.enqueue(_root_hex(i), batch_id=f"b{i}")
+    q.drain()  # OPEN
+    # Manually set HALF_OPEN to exercise the half-open allow-attempt branch.
+    q._breaker.state = BreakerState.HALF_OPEN
+    q.drain()  # half-open probe (call 4) succeeds -> CLOSED, drains rest
+    assert q.breaker_state == BreakerState.CLOSED
+    assert q.depth == 0
+
+
+def test_bump_attempts_rewrites_entry_with_incremented_counter(tmp_path):
+    """A failed-but-retryable entry is rewritten in place with attempts+1."""
+    clock = _FakeClock()
+    anchor = _FailAnchor()
+    q = LocalReplayQueue(_cfg(max_entries=100, max_retries=5), queue_root=tmp_path, anchor=anchor, clock=clock)
+    q.enqueue(_root_hex(1), batch_id="b1")
+    q.drain()  # 1 failure -> bump to attempts=1
+    data = json.loads(_entries(tmp_path)[0].read_text())
+    assert data["attempts"] == 1
+    assert data["root_hex"] == _root_hex(1)  # same root, rewritten
+
+
+def test_bump_attempts_keeps_same_filename_and_seq(tmp_path):
+    """The atomic bump preserves the entry's seq + filename (in-place overwrite).
+
+    graq_predict failure-chain #1 guard: the bump must NOT remove-then-rewrite
+    (which would lose the root on a crash between the two). Same seq+root => same
+    deterministic path => os.replace overwrites atomically, so the root is on
+    disk the whole time and exactly ONE entry exists before and after.
+    """
+    clock = _FakeClock()
+    anchor = _FailAnchor()
+    q = LocalReplayQueue(_cfg(max_entries=100, max_retries=5), queue_root=tmp_path, anchor=anchor, clock=clock)
+    q.enqueue(_root_hex(1), batch_id="b1")
+    name_before = _entries(tmp_path)[0].name
+    seq_before = json.loads(_entries(tmp_path)[0].read_text())["seq"]
+    q.drain()  # fail -> atomic in-place bump
+    entries_after = _entries(tmp_path)
+    assert len(entries_after) == 1  # still exactly one entry (no gap, no dup)
+    assert entries_after[0].name == name_before  # same filename
+    assert json.loads(entries_after[0].read_text())["seq"] == seq_before  # same seq
+
+
+def test_bumped_entry_anchors_once_when_rekor_recovers(tmp_path):
+    """After bumps, a recovered Rekor anchors the root exactly once (no double on disk)."""
+
+    class _FlakyRecordingAnchor:
+        available = True
+
+        def __init__(self, fail_until):
+            self.fail_until = fail_until
+            self.calls = 0
+            self.anchored: list[bytes] = []
+
+        def anchor(self, root_bytes):
+            self.calls += 1
+            if self.calls <= self.fail_until:
+                raise AnchorError(f"transient {self.calls}")
+            self.anchored.append(root_bytes)
+            return _receipt()
+
+    clock = _FakeClock()
+    anchor = _FlakyRecordingAnchor(fail_until=1)  # 1st attempt fails (bump), then succeeds
+    q = LocalReplayQueue(_cfg(max_entries=100, max_retries=5), queue_root=tmp_path, anchor=anchor, clock=clock)
+    q.enqueue(_root_hex(1), batch_id="b1")
+    q.drain()  # attempt 1 fails -> bumped, still queued
+    assert q.depth == 1
+    q.drain()  # attempt 2 succeeds -> removed
+    assert q.depth == 0
+    assert anchor.anchored == [bytes.fromhex(_root_hex(1))]  # anchored once
+
+
+def test_remove_entry_missing_file_is_noop(tmp_path):
+    """_remove_entry tolerates an already-deleted file (FileNotFoundError arm)."""
+    q = LocalReplayQueue(_cfg(), queue_root=tmp_path)
+    q._remove_entry(Path(tmp_path) / "replay_queue" / "nope.json")  # must not raise
+
+
+def test_read_entry_non_dict_json_skipped(tmp_path):
+    """A JSON array (not an object) is rejected by _read_entry (line 440 path)."""
+    anchor = _OkAnchor()
+    q = LocalReplayQueue(_cfg(integrity_check=False), queue_root=tmp_path, anchor=anchor)
+    qdir = Path(tmp_path) / "replay_queue"
+    (qdir / f"{'0'*12}-{_root_hex(1)}.json").write_text("[1,2,3]")
+    assert q.drain() == 0
+
+
+def test_list_entries_unreadable_dir_returns_empty(tmp_path, monkeypatch):
+    """If the queue dir cannot be listed, _list_entries degrades to [] (line 465)."""
+    q = LocalReplayQueue(_cfg(), queue_root=tmp_path)
+    q.enqueue(_root_hex(1), batch_id="b1")
+
+    def boom_iterdir(self):
+        raise OSError("iterdir denied")
+
+    monkeypatch.setattr(Path, "iterdir", boom_iterdir)
+    assert q._list_entries() == []
+    assert q.depth == 0  # depth uses _list_entries
+
+
+def test_write_entry_temp_cleanup_failure_is_swallowed(tmp_path, monkeypatch):
+    """If a write fails AND the orphan-temp cleanup unlink also fails, no crash (403-406)."""
+    import os as _os
+
+    q = LocalReplayQueue(_cfg(), queue_root=tmp_path)
+
+    def boom_fsync(fd):
+        raise OSError("fsync failed")
+
+    def boom_unlink(path):
+        raise OSError("unlink failed")
+
+    monkeypatch.setattr(_os, "fsync", boom_fsync)
+    monkeypatch.setattr(_os, "unlink", boom_unlink)
+    # The fsync OSError propagates; the cleanup-unlink failure is swallowed.
+    with pytest.raises(OSError, match="fsync failed"):
+        q.enqueue(_root_hex(1), batch_id="b1")
+
+
+def test_remove_entry_oserror_is_logged_not_raised(tmp_path, monkeypatch, caplog):
+    """A non-FileNotFound OSError on unlink is logged at WARNING, not raised (430-431)."""
+    q = LocalReplayQueue(_cfg(), queue_root=tmp_path)
+    q.enqueue(_root_hex(1), batch_id="b1")
+    entry = _entries(tmp_path)[0]
+
+    def boom_unlink(self):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "unlink", boom_unlink)
+    with caplog.at_level("WARNING"):
+        q._remove_entry(entry)  # must not raise
+    assert any("failed to remove replay-queue entry" in r.message for r in caplog.records)
+
+
+def test_enqueue_rejects_non_hex_root(tmp_path):
+    """A non-hex root is refused at enqueue (it would fail bytes.fromhex at anchor)."""
+    q = LocalReplayQueue(_cfg(), queue_root=tmp_path)
+    with pytest.raises(ReplayQueueError, match="hex"):
+        q.enqueue("nothex!!", batch_id="b1")
+    with pytest.raises(ReplayQueueError, match="hex"):
+        q.enqueue("abc", batch_id="b1")  # odd length
+    assert q.depth == 0
+
+
+def test_subdir_never_escapes_queue_root(tmp_path):
+    """A traversal-style config.directory cannot place the queue outside queue_root."""
+    q = LocalReplayQueue(_cfg(directory="../../../../etc/evil"), queue_root=tmp_path)
+    # Only the last component is used; it stays under queue_root.
+    assert q.queue_dir.parent == Path(tmp_path)
+    assert q.queue_dir.name == "evil"
+
+
+def test_subdir_dotdot_falls_back_to_default(tmp_path):
+    """A config.directory whose last component is '..' falls back to replay_queue."""
+    q = LocalReplayQueue(_cfg(directory="foo/.."), queue_root=tmp_path)
+    assert q.queue_dir == Path(tmp_path) / "replay_queue"
+
+
+def test_drain_skips_nonhex_root_on_disk(tmp_path):
+    """A non-hex root that reached disk (tamper) is skipped, not crashed (drain guard)."""
+    anchor = _OkAnchor()
+    q = LocalReplayQueue(_cfg(integrity_check=False), queue_root=tmp_path, anchor=anchor)
+    qdir = Path(tmp_path) / "replay_queue"
+    (qdir / f"{'0'*12}-deadbeef.json").write_text(
+        json.dumps({"seq": 1, "root_hex": "nothex", "batch_id": "b", "attempts": 0, "metadata": {}})
+    )
+    assert q.drain() == 0  # skipped, no crash
+    assert anchor.anchored == []
+
+
+def test_concurrent_enqueue_all_persist(tmp_path):
+    """Concurrent enqueues from many threads all persist with unique seqs (lock)."""
+    import threading
+
+    q = LocalReplayQueue(_cfg(max_entries=100), queue_root=tmp_path)
+    barrier = threading.Barrier(16)
+
+    def worker(i):
+        barrier.wait()
+        q.enqueue(_root_hex(i), batch_id=f"b{i}")
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(16)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert q.depth == 16
+    seqs = [int(p.name.split("-", 1)[0]) for p in _entries(tmp_path)]
+    assert len(set(seqs)) == 16  # every entry got a unique sequence number
+
+
+def test_corrupt_json_is_logged(tmp_path, caplog):
+    """A corrupt JSON entry is logged at WARNING when read (observability)."""
+    q = LocalReplayQueue(_cfg(), queue_root=tmp_path, anchor=_OkAnchor())
+    qdir = Path(tmp_path) / "replay_queue"
+    (qdir / f"{'0'*12}-{_root_hex(1)}.json").write_text("{ not json")
+    with caplog.at_level("WARNING"):
+        q.drain()
+    assert any("unreadable/corrupt" in r.message for r in caplog.records)
+
+
+def test_highest_seq_ignores_malformed_filename(tmp_path):
+    """A non-numeric seq prefix is skipped by _highest_seq_on_disk (line 474)."""
+    qdir = Path(tmp_path) / "replay_queue"
+    qdir.mkdir(parents=True, exist_ok=True)
+    # A file whose prefix before '-' is not an int.
+    (qdir / f"notanumber-{_root_hex(1)}.json").write_text(
+        json.dumps({"seq": 1, "root_hex": _root_hex(1), "batch_id": "b", "attempts": 0, "metadata": {}})
+    )
+    # Construction calls _highest_seq_on_disk; malformed prefix must not crash.
+    q = LocalReplayQueue(_cfg(integrity_check=False), queue_root=tmp_path)
+    assert q._next_seq >= 1  # survived the malformed filename

--- a/tests/test_tamper_evidence/test_sigstore_rekor.py
+++ b/tests/test_tamper_evidence/test_sigstore_rekor.py
@@ -1,0 +1,328 @@
+"""Tests for the Sigstore Rekor anchor (v0.59.0 PR-4, R25-EU01 Task 1.4).
+
+Every test runs WITHOUT the optional ``sigstore`` package and WITHOUT network:
+a fake :class:`RekorTransport` is injected, and the backoff sleep is injected so
+retries are instant + deterministic. The lazy-import / availability surface is
+tested by stubbing ``importlib.util.find_spec``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from graqle.config.attestation_config import RekorConfig
+from graqle.governance.tamper_evidence.anchors import sigstore_rekor as sr
+from graqle.governance.tamper_evidence.anchors.sigstore_rekor import (
+    AnchorError,
+    AnchorUnavailableError,
+    RekorAnchor,
+    RekorReceipt,
+    RekorTransport,
+)
+
+
+# ---- fakes --------------------------------------------------------------------
+
+
+def _receipt(i: int = 1) -> RekorReceipt:
+    return RekorReceipt(
+        log_index=i,
+        log_id="logid",
+        signed_tree_head="sth",
+        inclusion_cert="cert",
+        integrated_time=1_700_000_000 + i,
+    )
+
+
+class _OkTransport:
+    """Always succeeds; records every submitted root."""
+
+    def __init__(self):
+        self.submitted: list[bytes] = []
+
+    def submit(self, root_bytes: bytes) -> RekorReceipt:
+        self.submitted.append(root_bytes)
+        return _receipt(len(self.submitted))
+
+
+class _FlakyTransport:
+    """Fails the first ``fail_n`` calls, then succeeds."""
+
+    def __init__(self, fail_n: int):
+        self.fail_n = fail_n
+        self.calls = 0
+
+    def submit(self, root_bytes: bytes) -> RekorReceipt:
+        self.calls += 1
+        if self.calls <= self.fail_n:
+            raise RuntimeError(f"transient rekor error {self.calls}")
+        return _receipt(self.calls)
+
+
+class _AlwaysFailTransport:
+    def __init__(self):
+        self.calls = 0
+
+    def submit(self, root_bytes: bytes) -> RekorReceipt:
+        self.calls += 1
+        raise RuntimeError("rekor down")
+
+
+def _no_sleep(_seconds: float) -> None:
+    pass
+
+
+# ---- Protocol conformance -----------------------------------------------------
+
+
+def test_fakes_satisfy_transport_protocol():
+    assert isinstance(_OkTransport(), RekorTransport)
+    assert isinstance(_FlakyTransport(1), RekorTransport)
+
+
+# ---- happy path ---------------------------------------------------------------
+
+
+def test_anchor_returns_receipt_on_success():
+    transport = _OkTransport()
+    anchor = RekorAnchor(transport=transport, sleep=_no_sleep)
+    receipt = anchor.anchor(b"\x11" * 32)
+    assert isinstance(receipt, RekorReceipt)
+    assert receipt.log_index == 1
+    assert transport.submitted == [b"\x11" * 32]
+
+
+def test_anchor_accepts_bytearray():
+    transport = _OkTransport()
+    anchor = RekorAnchor(transport=transport, sleep=_no_sleep)
+    anchor.anchor(bytearray(b"\x22" * 32))
+    assert transport.submitted == [b"\x22" * 32]
+
+
+def test_anchor_rejects_non_bytes():
+    anchor = RekorAnchor(transport=_OkTransport(), sleep=_no_sleep)
+    with pytest.raises(AnchorError, match="must be bytes"):
+        anchor.anchor("not bytes")  # type: ignore[arg-type]
+
+
+# ---- retry / backoff ----------------------------------------------------------
+
+
+def test_anchor_retries_then_succeeds():
+    transport = _FlakyTransport(fail_n=2)
+    sleeps: list[float] = []
+    anchor = RekorAnchor(
+        config=RekorConfig(retry_max_attempts=3),
+        transport=transport,
+        sleep=sleeps.append,
+    )
+    receipt = anchor.anchor(b"\x33" * 32)
+    assert receipt.log_index == 3  # 3rd call succeeded
+    assert transport.calls == 3
+    # Exponential backoff between the 3 attempts: 2^0=1, 2^1=2.
+    assert sleeps == [1.0, 2.0]
+
+
+def test_anchor_raises_after_exhausting_attempts():
+    transport = _AlwaysFailTransport()
+    anchor = RekorAnchor(
+        config=RekorConfig(retry_max_attempts=3),
+        transport=transport,
+        sleep=_no_sleep,
+    )
+    with pytest.raises(AnchorError, match="after 3 attempt"):
+        anchor.anchor(b"\x44" * 32)
+    assert transport.calls == 3  # all attempts used
+
+
+def test_anchor_single_attempt_no_backoff():
+    transport = _AlwaysFailTransport()
+    sleeps: list[float] = []
+    anchor = RekorAnchor(
+        config=RekorConfig(retry_max_attempts=1),
+        transport=transport,
+        sleep=sleeps.append,
+    )
+    with pytest.raises(AnchorError):
+        anchor.anchor(b"\x55" * 32)
+    assert transport.calls == 1
+    assert sleeps == []  # no backoff when only one attempt
+
+
+def test_anchor_error_chains_last_transport_error():
+    anchor = RekorAnchor(
+        config=RekorConfig(retry_max_attempts=2),
+        transport=_AlwaysFailTransport(),
+        sleep=_no_sleep,
+    )
+    with pytest.raises(AnchorError) as exc_info:
+        anchor.anchor(b"\x66" * 32)
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+
+# ---- availability / lazy optional dependency ----------------------------------
+
+
+def test_available_true_when_transport_injected():
+    assert RekorAnchor(transport=_OkTransport()).available is True
+
+
+def test_available_reflects_sigstore_importability(monkeypatch):
+    """With no transport, `available` mirrors whether sigstore can be imported."""
+    monkeypatch.setattr(sr, "_sigstore_importable", lambda: True)
+    assert RekorAnchor().available is True
+    monkeypatch.setattr(sr, "_sigstore_importable", lambda: False)
+    assert RekorAnchor().available is False
+
+
+def test_anchor_raises_unavailable_when_sigstore_missing(monkeypatch):
+    """No transport + sigstore not importable -> AnchorUnavailableError with remedy."""
+    monkeypatch.setattr(sr, "_sigstore_importable", lambda: False)
+    anchor = RekorAnchor(sleep=_no_sleep)
+    with pytest.raises(AnchorUnavailableError, match="pip install graqle\\[attestation\\]"):
+        anchor.anchor(b"\x77" * 32)
+
+
+def test_submit_raising_unavailable_surfaces_without_retry():
+    """If the TRANSPORT itself raises AnchorUnavailableError, it is not retried."""
+
+    class _UnavailableTransport:
+        def __init__(self):
+            self.calls = 0
+
+        def submit(self, root_bytes):
+            self.calls += 1
+            raise AnchorUnavailableError()
+
+    transport = _UnavailableTransport()
+    anchor = RekorAnchor(
+        config=RekorConfig(retry_max_attempts=5), transport=transport, sleep=_no_sleep
+    )
+    with pytest.raises(AnchorUnavailableError):
+        anchor.anchor(b"\xab" * 32)
+    assert transport.calls == 1  # surfaced on first attempt, not retried
+
+
+def test_unavailable_is_not_retried(monkeypatch):
+    """AnchorUnavailableError surfaces immediately — retrying can't install a dep."""
+    build_calls = {"n": 0}
+
+    def fake_build(_config):
+        build_calls["n"] += 1
+        raise AnchorUnavailableError()
+
+    monkeypatch.setattr(sr, "_build_sigstore_transport", fake_build)
+    anchor = RekorAnchor(config=RekorConfig(retry_max_attempts=5), sleep=_no_sleep)
+    with pytest.raises(AnchorUnavailableError):
+        anchor.anchor(b"\x88" * 32)
+    assert build_calls["n"] == 1  # built once, not retried 5x
+
+
+def test_lazy_transport_built_once_and_cached(monkeypatch):
+    """The real transport is built lazily on first anchor, then reused."""
+    transport = _OkTransport()
+    build_calls = {"n": 0}
+
+    def fake_build(_config):
+        build_calls["n"] += 1
+        return transport
+
+    monkeypatch.setattr(sr, "_build_sigstore_transport", fake_build)
+    anchor = RekorAnchor(sleep=_no_sleep)  # no transport injected
+    anchor.anchor(b"\x99" * 32)
+    anchor.anchor(b"\xaa" * 32)
+    assert build_calls["n"] == 1  # built once, cached for the second anchor
+    assert len(transport.submitted) == 2
+
+
+def test_build_sigstore_transport_raises_when_missing(monkeypatch):
+    monkeypatch.setattr(sr, "_sigstore_importable", lambda: False)
+    with pytest.raises(AnchorUnavailableError):
+        sr._build_sigstore_transport(RekorConfig())
+
+
+def test_build_sigstore_transport_returns_adapter_when_present(monkeypatch):
+    """When sigstore is importable, the builder returns the real adapter type."""
+    monkeypatch.setattr(sr, "_sigstore_importable", lambda: True)
+    transport = sr._build_sigstore_transport(RekorConfig())  # default https url
+    assert isinstance(transport, sr._SigstoreRekorTransport)
+
+
+# ---- SSRF guard on the Rekor URL ----------------------------------------------
+
+
+def test_validate_rekor_url_accepts_default_https():
+    sr._validate_rekor_url("https://rekor.sigstore.dev")  # must not raise
+
+
+def test_validate_rekor_url_rejects_non_https():
+    with pytest.raises(AnchorError, match="https"):
+        sr._validate_rekor_url("http://rekor.sigstore.dev")
+
+
+@pytest.mark.parametrize(
+    "host",
+    ["localhost", "127.0.0.1", "0.0.0.0", "169.254.169.254", "metadata.google.internal"],
+)
+def test_validate_rekor_url_rejects_internal_hosts(host):
+    """SSRF guard: loopback / link-local / metadata targets are refused."""
+    with pytest.raises(AnchorError, match="loopback/internal"):
+        sr._validate_rekor_url(f"https://{host}/api")
+
+
+def test_validate_rekor_url_rejects_missing_host():
+    with pytest.raises(AnchorError, match="no host"):
+        sr._validate_rekor_url("https://")
+
+
+def test_build_transport_rejects_ssrf_url(monkeypatch):
+    """The SSRF guard runs at transport-build time, before any client is created."""
+    monkeypatch.setattr(sr, "_sigstore_importable", lambda: True)
+    with pytest.raises(AnchorError, match="loopback/internal"):
+        sr._build_sigstore_transport(RekorConfig(url="https://169.254.169.254"))
+
+
+# ---- root_bytes size guard ----------------------------------------------------
+
+
+def test_anchor_rejects_empty_root():
+    anchor = RekorAnchor(transport=_OkTransport(), sleep=_no_sleep)
+    with pytest.raises(AnchorError, match="implausible length"):
+        anchor.anchor(b"")
+
+
+def test_anchor_rejects_oversized_root():
+    anchor = RekorAnchor(transport=_OkTransport(), sleep=_no_sleep)
+    with pytest.raises(AnchorError, match="implausible length"):
+        anchor.anchor(b"\x00" * 65)
+
+
+def test_anchor_accepts_32_byte_root():
+    transport = _OkTransport()
+    anchor = RekorAnchor(transport=transport, sleep=_no_sleep)
+    anchor.anchor(b"\x11" * 32)  # canonical SHA-256 root size
+    assert len(transport.submitted) == 1
+
+
+def test_sigstore_importable_uses_find_spec(monkeypatch):
+    """_sigstore_importable is a pure find_spec probe (no import side effects)."""
+    import importlib.util as _ilu
+
+    monkeypatch.setattr(_ilu, "find_spec", lambda name: object() if name == "sigstore" else None)
+    assert sr._sigstore_importable() is True
+    monkeypatch.setattr(_ilu, "find_spec", lambda name: None)
+    assert sr._sigstore_importable() is False
+
+
+# ---- RekorReceipt -------------------------------------------------------------
+
+
+def test_receipt_is_frozen():
+    r = _receipt()
+    with pytest.raises(Exception):
+        r.log_index = 99  # type: ignore[misc]
+
+
+def test_unavailable_error_is_anchor_error_subclass():
+    """AnchorUnavailableError is catchable as AnchorError (callers may catch broadly)."""
+    assert issubclass(AnchorUnavailableError, AnchorError)


### PR DESCRIPTION
## v0.59.0 Layer 5 — public sync: PR-3b (batcher coverage) + PR-4 (Rekor anchor + replay queue)

> Public cherry-pick of two already-merged private PRs (research-development-graqle #140 + #141). **No version bump** — stays 0.58.1; the single bump to 0.59.0 lands in PR-7.

Two sequential commits:

### 1. PR-3b — `batcher.py` to realistic 100% coverage (commit `94702155`)
Follow-up to PR-3. Brings `batcher.py` to **100% on Linux CI** (94% on Windows; the only Windows-uncovered lines are the POSIX-only `_safe_dir_fsync` body, covered on Linux). 8 fault-injection tests (each asserts graceful degradation, not coverage theatre) + one **invariant-guard** test proving the key==filename-stem binding. Production change: removed a provably-dead in-loop dedup branch in `_recover_from_wal` (the binding + unique filenames already guarantee distinct recovered keys; exactly-once vs the live path stays enforced by `enqueue()`).

### 2. PR-4 — Sigstore Rekor anchor + durable replay queue (commit `f0cd030c`)
- **`anchors/sigstore_rekor.py` — `RekorAnchor`**: optional-`sigstore` lazy import (`importlib.util.find_spec`) + injectable `RekorTransport` (100% unit-testable, no network/no dep); bounded exponential-backoff retry; fail-closed (`AnchorError`, never silently drops); **SSRF-guarded Rekor URL** (https-only, rejects loopback/link-local/metadata hosts before any client is built); `root_bytes` size guard.
- **`local_replay_queue.py` — `LocalReplayQueue`**: CONDITION-3 durable fallback for unreachable Rekor. Disjoint from the PR-3 WAL (`.graqle/replay_queue/` vs `.graqle/uncommitted/`). 5-state overflow (`NORMAL/DEGRADED/ALERT/PAUSE/RECOVERY`) + independent circuit-breaker + SHA-256 integrity + audited operator override. **AC-9**: `pause_writes` persists + signals PAUSE, never drops a root. Atomic `tempfile→fsync→os.replace`; `RLock`-serialized; injectable clock+anchor; **atomic in-place attempt-bump** (no remove-then-write window — crash-safe).

### Review (both PRs, private repo)
Each went through the full ADR-209 triple-sentinel chain (`review-all ×2` + `predict` + `review-security`):
- PR-3b: `focus=tests` flagged a missing invariant-validation test → added.
- PR-4: **security pass caught a real SSRF** (config URL → client) and **predict caught a real durability bug** (remove-then-rewrite could lose a root on crash) — both fixed before merge; plus thread-safety lock, hex validation, path-traversal guard, POSIX perms.

### Verification
- **214 tamper_evidence tests pass** in the public tree, 4 skipped (POSIX-only + hypothesis — platform-correct), zero regressions.
- Coverage: `sigstore_rekor.py` 100%, `local_replay_queue.py` 100% (Linux CI), `merkle.py` 100%, `batcher.py` 100% (Linux CI). The only `# pragma: no cover` line is the real `sigstore` adapter (needs the optional dep + live Rekor).
- TS-2 trade-secret scan: clean.

### Design notes (carried from the private PRs)
- **At-least-once anchoring** (not exactly-once): a lost Rekor response → re-anchor → benign duplicate (content-addressed root; inclusion proof validates against either; Rekor coalesces). Exactly-once deferred to the PR-5 committer.
- **Crash-recovery commit order** is content-address (hash-sorted), not enqueue order — sound for tamper-evidence (each record → one leaf + valid proof).
- Optional dependency: `sigstore>=3.0,<3.1` under a `[attestation]` extra is wired in PR-7's packaging pass; this PR adds no hard dependency.

### Files
- `graqle/governance/tamper_evidence/batcher.py` (MOD — dead-branch removal)
- `graqle/governance/tamper_evidence/anchors/__init__.py` (NEW)
- `graqle/governance/tamper_evidence/anchors/sigstore_rekor.py` (NEW)
- `graqle/governance/tamper_evidence/local_replay_queue.py` (NEW)
- `tests/test_tamper_evidence/test_batcher.py` (MOD — +8 tests)
- `tests/test_tamper_evidence/test_sigstore_rekor.py` (NEW)
- `tests/test_tamper_evidence/test_local_replay_queue.py` (NEW)
