### PR TITLE
v0.59.0 Layer 5 PR-5: committer orchestrator + audit-log v3 (R25-EU01 Task 1.5)

### DIFF
--- a/graqle/governance/tamper_evidence/audit_log_v3.py
+++ b/graqle/governance/tamper_evidence/audit_log_v3.py
@@ -1,0 +1,190 @@
+"""Audit-log v3: commit-status sidecar over the v2 governed trace (R25-EU01 PR-5).
+
+The v2 audit record is :class:`graqle.governance.trace_schema.GovernedTrace` —
+the system of record for every governed tool call (schema_version ``"2"`` since
+cr-017). That model is ``ConfigDict(extra="forbid")``: its field set is frozen,
+and adding Layer-5 commit fields directly to it would be a breaking schema change
+touching every reader.
+
+Audit-log **v3** therefore composes ALONGSIDE v2 rather than mutating it: a
+:class:`CommitRecord` is a *sidecar* that references a trace by id and carries
+only the cryptographic-commit lifecycle — which batch the trace's record landed
+in, when it was committed, and (crucially) its :class:`CommitStatus`. The trace
+stays exactly as v2 wrote it; v3 is a separate, joinable record.
+
+**No-silent-drop invariant.** :class:`CommitStatus` makes the fate of every
+submitted record explicit and total — a record is always in exactly one of:
+
+    PENDING        enqueued to the batcher, not yet flushed
+    COMMITTED      in a flushed batch with a Merkle root (root proven locally)
+    ANCHORED       the batch root is anchored in Rekor (externally proven)
+    REPLAY_QUEUED  Rekor was unreachable; root durably queued for later anchor
+    FAILED         a terminal, surfaced failure (operator must act)
+
+There is no "unknown" / "lost" state: a record that leaves ``submit()`` is
+tracked to one of these, and the committer never silently discards one (the
+AC-9 lineage from PR-4's replay queue).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+from uuid import UUID
+
+
+class CommitStatus(str, Enum):
+    """The total, explicit set of commit-lifecycle states (no-silent-drop).
+
+    Ordered loosely by progression: PENDING -> COMMITTED -> ANCHORED is the
+    happy path; REPLAY_QUEUED is the Rekor-unavailable branch (still progressing
+    toward ANCHORED on a later drain); FAILED is terminal and operator-surfaced.
+    """
+
+    PENDING = "pending"
+    COMMITTED = "committed"
+    ANCHORED = "anchored"
+    REPLAY_QUEUED = "replay_queued"
+    FAILED = "failed"
+
+
+# Terminal states: no further automatic transition is expected from these.
+# COMMITTED and REPLAY_QUEUED are NON-terminal (a later anchor/drain advances
+# them to ANCHORED). PENDING is non-terminal (a flush advances it).
+_TERMINAL = frozenset({CommitStatus.ANCHORED, CommitStatus.FAILED})
+
+
+@dataclass
+class CommitRecord:
+    """An audit-log v3 sidecar binding a governed trace to its commit lifecycle.
+
+    Joinable to the v2 :class:`GovernedTrace` via ``trace_id``. Carries only the
+    Layer-5 commit fields, so the v2 record is never mutated.
+
+    Attributes
+    ----------
+    trace_id:
+        The ``id`` of the :class:`GovernedTrace` this commit pertains to.
+    record_hash:
+        SHA-256 (hex) content-address of the governed record that entered the
+        batch — the batcher's idempotency key, so a CommitRecord is joinable to
+        the exact leaf as well as the trace.
+    commit_status:
+        The current :class:`CommitStatus`. Starts at PENDING.
+    batch_id:
+        The batch this record was committed in (set at COMMITTED).
+    merkle_root_hex:
+        The batch's Merkle root, lowercase hex (set at COMMITTED).
+    rekor_log_index / rekor_log_id:
+        Rekor inclusion-cert identifiers (set at ANCHORED).
+    committed_at_iso / anchored_at_iso:
+        UTC ISO-8601 timestamps for the COMMITTED / ANCHORED transitions.
+    error:
+        Failure detail (set at FAILED).
+    schema_version:
+        The audit-log generation. ``"3"`` for these sidecar records.
+    """
+
+    trace_id: UUID
+    record_hash: str
+    commit_status: CommitStatus = CommitStatus.PENDING
+    batch_id: str | None = None
+    merkle_root_hex: str | None = None
+    rekor_log_index: int | None = None
+    rekor_log_id: str | None = None
+    committed_at_iso: str | None = None
+    anchored_at_iso: str | None = None
+    error: str | None = None
+    schema_version: str = "3"
+
+    # -- transitions (each is explicit; none drops the record) --------------
+
+    def mark_committed(self, batch_id: str, merkle_root_hex: str) -> None:
+        """PENDING -> COMMITTED: the record's batch was flushed with a root."""
+        self.commit_status = CommitStatus.COMMITTED
+        self.batch_id = batch_id
+        self.merkle_root_hex = merkle_root_hex
+        self.committed_at_iso = _utc_now_iso()
+
+    def mark_anchored(self, rekor_log_index: int, rekor_log_id: str) -> None:
+        """COMMITTED -> ANCHORED: the batch root is in Rekor (externally proven)."""
+        self.commit_status = CommitStatus.ANCHORED
+        self.rekor_log_index = rekor_log_index
+        self.rekor_log_id = rekor_log_id
+        self.anchored_at_iso = _utc_now_iso()
+
+    def mark_replay_queued(self, batch_id: str, merkle_root_hex: str) -> None:
+        """-> REPLAY_QUEUED: Rekor unreachable; root durably queued for later.
+
+        Sets the batch identity too (the record IS committed locally with a
+        root; only the external anchor is deferred), so a later drain can
+        advance it to ANCHORED.
+        """
+        self.commit_status = CommitStatus.REPLAY_QUEUED
+        self.batch_id = batch_id
+        self.merkle_root_hex = merkle_root_hex
+        if self.committed_at_iso is None:
+            self.committed_at_iso = _utc_now_iso()
+
+    def mark_failed(self, error: str) -> None:
+        """-> FAILED: a terminal, surfaced failure (operator must act)."""
+        self.commit_status = CommitStatus.FAILED
+        self.error = error[:1000]
+
+    @property
+    def is_terminal(self) -> bool:
+        """True if no further automatic transition is expected (ANCHORED/FAILED)."""
+        return self.commit_status in _TERMINAL
+
+    def snapshot(self) -> dict[str, Any]:
+        """Capture the FULL mutable state for an exact rollback.
+
+        Returns every commit-lifecycle field (not just status), so a failed batch
+        can be restored byte-for-byte to its pre-batch state — restoring only the
+        status would leave stale ``batch_id`` / root / anchor fields on a
+        rolled-back record (a real inconsistency caught in PR-5 review).
+        """
+        return {
+            "commit_status": self.commit_status,
+            "batch_id": self.batch_id,
+            "merkle_root_hex": self.merkle_root_hex,
+            "rekor_log_index": self.rekor_log_index,
+            "rekor_log_id": self.rekor_log_id,
+            "committed_at_iso": self.committed_at_iso,
+            "anchored_at_iso": self.anchored_at_iso,
+            "error": self.error,
+        }
+
+    def restore(self, snap: dict[str, Any]) -> None:
+        """Restore the full mutable state captured by :meth:`snapshot`."""
+        self.commit_status = snap["commit_status"]
+        self.batch_id = snap["batch_id"]
+        self.merkle_root_hex = snap["merkle_root_hex"]
+        self.rekor_log_index = snap["rekor_log_index"]
+        self.rekor_log_id = snap["rekor_log_id"]
+        self.committed_at_iso = snap["committed_at_iso"]
+        self.anchored_at_iso = snap["anchored_at_iso"]
+        self.error = snap["error"]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain dict for the append-only audit store / KG."""
+        return {
+            "schema_version": self.schema_version,
+            "trace_id": str(self.trace_id),
+            "record_hash": self.record_hash,
+            "commit_status": self.commit_status.value,
+            "batch_id": self.batch_id,
+            "merkle_root_hex": self.merkle_root_hex,
+            "rekor_log_index": self.rekor_log_index,
+            "rekor_log_id": self.rekor_log_id,
+            "committed_at_iso": self.committed_at_iso,
+            "anchored_at_iso": self.anchored_at_iso,
+            "error": self.error,
+        }
+
+
+def _utc_now_iso() -> str:
+    """Current UTC time as an ISO-8601 string with a trailing Z."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/graqle/governance/tamper_evidence/committer.py
+++ b/graqle/governance/tamper_evidence/committer.py
@@ -1,0 +1,426 @@
+"""Committer orchestrator for Layer 5 tamper-evidence (R25-EU01 Task 1.5).
+
+The committer is the seam that ties the Layer-5 pieces together into one
+non-blocking commit lifecycle, while keeping the governed-trace write path
+(R18 / trace_capture) completely undisturbed:
+
+    submit(record)                      # non-blocking: enqueue + track PENDING
+        -> WalBatcher.enqueue (PR-3)    # durable WAL, content-addressed
+    on batcher flush (size/time):
+        -> MerkleTree over the batch    # PR-2/PR-3 (built by the batcher)
+        -> RekorAnchor.anchor (PR-4)    # external transparency-log anchor
+              success     -> mark ANCHORED
+              AnchorError -> LocalReplayQueue.enqueue (PR-4) -> mark REPLAY_QUEUED
+        -> persist (batch_id, root, rekor_cert) to the KG    # batched MERGE (PR-6 wires Neo4j)
+
+Design choices (PR-5 INVESTIGATE, blast-radius MEDIUM):
+
+* **Composition, not modification.** trace_capture.py is a 47-dependency hub; the
+  committer does NOT restructure it. Instead it is wired in as a *minimal additive
+  observer*: :meth:`as_trace_observer` returns a callback that ``TraceCapture``
+  invokes (best-effort) after a trace is finalized. A committer failure therefore
+  can never break the governed-trace path — the trace is the system of record;
+  the cryptographic commit is downstream.
+* **No-silent-drop.** Every submitted record gets a :class:`CommitRecord` whose
+  :class:`CommitStatus` is always one of PENDING/COMMITTED/ANCHORED/
+  REPLAY_QUEUED/FAILED. A record is never lost: if anchoring fails it is
+  REPLAY_QUEUED (durably), and a hard failure is FAILED (surfaced), never dropped.
+* **Batched persist + rollback.** The per-batch KG persist is staged and applied
+  as a unit; on persist failure the staged commit records roll back to their
+  pre-batch status so there is no partial commit. (The Neo4j ``:CommittedBatch``
+  MERGE itself lands in PR-6; PR-5 stages the data + status and exposes a
+  ``kg_persist`` callback seam.)
+* **Fully injectable** (batcher, anchor, replay_queue, kg_persist, clock) so the
+  whole lifecycle is unit-testable offline — no network, no Neo4j.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from graqle.config.attestation_config import AttestationConfig
+from graqle.governance.tamper_evidence.anchors.sigstore_rekor import (
+    AnchorError,
+    RekorAnchor,
+    RekorReceipt,
+)
+from graqle.governance.tamper_evidence.audit_log_v3 import (
+    CommitRecord,
+    CommitStatus,
+)
+from graqle.governance.tamper_evidence.batcher import WalBatcher
+from graqle.governance.tamper_evidence.errors import TamperEvidenceError
+from graqle.governance.tamper_evidence.local_replay_queue import LocalReplayQueue
+from graqle.governance.tamper_evidence.merkle import MerkleTree, leaf_hash_for_record
+
+logger = logging.getLogger(__name__)
+
+# A KG-persist callback receives the committed (batch_id, root_hex, receipt-or-None,
+# commit_records) and durably records them. PR-6 wires the Neo4j :CommittedBatch
+# MERGE behind this seam; until then a no-op default is used. It MUST raise on
+# failure so the committer can roll the batch's commit records back.
+KgPersistFn = Callable[["BatchCommit"], None]
+
+
+class CommitterError(TamperEvidenceError):
+    """Raised for committer-orchestration failures that cannot proceed safely."""
+
+
+@dataclass(frozen=True)
+class BatchCommit:
+    """The result of committing one batch: identity, root, anchor, and records."""
+
+    batch_id: str
+    merkle_root_hex: str
+    receipt: RekorReceipt | None  # None when REPLAY_QUEUED (anchor deferred)
+    commit_records: list[CommitRecord]
+    anchored: bool
+
+
+def _record_hash(record: dict[str, Any]) -> str:
+    """Content-address of a governed record == its Merkle leaf hash, hex.
+
+    Matches the batcher's idempotency key derivation conceptually (both are
+    content-addressed), and ties a CommitRecord to its exact leaf.
+    """
+    return leaf_hash_for_record(record).hex()
+
+
+class Committer:
+    """Orchestrates record -> batch -> Merkle root -> Rekor anchor (or replay queue).
+
+    Parameters
+    ----------
+    config:
+        Layer 5 attestation config (passed through to the batcher).
+    batcher:
+        A :class:`WalBatcher`. If omitted, the caller must inject one; the
+        committer installs ITS OWN flush handler as the batcher's committer
+        callback, so do not also pass a committer callback to the batcher.
+    anchor:
+        A :class:`RekorAnchor` (or compatible). Optional: without one, batches
+        are committed locally (COMMITTED) but not anchored.
+    replay_queue:
+        A :class:`LocalReplayQueue` for the Rekor-unavailable fallback. Optional:
+        without one, an anchor failure marks records FAILED instead of
+        REPLAY_QUEUED (degraded, but still no silent drop).
+    kg_persist:
+        Callback to durably persist a :class:`BatchCommit` (PR-6 Neo4j seam).
+        Must raise on failure (triggers rollback). Defaults to a no-op.
+    """
+
+    def __init__(
+        self,
+        config: AttestationConfig,
+        batcher: WalBatcher,
+        anchor: RekorAnchor | None = None,
+        replay_queue: LocalReplayQueue | None = None,
+        kg_persist: KgPersistFn | None = None,
+    ) -> None:
+        self._config = config
+        self._batcher = batcher
+        self._anchor = anchor
+        self._replay_queue = replay_queue
+        self._kg_persist = kg_persist
+        self._lock = threading.RLock()
+        # Commit records keyed by content-address (the batcher's idempotency key),
+        # so a record submitted twice maps to one CommitRecord (mirrors the
+        # batcher's content-addressed dedup). This is the no-silent-drop ledger.
+        self._records: dict[str, CommitRecord] = {}
+        # Batch ids whose KG mirror failed AFTER a durable Rekor anchor. The
+        # anchor is authoritative; these are deferred for out-of-band KG
+        # reconciliation rather than re-anchored (which would orphan the anchor).
+        self._kg_persist_pending: list[str] = []
+        # Wire our flush handler in as the batcher's committer callback.
+        self._batcher._committer = self._on_batch_flush  # type: ignore[attr-defined]
+
+    # ---- public API -----------------------------------------------------------
+
+    def submit(self, record: dict[str, Any], trace_id: Any = None) -> CommitRecord:
+        """Non-blocking: enqueue ``record`` for commit and track it PENDING.
+
+        Returns the :class:`CommitRecord` (PENDING, or its current status if the
+        same record was already submitted — content-addressed, so a re-submit is
+        idempotent). The heavy work (Merkle build + anchor) happens later when
+        the batcher flushes, via :meth:`_on_batch_flush`.
+        """
+        from uuid import UUID, uuid4
+
+        if not isinstance(record, dict):
+            raise CommitterError(
+                f"record must be a dict, got {type(record).__name__}"
+            )
+        rhash = _record_hash(record)
+        with self._lock:
+            existing = self._records.get(rhash)
+            if existing is not None:
+                return existing  # idempotent: same content already tracked
+            tid = trace_id if isinstance(trace_id, UUID) else uuid4()
+            cr = CommitRecord(trace_id=tid, record_hash=rhash, commit_status=CommitStatus.PENDING)
+            self._records[rhash] = cr
+            # Enqueue AFTER tracking so a flush triggered inline by enqueue (when
+            # the size ceiling is hit) already sees this record's CommitRecord.
+            self._batcher.enqueue(record)
+            return cr
+
+    def flush(self) -> int:
+        """Force a batcher flush now; returns the number of records committed."""
+        return self._batcher.flush()
+
+    def commit_record_for(self, record: dict[str, Any]) -> CommitRecord | None:
+        """Look up the tracked :class:`CommitRecord` for ``record`` (or None)."""
+        with self._lock:
+            return self._records.get(_record_hash(record))
+
+    def status_counts(self) -> dict[str, int]:
+        """A census of commit statuses across all tracked records (observability)."""
+        counts: dict[str, int] = {s.value: 0 for s in CommitStatus}
+        with self._lock:
+            for cr in self._records.values():
+                counts[cr.commit_status.value] += 1
+        return counts
+
+    def as_trace_observer(self) -> Callable[[Any], None]:
+        """Return a best-effort observer callback for ``TraceCapture``.
+
+        The callback extracts a committable record from a finalized
+        :class:`GovernedTrace` and submits it. It NEVER raises: the governed
+        trace path must not be affected by a committer error (the hook in
+        trace_capture wraps this defensively too, but we belt-and-suspenders it
+        here). Returns quickly — the actual commit work is deferred to flush.
+        """
+
+        def _observe(trace: Any) -> None:
+            try:
+                record = _trace_to_record(trace)
+                if record is not None:
+                    self.submit(record, trace_id=getattr(trace, "id", None))
+            except Exception:  # never break the trace path
+                logger.warning("committer trace-observer failed (non-fatal)", exc_info=True)
+
+        return _observe
+
+    # ---- batch flush handler (invoked by the batcher) -------------------------
+
+    @staticmethod
+    def _new_batch_id() -> str:
+        """A fresh batch identifier from a CSPRNG.
+
+        ``secrets.token_hex`` makes the cryptographically-secure source explicit
+        for this tamper-evidence context (uuid4 is already urandom-backed in
+        CPython, but the intent should not depend on that implementation detail).
+        The batch_id is an identifier, not a secret — the cryptographic strength
+        of the commitment lives in the Merkle root + Rekor anchor — but a
+        collision-resistant, unpredictable id is still the right default here.
+        """
+        import secrets
+
+        return secrets.token_hex(16)
+
+    def _on_batch_flush(self, records: list[dict[str, Any]], tree: MerkleTree) -> None:
+        """Batcher committer callback: anchor the batch root, advance statuses.
+
+        Invoked by :class:`WalBatcher` with the flushed records + their Merkle
+        tree. Order is load-bearing:
+
+        1. mint a batch_id + read the root;
+        2. mark every record COMMITTED (root proven locally);
+        3. attempt the Rekor anchor:
+             success      -> mark ANCHORED;
+             AnchorError  -> enqueue the root to the replay queue, mark
+                             REPLAY_QUEUED (or FAILED if no queue);
+        4. persist the BatchCommit to the KG (batched). On persist failure, roll
+           the batch's commit records back to PENDING so nothing is half-committed
+           — the batcher then leaves the WAL intact (it re-raises on our raise),
+           and the next flush retries the whole batch.
+
+        Raising from here propagates to the batcher, which (by its contract)
+        leaves the WAL entries in place for retry — so a persist failure never
+        loses a record.
+
+        Locking note: this runs under ``self._lock`` and that lock is held across
+        the anchor call (which may sleep on retry backoff). That is intentional —
+        the batcher already serializes flush against ``enqueue`` at its own lock,
+        and the anchor's retry budget is bounded — so concurrent ``submit`` calls
+        briefly wait during a flush rather than racing the ``_records`` ledger.
+        """
+        with self._lock:
+            batch_id = self._new_batch_id()
+            root_hex = tree.root_hex
+            batch_records = [self._track(r) for r in records]
+
+            # Snapshot the FULL pre-batch state of each record for an exact
+            # rollback (status alone is insufficient — see _kg_persist failure
+            # path; restoring only status would leave stale batch/root/anchor
+            # fields on a rolled-back record).
+            snapshot = [(cr, cr.snapshot()) for cr in batch_records]
+
+            for cr in batch_records:
+                cr.mark_committed(batch_id, root_hex)
+
+            receipt: RekorReceipt | None = None
+            anchored = False
+            if self._anchor is not None:
+                try:
+                    receipt = self._anchor.anchor(tree.root)
+                    for cr in batch_records:
+                        cr.mark_anchored(receipt.log_index, receipt.log_id)
+                    anchored = True
+                except AnchorError as exc:
+                    self._handle_anchor_failure(batch_id, root_hex, batch_records, exc)
+
+            batch = BatchCommit(
+                batch_id=batch_id,
+                merkle_root_hex=root_hex,
+                receipt=receipt,
+                commit_records=list(batch_records),
+                anchored=anchored,
+            )
+
+            if self._kg_persist is not None:
+                try:
+                    self._kg_persist(batch)
+                except Exception as exc:
+                    self._handle_persist_failure(batch_id, batch_records, snapshot, anchored, exc)
+
+    def _handle_persist_failure(
+        self,
+        batch_id: str,
+        batch_records: list[CommitRecord],
+        snapshot: list[tuple[CommitRecord, dict[str, Any]]],
+        anchored: bool,
+        exc: Exception,
+    ) -> None:
+        """Resolve a KG-persist failure WITHOUT ever causing a double-anchor.
+
+        The Rekor anchor (when it happened) is PERMANENT and immutable — it
+        cannot be rolled back. So the resolution depends on whether the batch was
+        already anchored (graq_predict failure-chain #2):
+
+        * **Not anchored** (anchor disabled, or it failed → REPLAY_QUEUED/FAILED):
+          nothing irreversible happened, so roll the records back to their full
+          pre-batch state and re-raise. The batcher keeps the WAL intact and the
+          whole batch is retried cleanly.
+
+        * **Anchored**: the cryptographic commitment is already durable in Rekor.
+          Re-flushing would re-anchor the SAME root under a NEW batch_id,
+          orphaning the first anchor — so we must NOT re-raise. The records stay
+          ANCHORED (no-silent-drop: they ARE committed+anchored), the batcher
+          clears the WAL, and the failed KG mirror is recorded in
+          ``_kg_persist_pending`` for out-of-band reconciliation (it is surfaced,
+          never dropped). The KG row is a downstream mirror of the authoritative
+          Rekor anchor, so deferring it is safe.
+        """
+        if not anchored:
+            for cr, snap in snapshot:
+                cr.restore(snap)
+            raise CommitterError(
+                f"KG persist failed for unanchored batch {batch_id}; rolled back "
+                f"{len(batch_records)} record(s) for clean retry: {exc}"
+            ) from exc
+        # Anchored: keep records ANCHORED, defer the KG mirror, do NOT re-anchor.
+        self._kg_persist_pending.append(batch_id)
+        logger.error(
+            "KG persist failed for ALREADY-ANCHORED batch %s; records remain "
+            "ANCHORED (Rekor commitment is durable), KG mirror deferred for "
+            "reconciliation. NOT re-raising (would double-anchor). cause: %s",
+            batch_id, exc,
+        )
+
+    @property
+    def kg_persist_pending(self) -> list[str]:
+        """Batch ids whose KG mirror failed AFTER a durable anchor (reconcile out-of-band)."""
+        with self._lock:
+            return list(self._kg_persist_pending)
+
+    # ---- helpers --------------------------------------------------------------
+
+    def _track(self, record: dict[str, Any]) -> CommitRecord:
+        """Return the CommitRecord for ``record``, creating a PENDING one if absent.
+
+        A record can reach the flush handler without a prior submit() only via
+        crash-recovery (the batcher drains its WAL on startup and flushes records
+        that were never re-submitted through the committer). Such a record still
+        gets a CommitRecord here — no-silent-drop covers the recovery path too.
+        """
+        from uuid import uuid4
+
+        rhash = _record_hash(record)
+        cr = self._records.get(rhash)
+        if cr is None:
+            cr = CommitRecord(trace_id=uuid4(), record_hash=rhash, commit_status=CommitStatus.PENDING)
+            self._records[rhash] = cr
+        return cr
+
+    def _handle_anchor_failure(
+        self, batch_id: str, root_hex: str, batch_records: list[CommitRecord], exc: AnchorError
+    ) -> None:
+        """Rekor anchor failed: queue for replay (or mark FAILED if no queue)."""
+        if self._replay_queue is not None:
+            try:
+                self._replay_queue.enqueue(root_hex, batch_id, metadata={"reason": "anchor_failed"})
+                for cr in batch_records:
+                    cr.mark_replay_queued(batch_id, root_hex)
+                logger.warning(
+                    "Rekor anchor failed for batch %s; root queued for replay: %s",
+                    batch_id, exc,
+                )
+                return
+            except Exception as queue_exc:  # queue itself failed -> surface FAILED
+                for cr in batch_records:
+                    cr.mark_failed(f"anchor + replay-queue both failed: {queue_exc}")
+                logger.error(
+                    "Rekor anchor AND replay-queue failed for batch %s: anchor=%s queue=%s",
+                    batch_id, exc, queue_exc,
+                )
+                return
+        # No replay queue configured: do not silently drop — mark FAILED.
+        for cr in batch_records:
+            cr.mark_failed(f"anchor failed and no replay queue configured: {exc}")
+        logger.error("Rekor anchor failed for batch %s, no replay queue: %s", batch_id, exc)
+
+
+def _trace_to_record(trace: Any) -> dict[str, Any] | None:
+    """Project a finalized GovernedTrace into a committable leaf-input record.
+
+    Returns the minimal leaf-hash-input record (the frozen LEAF_HASH_FIELDS
+    shape from PR-1) derived from the trace, or None if the trace lacks the
+    fields needed to form a record. Kept defensive: the observer must tolerate
+    any trace shape without raising.
+    """
+    import hashlib
+    import json as _json
+
+    trace_id = getattr(trace, "id", None)
+    if trace_id is None:
+        return None
+    # content_hash binds the committed record to the trace's salient content.
+    try:
+        basis = _json.dumps(
+            {
+                "tool_name": getattr(trace, "tool_name", None),
+                "query": getattr(trace, "query", None),
+                "outcome": getattr(getattr(trace, "outcome", None), "value", None),
+            },
+            sort_keys=True,
+            default=str,
+        )
+    except (TypeError, ValueError):
+        logger.debug("could not derive a commit record from trace %s; skipping", trace_id)
+        return None
+    content_hash = hashlib.sha256(basis.encode("utf-8")).hexdigest()
+    timestamp = getattr(trace, "timestamp", None)
+    ts_unix = int(timestamp.timestamp()) if timestamp is not None else 0
+    return {
+        "proof_format_version": "1.0.0",
+        "record_id": str(trace_id),
+        "content_hash": content_hash,
+        "timestamp_unix": ts_unix,
+        "governance_metadata": {
+            "schema_version": getattr(trace, "schema_version", "2"),
+            "outcome": getattr(getattr(trace, "outcome", None), "value", None),
+        },
+    }

--- a/graqle/governance/trace_capture.py
+++ b/graqle/governance/trace_capture.py
@@ -29,7 +29,7 @@ import json
 import logging
 import time
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 from graqle.governance.trace_schema import (
     ClearanceLevel,
@@ -162,10 +162,18 @@ class TraceCapture:
         tool_name: str,
         arguments: dict[str, Any],
         store: TraceStore | None = None,
+        observer: Callable[[GovernedTrace], None] | None = None,
     ) -> None:
         self._tool_name = tool_name
         self._arguments = arguments
         self._store = store
+        # Optional, best-effort post-finalize observer (R25-EU01 PR-5). Invoked
+        # with the finalized trace AFTER it is persisted, so a downstream consumer
+        # (the Layer-5 committer) can observe completed traces without this module
+        # depending on it. A None observer (the default) preserves v0.58.x
+        # behaviour byte-for-byte. The observer is wrapped so it can NEVER affect
+        # the governed-trace path — the trace is the system of record.
+        self._observer = observer
         self._start_time: float = 0.0
         self.trace: GovernedTrace | None = None
         self.result: str = ""
@@ -254,5 +262,17 @@ class TraceCapture:
                 await self._store.append(self.trace)
             except Exception:
                 logger.warning("Failed to persist trace for %s", self._tool_name, exc_info=True)
+
+        # Post-finalize observer (R25-EU01 PR-5), best-effort. Runs AFTER persist
+        # so the trace is already the durable system of record; an observer
+        # failure is logged and swallowed — it must never affect the trace path
+        # or suppress a handler exception.
+        if self._observer is not None:
+            try:
+                self._observer(self.trace)
+            except Exception:
+                logger.warning(
+                    "Trace observer failed for %s (non-fatal)", self._tool_name, exc_info=True
+                )
 
         return False  # Never suppress exceptions

--- a/tests/test_tamper_evidence/test_audit_log_v3.py
+++ b/tests/test_tamper_evidence/test_audit_log_v3.py
@@ -1,0 +1,151 @@
+"""Tests for audit-log v3 commit-status sidecar (v0.59.0 PR-5, R25-EU01)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from graqle.governance.tamper_evidence.audit_log_v3 import (
+    CommitRecord,
+    CommitStatus,
+)
+
+
+def _cr() -> CommitRecord:
+    return CommitRecord(trace_id=uuid4(), record_hash="a" * 64)
+
+
+# ---- CommitStatus enum --------------------------------------------------------
+
+
+def test_commit_status_values_are_the_total_set():
+    """The 5 states are exactly the no-silent-drop lifecycle (no 'unknown')."""
+    assert {s.value for s in CommitStatus} == {
+        "pending", "committed", "anchored", "replay_queued", "failed",
+    }
+
+
+def test_commit_status_is_str_enum():
+    assert CommitStatus.ANCHORED == "anchored"  # str-comparable for serialization
+
+
+# ---- initial state ------------------------------------------------------------
+
+
+def test_new_record_is_pending():
+    cr = _cr()
+    assert cr.commit_status == CommitStatus.PENDING
+    assert cr.schema_version == "3"
+    assert cr.is_terminal is False
+    assert cr.batch_id is None
+
+
+# ---- transitions --------------------------------------------------------------
+
+
+def test_mark_committed_sets_batch_root_and_timestamp():
+    cr = _cr()
+    cr.mark_committed("batch1", "f" * 64)
+    assert cr.commit_status == CommitStatus.COMMITTED
+    assert cr.batch_id == "batch1"
+    assert cr.merkle_root_hex == "f" * 64
+    assert cr.committed_at_iso is not None and cr.committed_at_iso.endswith("Z")
+    assert cr.is_terminal is False  # COMMITTED still progresses to ANCHORED
+
+
+def test_mark_anchored_is_terminal():
+    cr = _cr()
+    cr.mark_committed("batch1", "f" * 64)
+    cr.mark_anchored(12345, "logid")
+    assert cr.commit_status == CommitStatus.ANCHORED
+    assert cr.rekor_log_index == 12345
+    assert cr.rekor_log_id == "logid"
+    assert cr.anchored_at_iso is not None
+    assert cr.is_terminal is True
+
+
+def test_mark_replay_queued_sets_batch_and_is_not_terminal():
+    cr = _cr()
+    cr.mark_replay_queued("batch2", "e" * 64)
+    assert cr.commit_status == CommitStatus.REPLAY_QUEUED
+    assert cr.batch_id == "batch2"
+    assert cr.merkle_root_hex == "e" * 64
+    assert cr.committed_at_iso is not None  # committed locally, anchor deferred
+    assert cr.is_terminal is False  # a later drain advances it to ANCHORED
+
+
+def test_replay_queued_preserves_existing_committed_timestamp():
+    cr = _cr()
+    cr.mark_committed("batch1", "f" * 64)
+    first_ts = cr.committed_at_iso
+    cr.mark_replay_queued("batch1", "f" * 64)
+    assert cr.committed_at_iso == first_ts  # not overwritten
+
+
+def test_mark_failed_is_terminal_and_truncates():
+    cr = _cr()
+    cr.mark_failed("x" * 5000)
+    assert cr.commit_status == CommitStatus.FAILED
+    assert cr.error is not None and len(cr.error) == 1000  # truncated
+    assert cr.is_terminal is True
+
+
+# ---- serialization ------------------------------------------------------------
+
+
+def test_to_dict_round_trip_shape():
+    cr = _cr()
+    cr.mark_committed("batch1", "f" * 64)
+    cr.mark_anchored(7, "log7")
+    d = cr.to_dict()
+    assert d["schema_version"] == "3"
+    assert d["commit_status"] == "anchored"
+    assert d["batch_id"] == "batch1"
+    assert d["merkle_root_hex"] == "f" * 64
+    assert d["rekor_log_index"] == 7
+    assert d["trace_id"] == str(cr.trace_id)
+    assert d["record_hash"] == "a" * 64
+
+
+def test_to_dict_pending_has_nulls():
+    cr = _cr()
+    d = cr.to_dict()
+    assert d["commit_status"] == "pending"
+    assert d["batch_id"] is None
+    assert d["rekor_log_index"] is None
+    assert d["error"] is None
+
+
+# ---- snapshot / restore (full-state rollback) ---------------------------------
+
+
+def test_snapshot_restore_round_trip_full_state():
+    """restore(snapshot()) returns the record to its EXACT prior state."""
+    cr = _cr()
+    snap = cr.snapshot()  # pristine PENDING
+    cr.mark_committed("batch1", "f" * 64)
+    cr.mark_anchored(7, "log7")
+    assert cr.commit_status == CommitStatus.ANCHORED
+    cr.restore(snap)
+    # Every mutable field is back to pristine — no stale batch/root/anchor data.
+    assert cr.commit_status == CommitStatus.PENDING
+    assert cr.batch_id is None
+    assert cr.merkle_root_hex is None
+    assert cr.rekor_log_index is None
+    assert cr.rekor_log_id is None
+    assert cr.committed_at_iso is None
+    assert cr.anchored_at_iso is None
+    assert cr.error is None
+
+
+def test_snapshot_captures_committed_state():
+    """A snapshot taken mid-lifecycle restores to THAT point, not pristine."""
+    cr = _cr()
+    cr.mark_committed("batch1", "f" * 64)
+    snap = cr.snapshot()  # COMMITTED
+    cr.mark_anchored(7, "log7")
+    cr.restore(snap)
+    assert cr.commit_status == CommitStatus.COMMITTED
+    assert cr.batch_id == "batch1"
+    assert cr.rekor_log_index is None  # anchor undone

--- a/tests/test_tamper_evidence/test_committer.py
+++ b/tests/test_tamper_evidence/test_committer.py
@@ -1,0 +1,388 @@
+"""Tests for the Layer 5 committer orchestrator (v0.59.0 PR-5, R25-EU01 Task 1.5).
+
+Offline + deterministic: a real (tested) WalBatcher is used for the durable
+enqueue/flush wiring, while the anchor, replay queue, and kg_persist seam are
+fakes. Covers the full no-silent-drop lifecycle (PENDING -> COMMITTED ->
+ANCHORED / REPLAY_QUEUED / FAILED), batched rollback, idempotency, the
+trace-observer hook, and crash-recovery tracking.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from uuid import uuid4
+
+import pytest
+
+from graqle.config.attestation_config import AttestationConfig, ReplayQueueConfig
+from graqle.governance.tamper_evidence.anchors.sigstore_rekor import (
+    AnchorError,
+    RekorAnchor,
+    RekorReceipt,
+)
+from graqle.governance.tamper_evidence.audit_log_v3 import CommitStatus
+from graqle.governance.tamper_evidence.batcher import WalBatcher
+from graqle.governance.tamper_evidence.committer import (
+    BatchCommit,
+    Committer,
+    CommitterError,
+    _record_hash,
+    _trace_to_record,
+)
+from graqle.governance.tamper_evidence.local_replay_queue import LocalReplayQueue
+
+
+# ---- fakes / helpers ----------------------------------------------------------
+
+
+def _record(i: int) -> dict:
+    return {
+        "proof_format_version": "1.0.0",
+        "record_id": f"tr_{i:06d}",
+        "content_hash": hashlib.sha256(f"payload-{i}".encode()).hexdigest(),
+        "timestamp_unix": 1_700_000_000 + i,
+        "governance_metadata": {"decision": "ALLOW", "seq": i},
+    }
+
+
+def _receipt(i: int = 1) -> RekorReceipt:
+    return RekorReceipt(i, "logid", "sth", "cert", 1_700_000_000 + i)
+
+
+class _OkTransport:
+    def __init__(self):
+        self.calls = 0
+
+    def submit(self, root_bytes):
+        self.calls += 1
+        return _receipt(self.calls)
+
+
+class _FailTransport:
+    def submit(self, root_bytes):
+        raise RuntimeError("rekor down")
+
+
+def _ok_anchor() -> RekorAnchor:
+    return RekorAnchor(transport=_OkTransport(), sleep=lambda _s: None)
+
+
+def _fail_anchor() -> RekorAnchor:
+    return RekorAnchor(
+        config=__import__("graqle.config.attestation_config", fromlist=["RekorConfig"]).RekorConfig(retry_max_attempts=1),
+        transport=_FailTransport(),
+        sleep=lambda _s: None,
+    )
+
+
+def _config(**over) -> AttestationConfig:
+    base = {"batch_max_records": 1000, "batch_max_seconds": 5}
+    base.update(over)
+    return AttestationConfig(**base)
+
+
+def _batcher(tmp_path, **cfg_over) -> WalBatcher:
+    # The committer installs its own flush handler; do NOT pass a committer here.
+    return WalBatcher(_config(**cfg_over), wal_root=tmp_path)
+
+
+def _replay_queue(tmp_path, anchor=None) -> LocalReplayQueue:
+    return LocalReplayQueue(ReplayQueueConfig(), queue_root=tmp_path, anchor=anchor)
+
+
+# ---- submit / PENDING ---------------------------------------------------------
+
+
+def test_submit_tracks_pending(tmp_path):
+    c = Committer(_config(), batcher=_batcher(tmp_path), anchor=_ok_anchor())
+    cr = c.submit(_record(1))
+    assert cr.commit_status == CommitStatus.PENDING
+    assert cr.record_hash == _record_hash(_record(1))
+
+
+def test_submit_rejects_non_dict(tmp_path):
+    c = Committer(_config(), batcher=_batcher(tmp_path))
+    with pytest.raises(CommitterError, match="must be a dict"):
+        c.submit("nope")  # type: ignore[arg-type]
+
+
+def test_submit_is_idempotent(tmp_path):
+    c = Committer(_config(), batcher=_batcher(tmp_path), anchor=_ok_anchor())
+    cr1 = c.submit(_record(1))
+    cr2 = c.submit(_record(1))
+    assert cr1 is cr2  # same content -> same CommitRecord
+    assert c.status_counts()["pending"] == 1
+
+
+def test_submit_uses_provided_trace_id(tmp_path):
+    c = Committer(_config(), batcher=_batcher(tmp_path))
+    tid = uuid4()
+    cr = c.submit(_record(1), trace_id=tid)
+    assert cr.trace_id == tid
+
+
+# ---- happy path: COMMITTED -> ANCHORED ----------------------------------------
+
+
+def test_flush_commits_and_anchors(tmp_path):
+    c = Committer(_config(), batcher=_batcher(tmp_path), anchor=_ok_anchor())
+    for i in range(3):
+        c.submit(_record(i))
+    committed = c.flush()
+    assert committed == 3
+    counts = c.status_counts()
+    assert counts["anchored"] == 3
+    cr = c.commit_record_for(_record(0))
+    assert cr.commit_status == CommitStatus.ANCHORED
+    assert cr.batch_id is not None
+    assert cr.merkle_root_hex is not None
+    assert cr.rekor_log_index is not None
+
+
+def test_size_trigger_anchors_inline(tmp_path):
+    c = Committer(_config(batch_max_records=2), batcher=_batcher(tmp_path, batch_max_records=2), anchor=_ok_anchor())
+    c.submit(_record(0))
+    assert c.status_counts()["pending"] == 1
+    c.submit(_record(1))  # hits ceiling -> inline flush -> anchored
+    assert c.status_counts()["anchored"] == 2
+
+
+def test_commit_without_anchor_stays_committed(tmp_path):
+    """No anchor configured: records commit locally (COMMITTED), not anchored."""
+    c = Committer(_config(), batcher=_batcher(tmp_path), anchor=None)
+    c.submit(_record(1))
+    c.flush()
+    cr = c.commit_record_for(_record(1))
+    assert cr.commit_status == CommitStatus.COMMITTED  # no silent drop, no anchor
+
+
+# ---- anchor failure -> REPLAY_QUEUED ------------------------------------------
+
+
+def test_anchor_failure_queues_for_replay(tmp_path):
+    rq = _replay_queue(tmp_path / "rq")
+    c = Committer(_config(), batcher=_batcher(tmp_path), anchor=_fail_anchor(), replay_queue=rq)
+    c.submit(_record(1))
+    c.flush()
+    cr = c.commit_record_for(_record(1))
+    assert cr.commit_status == CommitStatus.REPLAY_QUEUED
+    assert cr.batch_id is not None
+    assert rq.depth == 1  # root durably queued
+
+
+def test_anchor_failure_without_queue_marks_failed(tmp_path):
+    """No replay queue: anchor failure marks FAILED (surfaced), never dropped."""
+    c = Committer(_config(), batcher=_batcher(tmp_path), anchor=_fail_anchor(), replay_queue=None)
+    c.submit(_record(1))
+    c.flush()
+    cr = c.commit_record_for(_record(1))
+    assert cr.commit_status == CommitStatus.FAILED
+    assert cr.error is not None
+
+
+def test_anchor_and_queue_both_fail_marks_failed(tmp_path):
+    """If both the anchor and the replay-queue enqueue fail, mark FAILED."""
+
+    class _BrokenQueue:
+        def enqueue(self, *a, **k):
+            raise OSError("queue write failed")
+
+    c = Committer(_config(), batcher=_batcher(tmp_path), anchor=_fail_anchor(), replay_queue=_BrokenQueue())
+    c.submit(_record(1))
+    c.flush()
+    cr = c.commit_record_for(_record(1))
+    assert cr.commit_status == CommitStatus.FAILED
+    assert "replay-queue" in cr.error
+
+
+# ---- batched persist + rollback -----------------------------------------------
+
+
+def test_kg_persist_called_with_batch_commit(tmp_path):
+    seen: list[BatchCommit] = []
+    c = Committer(_config(), batcher=_batcher(tmp_path), anchor=_ok_anchor(), kg_persist=seen.append)
+    for i in range(3):
+        c.submit(_record(i))
+    c.flush()
+    assert len(seen) == 1
+    batch = seen[0]
+    assert batch.anchored is True
+    assert len(batch.commit_records) == 3
+    assert batch.receipt is not None
+    assert batch.merkle_root_hex is not None
+
+
+def test_kg_persist_failure_unanchored_rolls_back_and_retries(tmp_path):
+    """KG-persist failure on an UNANCHORED batch rolls back fully + retries cleanly.
+
+    With no anchor configured, nothing irreversible happened, so a persist
+    failure rolls every record back to pristine PENDING and re-raises (batcher
+    keeps the WAL intact). A clean retry then commits.
+    """
+    state = {"fail": True}
+
+    def flaky_persist(_batch):
+        if state["fail"]:
+            raise RuntimeError("neo4j unavailable")
+
+    # anchor=None => batch is COMMITTED but not anchored => safe to roll back.
+    c = Committer(_config(), batcher=_batcher(tmp_path), anchor=None, kg_persist=flaky_persist)
+    c.submit(_record(1))
+    with pytest.raises(Exception):
+        c.flush()
+    cr = c.commit_record_for(_record(1))
+    # FULL rollback: NO stale batch/root fields remain.
+    assert cr.commit_status == CommitStatus.PENDING
+    assert cr.batch_id is None
+    assert cr.merkle_root_hex is None
+    assert cr.committed_at_iso is None
+    # Retry: persist now succeeds -> WAL entry drains, record COMMITTED.
+    state["fail"] = False
+    c.flush()
+    cr = c.commit_record_for(_record(1))
+    assert cr.commit_status == CommitStatus.COMMITTED
+
+
+def test_kg_persist_failure_after_anchor_does_not_double_anchor(tmp_path):
+    """KG-persist failure AFTER a successful anchor must NOT roll back / re-anchor.
+
+    graq_predict failure-chain #2: the Rekor anchor is permanent. If persist
+    fails post-anchor, re-flushing would re-anchor the same root under a new
+    batch_id, orphaning the first. So the records stay ANCHORED, the KG mirror is
+    deferred (surfaced via kg_persist_pending), and the anchor transport is
+    called EXACTLY ONCE.
+    """
+    transport = _OkTransport()
+    anchor = RekorAnchor(transport=transport, sleep=lambda _s: None)
+
+    def always_fail_persist(_batch):
+        raise RuntimeError("neo4j unavailable")
+
+    c = Committer(_config(), batcher=_batcher(tmp_path), anchor=anchor, kg_persist=always_fail_persist)
+    c.submit(_record(1))
+    c.flush()  # must NOT raise (anchored => deferred, not re-raised)
+    cr = c.commit_record_for(_record(1))
+    assert cr.commit_status == CommitStatus.ANCHORED  # no rollback, no silent drop
+    assert c.kg_persist_pending  # the failed KG mirror is recorded for reconcile
+    assert len(c.kg_persist_pending) == 1
+    # The anchor transport was called exactly once — no double-anchor.
+    assert transport.calls == 1
+    # WAL was cleared (batcher did not re-raise) — record is genuinely committed.
+    from graqle.governance.tamper_evidence.batcher import WAL_SUBDIR
+    wal = tmp_path / WAL_SUBDIR
+    remaining = list(wal.glob("*.wal.json")) if wal.exists() else []
+    assert remaining == []
+
+
+# ---- status census ------------------------------------------------------------
+
+
+def test_status_counts_total(tmp_path):
+    c = Committer(_config(), batcher=_batcher(tmp_path), anchor=_ok_anchor())
+    for i in range(2):
+        c.submit(_record(i))
+    counts = c.status_counts()
+    assert sum(counts.values()) == 2
+    assert set(counts) == {"pending", "committed", "anchored", "replay_queued", "failed"}
+
+
+# ---- crash-recovery tracking (record reaches flush without prior submit) ------
+
+
+def test_recovered_record_gets_tracked(tmp_path):
+    """A record drained from the WAL on restart (never submitted) is still tracked."""
+    # Seed a WAL entry via one committer, then build a fresh committer over the
+    # same WAL root: the batcher recovers the entry; flushing tracks it.
+    b1 = _batcher(tmp_path)
+    Committer(_config(), batcher=b1, anchor=_ok_anchor()).submit(_record(5))
+    # New batcher over the same root drains the WAL on construction.
+    b2 = _batcher(tmp_path)
+    c2 = Committer(_config(), batcher=b2, anchor=_ok_anchor())
+    assert b2.pending_count == 1  # recovered
+    c2.flush()
+    cr = c2.commit_record_for(_record(5))
+    assert cr is not None and cr.commit_status == CommitStatus.ANCHORED  # no silent drop
+
+
+# ---- trace observer -----------------------------------------------------------
+
+
+class _FakeTrace:
+    def __init__(self, tid=None, tool="graq_reason", query="q", outcome_val="success"):
+        from datetime import datetime, timezone
+
+        self.id = tid or uuid4()
+        self.tool_name = tool
+        self.query = query
+        self.outcome = type("O", (), {"value": outcome_val})()
+        self.timestamp = datetime(2026, 5, 23, tzinfo=timezone.utc)
+        self.schema_version = "2"
+
+
+def test_as_trace_observer_submits_record(tmp_path):
+    c = Committer(_config(), batcher=_batcher(tmp_path), anchor=_ok_anchor())
+    observe = c.as_trace_observer()
+    trace = _FakeTrace()
+    observe(trace)
+    assert c.status_counts()["pending"] == 1
+
+
+def test_trace_observer_never_raises_on_bad_trace(tmp_path):
+    c = Committer(_config(), batcher=_batcher(tmp_path))
+    observe = c.as_trace_observer()
+    observe(object())  # garbage trace -> must not raise
+    observe(None)  # also must not raise
+    assert c.status_counts()["pending"] == 0  # nothing committed from garbage
+
+
+def test_trace_to_record_shape():
+    trace = _FakeTrace()
+    rec = _trace_to_record(trace)
+    assert rec["proof_format_version"] == "1.0.0"
+    assert rec["record_id"] == str(trace.id)
+    assert len(rec["content_hash"]) == 64
+    assert rec["timestamp_unix"] > 0
+    assert rec["governance_metadata"]["outcome"] == "success"
+
+
+def test_trace_to_record_none_when_no_id():
+    assert _trace_to_record(object()) is None
+
+
+def test_trace_observer_submits_and_survives_submit_failure(tmp_path, monkeypatch):
+    """The observer path: a valid trace submits; if submit raises, it's swallowed.
+
+    Covers the observer's submit call + its defensive except (committer 197-198).
+    """
+    c = Committer(_config(), batcher=_batcher(tmp_path), anchor=_ok_anchor())
+    observe = c.as_trace_observer()
+    # Force submit to raise AFTER a record is extracted -> exercises the except.
+    monkeypatch.setattr(c, "submit", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+    observe(_FakeTrace())  # must not raise despite submit blowing up
+
+
+def test_trace_to_record_non_serializable_returns_none():
+    """A trace whose fields can't be JSON-serialized (even with default=str) -> None.
+
+    Covers the _trace_to_record except (TypeError/ValueError) arm (342-343).
+    """
+
+    class _Unserializable:
+        id = uuid4()
+        tool_name = "graq_reason"
+        query = "q"
+
+        @property
+        def outcome(self):
+            # json.dumps(default=str) will call str() on this; raise there to
+            # trigger the serialization-failure branch.
+            class _Boom:
+                value = property(lambda self: (_ for _ in ()).throw(ValueError("nope")))
+
+                def __str__(self):
+                    raise ValueError("cannot stringify")
+
+            return _Boom()
+
+    # getattr(...outcome).value raises inside the dict build -> caught -> None.
+    assert _trace_to_record(_Unserializable()) is None

--- a/tests/test_tamper_evidence/test_trace_capture_observer.py
+++ b/tests/test_tamper_evidence/test_trace_capture_observer.py
@@ -27,7 +27,11 @@ class _MemStore:
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    # asyncio.run() creates + manages its own event loop. NOT
+    # asyncio.get_event_loop(), which raises "no current event loop" on a clean
+    # Python 3.10+ main thread (the codebase convention is asyncio.run — see
+    # tests/test_governance/test_trace_capture.py).
+    return asyncio.run(coro)
 
 
 async def _capture(observer=None, store=None, raise_in_handler=False):

--- a/tests/test_tamper_evidence/test_trace_capture_observer.py
+++ b/tests/test_tamper_evidence/test_trace_capture_observer.py
@@ -1,0 +1,100 @@
+"""Tests for the additive trace_capture observer hook (v0.59.0 PR-5, R25-EU01).
+
+The PR-5 hook adds ONE optional ``observer`` param to TraceCapture, invoked
+best-effort AFTER the trace is persisted. These tests verify: (1) the observer
+sees the finalized trace, (2) it runs after persist, (3) an observer exception
+never breaks the trace path or suppresses a handler exception, and (4) the
+default (no observer) preserves prior behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from graqle.governance.trace_capture import TraceCapture
+
+
+class _MemStore:
+    """Minimal async trace store capturing appended traces in order."""
+
+    def __init__(self):
+        self.appended = []
+
+    async def append(self, trace):
+        self.appended.append(trace)
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+async def _capture(observer=None, store=None, raise_in_handler=False):
+    tc = TraceCapture("graq_reason", {"question": "hello"}, store=store, observer=observer)
+    async with tc:
+        tc.set_result('{"confidence": 0.9}')
+        if raise_in_handler:
+            raise ValueError("handler boom")
+    return tc
+
+
+def test_observer_receives_finalized_trace():
+    seen = []
+    tc = _run(_capture(observer=seen.append))
+    assert len(seen) == 1
+    assert seen[0] is tc.trace
+    from graqle.governance.trace_schema import Outcome
+
+    assert tc.trace.outcome == Outcome.SUCCESS  # finalized before observer ran
+
+
+def test_observer_runs_after_persist():
+    """The observer must see the trace only after it is appended to the store."""
+    store = _MemStore()
+    order = []
+
+    def observer(trace):
+        order.append("observed")
+        assert store.appended == [trace]  # persist already happened
+
+    _run(_capture(observer=observer, store=store))
+    assert order == ["observed"]
+    assert len(store.appended) == 1
+
+
+def test_observer_exception_does_not_break_trace_path():
+    store = _MemStore()
+
+    def boom(_trace):
+        raise RuntimeError("observer boom")
+
+    # Must complete normally despite the observer raising.
+    tc = _run(_capture(observer=boom, store=store))
+    assert len(store.appended) == 1  # trace still persisted
+    assert tc.trace is not None
+
+
+def test_observer_exception_does_not_suppress_handler_exception():
+    def boom(_trace):
+        raise RuntimeError("observer boom")
+
+    # The handler's ValueError must still propagate (observer runs in __aexit__,
+    # which returns False and never suppresses).
+    with pytest.raises(ValueError, match="handler boom"):
+        _run(_capture(observer=boom, raise_in_handler=True))
+
+
+def test_no_observer_is_a_noop():
+    """Default (observer=None) preserves prior behaviour: trace persisted, no error."""
+    store = _MemStore()
+    tc = _run(_capture(observer=None, store=store))
+    assert len(store.appended) == 1
+    assert tc.trace is not None
+
+
+def test_observer_still_called_when_no_store():
+    """Observer fires even without a store (it observes the in-memory trace)."""
+    seen = []
+    _run(_capture(observer=seen.append, store=None))
+    assert len(seen) == 1


### PR DESCRIPTION
## v0.59.0 Layer 5 — PR-5: committer orchestrator + audit-log v3

> R25-EU01 Task 1.5. Part of the Layer 5 cryptographic-tamper-evidence sequence (PR-0..PR-7). **No version bump** — stays 0.58.1; the single bump to 0.59.0 lands in PR-7. This is the highest-blast-radius PR in the sequence (it integrates the trace-capture hub); the diff is deliberately kept contained — see "Blast radius" below.

### What this adds

**`committer.py` — `Committer`**, the orchestrator tying the Layer-5 pieces into one non-blocking commit lifecycle:

    submit(record)                  # non-blocking: track CommitRecord(PENDING) + WAL enqueue (PR-3)
    on batcher flush (size/time):
        build Merkle root (PR-2/3) -> RekorAnchor.anchor (PR-4)
            success      -> ANCHORED
            AnchorError  -> LocalReplayQueue.enqueue (PR-4) -> REPLAY_QUEUED  (or FAILED if no queue)
        kg_persist(BatchCommit)     # batched; Neo4j :CommittedBatch MERGE wired in PR-6 behind this seam

**`audit_log_v3.py` — `CommitRecord` + `CommitStatus`.** Audit-log v3 composes *alongside* the v2 `GovernedTrace` (which is `extra="forbid"`) rather than mutating it: a `CommitRecord` is a sidecar joined by `trace_id`, carrying only the commit lifecycle. `CommitStatus` (PENDING/COMMITTED/ANCHORED/REPLAY_QUEUED/FAILED) makes every record's fate **total and explicit** — there is no "unknown"/"lost" state (no-silent-drop).

**`trace_capture.py` — one additive observer hook.** A single optional `observer` param on `TraceCapture`, invoked best-effort *after* the trace is persisted. Default `None` = byte-identical v0.58.x behaviour. The committer's `as_trace_observer()` is that callback.

### Blast radius — contained by design

trace_capture.py is a 47-dependency governance/SOC2 hub. Per the PR-5 INVESTIGATE decision (composition over inheritance), the committer does **not** restructure it: the change is **one optional param + one best-effort call site** (`+22/-1`). The committer composes alongside via the callback, mirroring PR-3's committer-callback and PR-4's injectable-anchor patterns. **All 49 existing trace_capture tests pass unchanged**; the sentinel rated this change "a textbook example of safe, backward-compatible feature addition" (95%).

### Tests — 39, fully offline

`test_committer.py` (real WalBatcher for wiring + fake anchor/replay-queue/kg_persist) + `test_audit_log_v3.py` + `test_trace_capture_observer.py`. Covers the full lifecycle, both anchor-failure branches, batched rollback (both anchored + unanchored), idempotency, crash-recovery tracking, the observer hook (and its never-raise guarantee), and the no-double-anchor invariant.

**Coverage (realistic 100%):** `committer.py` **100%**, `audit_log_v3.py` **100%** (statement + branch). The trace_capture hook lines are covered. 302 tamper_evidence + trace_capture tests pass overall, zero regressions. TS-2 scan clean; patent-notice header in trace_capture.py preserved verbatim.

### Sentinel review chain (ADR-209 Phase 7)

| Pass | Focus | Verdict | Real findings |
|------|-------|---------|---------------|
| 1 | all (committer) | BLOCKED (92%) | partial-rollback bug |
| predict | failure-chains | 0.3 (no writeback) | **double-anchor bug** + 4 chains adjudicated |
| 2 | all (trace_capture hook) | **APPROVED (95%)** | 0 (textbook additive change) |
| 3 | security (committer) | CHANGES_REQUESTED (88%) | CSPRNG batch_id |

**Real bugs caught and fixed:**
1. **Double-anchor (predict pass).** A KG-persist failure *after* a successful Rekor anchor previously rolled records back to PENDING, so the retry re-anchored the same root under a NEW batch_id — orphaning the permanent first anchor. **Fix:** `_handle_persist_failure` distinguishes anchored from unanchored. Unanchored → full rollback + re-raise (clean retry). Anchored → records stay ANCHORED (the Rekor commitment is durable and immutable), the failed KG mirror is recorded in `kg_persist_pending` for out-of-band reconciliation, and the flush does NOT re-raise — so the anchor happens exactly once. No-silent-drop is preserved (the record is ANCHORED, never lost).
2. **Partial rollback (review pass 1).** The rollback restored only `commit_status`, leaving stale `batch_id`/root/anchor fields on a rolled-back record. **Fix:** `CommitRecord.snapshot()` / `restore()` capture and restore the full mutable state.
3. **CSPRNG batch_id (security pass).** `secrets.token_hex(16)` makes the cryptographically-secure source explicit for this tamper-evidence context.

Adjudicated-and-sound (no change needed): record-content validation happens downstream in PR-1's canonicalize allowlist; the `_records` ledger is fully `RLock`-serialized (reentrant, so an inline flush during `submit` is safe); content-addressed dedup means a submit + a WAL-recovery of the same record collapse to one CommitRecord.

### Design decisions flagged for Research / sole-approver review

1. **KG persist is a downstream mirror of the authoritative Rekor anchor.** When persist fails *after* anchoring, the anchor (not the KG row) is the source of truth, so we defer the KG mirror rather than re-anchor. The Neo4j `:CommittedBatch` MERGE itself lands in PR-6 behind the `kg_persist` seam; PR-5 stages the data + status and exposes `kg_persist_pending`.
2. **At-least-once anchoring** inherited from PR-4 (a lost Rekor response → re-anchor → benign duplicate). The PR-5 fix specifically prevents the *batch-id-orphaning* form of double-anchor.

### Files
- `graqle/governance/trace_capture.py` (MOD — additive observer hook only)
- `graqle/governance/tamper_evidence/committer.py` (NEW)
- `graqle/governance/tamper_evidence/audit_log_v3.py` (NEW)
- `tests/test_tamper_evidence/test_committer.py` (NEW)
- `tests/test_tamper_evidence/test_audit_log_v3.py` (NEW)
- `tests/test_tamper_evidence/test_trace_capture_observer.py` (NEW)

### Notes
- Constitutional fallback **V-V059-PR5-WRITE-NATIVE-001**: native Write/Edit used for worktree file creation (graq_generate/graq_write fail on worktree paths — S-010). Sentinel review performed via `graq_review(diff=...)`.
- `research-review-requested` label not created on the repo (one-time setup) — design decisions flagged inline above instead.
