### PR TITLE
PR-7: v0.59.0 release — Layer 5 custody/ed25519 (C-P2-1) + GATE2-COND-2 + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## 0.59.0 (2026-05-24) — [Layer 5: cryptographic tamper-evidence (RFC 6962 Merkle + RFC 8785 JCS + Sigstore Rekor + ed25519) + runtime layer-switch with monotonic-on]
+
+> **GraQle v0.59.0 ships Layer 5 — cryptographic tamper-evidence — the step up from v0.58.0's *procedural* binding (tampering is detectable by inspection) to *cryptographic* binding (tampering is mathematically detectable by any third party with no GraQle infrastructure access). Governed-trace records are batched into RFC 6962 Merkle trees, canonicalised with RFC 8785 JCS, sealed under an ed25519-signed proof bundle, and the batch root is anchored to the public Sigstore Rekor transparency log. Implements R25-EU01 Phase M1 (Tasks 1.1–1.7) per ADR-RT-003. The whole layer is opt-in: with `attestation.enabled = false` (the default) v0.59.0 produces output byte-identical to v0.58.1 — the cryptographic machinery is real and inert-until-activated, not a no-op release. Layer 5 is the deepest of the five governance layers; a new runtime layer-switch architecture lets a deployment adopt L1–L5 on its own timeline, with a production "monotonic-on" rule (once a layer records its first governed write, it cannot be silently disabled — EU AI Act Article 12: once you start recording, you do not stop recording).**
+
+### Added
+
+- **`graqle.governance.tamper_evidence` — the Layer 5 module** (R25-EU01 Phase M1):
+  - **`canonicalize.py`** — RFC 8785 JCS canonicalisation (Task 1.1). Separate `canon` (wrapper/signature scope) and `canon_leaf` (frozen leaf-input scope) functions; rejects non-finite floats (NaN/±Inf/−0.0) and non-JSON-native types so the leaf hash is deterministic across Python/JS/Go reference verifiers.
+  - **`merkle.py`** — custom RFC 6962 Merkle tree (Task 1.2): leaf/node domain separation, duplicate-last-node padding, `InclusionProof` scaffolding, bounded tree size.
+  - **`leaf_input_schema.py`** — the frozen leaf-hash-input allowlist (`LEAF_HASH_FIELDS`), separating it from the wrapper schema so wrapper fields can be added additively without changing any leaf hash (`proof_format_version` is *inside* the leaf to defeat version-relabel replay).
+  - **`batcher.py`** — async batcher with a write-ahead log (Task 1.3): `tempfile → fsync → os.replace` durable enqueue, SHA-256 content-addressed idempotency, crash-recovery replay.
+  - **`anchors/sigstore_rekor.py`** + **`local_replay_queue.py`** — Sigstore Rekor anchor (Task 1.4) with an independent circuit-breaker and a durable local replay queue fallback (CONDITION-3); `fail_open_on_anchor_error` defaults to `false` (an unreachable Rekor never silently skips anchoring).
+  - **`committer.py`** + audit-log v3 (Task 1.5) — orchestrates batch → Merkle → anchor → persist with a no-silent-drop `CommitStatus`.
+  - **`kg_persist.py`** + **`:CommittedBatch` Neo4j schema** (Task 1.6) — single-label, `batch_quarter`-partitioned schema; `Neo4jBatchPersister` mirrors each anchored batch into the KG write-once via `MERGE ... ON CREATE SET`.
+
+- **`graqle.governance.layer_status` — runtime layer-switch + monotonic-on** (ADR-RT-003 §2.2, LS-1..LS-7):
+  - Per-layer enabled/monotonic-on registry; production-mode first write flips a layer to `MONOTONIC_ON` and any later disable raises `LayerMonotonicityViolation` (the refused attempt is itself audited). Development mode toggles freely.
+  - `dependency_graph.py` validates L5 requires L1+L2+L3; queryable transition `history()`.
+  - **LS-7 monotonic-on CAS atomicity** — the in-process flip is lock-guarded, and `Neo4jConnector.persist_monotonic_on()` adds a cross-process **COALESCE write-once** compare-and-set so two concurrent writers can never double-flip (proven by a 50-threads × 200-iterations × 10-runs zero-duplicate test).
+
+- **`graqle.governance.custody.ed25519_key_manifest` — signing-key validity window** (Task 1.7 / C-P2-1). Per-`kid` `valid_from`/`valid_until` window and a monotonic `ACTIVE → RETIRED → REVOKED` lifecycle: ACTIVE signs + verifies, RETIRED is verify-only (historical proofs stay valid), REVOKED is rejected unconditionally. Lets a verifier decide whether a `kid` was trusted to sign at the moment a proof was produced. Uses the `cryptography` ed25519 primitives (a core dependency).
+
+- **`graqle.config.attestation_config` — Layer 5 config surface.** New `attestation:` block (all `extra="forbid"`); secrets (webhook URL, operator token, ed25519 signing-key path) are env-var-only. Omitting the block is byte-identical to v0.58.1.
+
+### Changed
+
+- **`graqle/governance/trace_capture.py`** gains one additive, opt-in observer hook for Merkle leaf emission; default behaviour unchanged.
+- **Version** bumped `0.58.1 → 0.59.0` (single bump for the whole Layer 5 PR sequence PR-0…PR-7).
+
+### Performance
+
+- **Write-path latency unchanged** (AC-5). The cr-018 measurement-only spike measured the Merkle commitment over 1,000 R18 traces at **~200× headroom under the AC-5 target** (≤227ms P95, 10% over the R18 baseline) — the user-observable write path is async (the batcher adds 0ms to the write path; per-record commit is bounded by `T_batch + Rekor_P95`). AC-1 commit latency target ≤60s.
+
+### Notes
+
+- **Opt-in and backward-compatible.** With `attestation.enabled = false` (default) and no `attestation:` config block, v0.59.0 output is byte-identical to v0.58.1.
+- **Cryptographic guarantee.** With Layer 5 enabled, tampering with any committed governed-trace record is detectable by any third party who can read the public Sigstore Rekor log — no GraQle infrastructure access required.
+
+---
+
 ## 0.58.1 (2026-05-21) — [docs: refresh PyPI landing page to v0.58.0]
 
 > **Documentation-only patch.** No code changes — functionally identical to v0.58.0.

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.58.1"
+__version__ = "0.59.0"

--- a/graqle/governance/custody/__init__.py
+++ b/graqle/governance/custody/__init__.py
@@ -1,0 +1,33 @@
+"""Key-custody module — ed25519 signing-key lifecycle (R25-EU01 Task 1.7 / C-P2-1).
+
+Layer 5 proof bundles are signed with an ed25519 key identified by a ``kid``
+(``graqle-sdk-signing-2026-Q2`` and the like, per R25-EU01 §"signature"). Keys
+rotate over time, so a verifier presented with an old proof must be able to ask:
+*was this kid trusted to produce a signature at the moment the proof was made?*
+
+:mod:`ed25519_key_manifest` answers that with a per-``kid`` validity window
+(``valid_from`` / ``valid_until``) and a three-state lifecycle
+(``ACTIVE → RETIRED → REVOKED``). See that module for the full contract.
+
+Public API::
+
+    from graqle.governance.custody import (
+        KeyState, KeyEntry, Ed25519KeyManifest, KeyManifestError,
+    )
+"""
+
+from __future__ import annotations
+
+from graqle.governance.custody.ed25519_key_manifest import (
+    Ed25519KeyManifest,
+    KeyEntry,
+    KeyManifestError,
+    KeyState,
+)
+
+__all__ = [
+    "KeyState",
+    "KeyEntry",
+    "Ed25519KeyManifest",
+    "KeyManifestError",
+]

--- a/graqle/governance/custody/ed25519_key_manifest.py
+++ b/graqle/governance/custody/ed25519_key_manifest.py
@@ -1,0 +1,382 @@
+"""ed25519 signing-key manifest with a validity window (R25-EU01 Task 1.7 / C-P2-1).
+
+Layer 5 proof bundles carry ``signature = {alg: ed25519, kid, sig}`` (R25-EU01
+§"signature"). A ``kid`` (key id, e.g. ``graqle-sdk-signing-2026-Q2``) is rotated
+on a schedule, so the manifest must let a verifier decide whether a given ``kid``
+was *trusted to sign* at the time a proof was produced — long after the active
+key has moved on.
+
+C-P2-1 (ADR-RT-002 §4.4 / ADR-RT-003 §11.2 PR-7) models that with two things per
+key:
+
+* a **validity window** ``valid_from`` / ``valid_until`` (UTC), and
+* a three-state **lifecycle**::
+
+      ACTIVE  ── retire() ──▶  RETIRED  ── revoke() ──▶  REVOKED
+        │                                                  ▲
+        └────────────────── revoke() ──────────────────────┘
+
+  | state    | can sign | verify-trusted (within window) |
+  |----------|----------|--------------------------------|
+  | ACTIVE   | yes      | yes                            |
+  | RETIRED  | no       | yes  (historical proofs only)  |
+  | REVOKED  | no       | NO   (key compromised)         |
+
+The lifecycle is **monotonic** (like the layer-status monotonic-on rule): a key
+can only move forward ACTIVE → RETIRED → REVOKED (or jump ACTIVE → REVOKED on an
+emergency compromise). It can never move back — a ``REVOKED`` key is dead, and
+re-activating a retired key would silently re-open a closed signing window. This
+mirrors ``layer_status.monotonic_on``: once you tighten custody you do not loosen
+it without re-instantiating the key.
+
+**Verify semantics (the security-critical part).** ``verify`` accepts a proof's
+signature iff ALL of:
+
+1. the ``kid`` is known to the manifest,
+2. the key is ACTIVE or RETIRED (REVOKED is rejected unconditionally — a revoked
+   key's *past* signatures are no longer trusted, the conservative default; the
+   spec line for C-P2-1 is "kid rotation → valid_from/valid_until in key
+   manifest", and revocation is the compromise escape hatch),
+3. the verification instant ``at`` falls within ``[valid_from, valid_until]``,
+   and
+4. the ed25519 signature is cryptographically valid for the message.
+
+``sign`` additionally requires the key be ACTIVE and hold a private key.
+
+The actual ed25519 primitives come from ``cryptography`` (a core dependency), so
+this module needs no optional extras and runs in CI unconditionally.
+
+Private-key handling (known limitation). Private keys are held in a process-local
+dict, separate from the public, shareable :class:`KeyEntry`, and are dropped on
+:meth:`Ed25519KeyManifest.retire` / :meth:`Ed25519KeyManifest.revoke` (a key that
+may not sign keeps no signing material). This module deliberately does NOT attempt
+in-memory zeroization of key bytes: CPython provides no guaranteed memory wipe and
+``cryptography``'s ``Ed25519PrivateKey`` does not expose its raw bytes for
+overwriting, so any "zeroization" here would be security theater. Deployments that
+need hardware-backed key custody should supply a private key from an HSM/KMS via a
+signing callback — out of scope for the C-P2-1 validity-window manifest, which
+governs *which kid is trusted when*, not at-rest key protection.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+from graqle.governance.tamper_evidence.errors import TamperEvidenceError
+
+__all__ = [
+    "KeyState",
+    "KeyEntry",
+    "Ed25519KeyManifest",
+    "KeyManifestError",
+]
+
+
+class KeyManifestError(TamperEvidenceError):
+    """Base class for key-manifest errors (unknown kid, illegal transition, …)."""
+
+
+class UnknownKidError(KeyManifestError, KeyError):
+    """The requested ``kid`` is not registered in the manifest.
+
+    Subclasses ``KeyError`` so ``except KeyError`` callers catch it naturally.
+    """
+
+    def __init__(self, kid: str) -> None:
+        self.kid = kid
+        super().__init__(f"unknown key id {kid!r}: not registered in the manifest")
+
+
+class IllegalKeyTransitionError(KeyManifestError):
+    """An attempt to move a key backwards in the lifecycle (e.g. un-revoke)."""
+
+    def __init__(self, kid: str, current: KeyState, requested: KeyState) -> None:
+        self.kid = kid
+        self.current = current
+        self.requested = requested
+        super().__init__(
+            f"illegal key transition for {kid!r}: {current.value} → "
+            f"{requested.value}. The key lifecycle is monotonic "
+            f"(ACTIVE → RETIRED → REVOKED); a key never moves backwards."
+        )
+
+
+class KeyNotSignableError(KeyManifestError):
+    """A signing request targeted a key that may not (or cannot) sign."""
+
+
+class KeyState(enum.Enum):
+    """Lifecycle state of a signing key (monotonic ACTIVE → RETIRED → REVOKED)."""
+
+    ACTIVE = "active"
+    RETIRED = "retired"
+    REVOKED = "revoked"
+
+
+# Rank used to enforce monotonic forward-only transitions.
+_STATE_RANK = {KeyState.ACTIVE: 0, KeyState.RETIRED: 1, KeyState.REVOKED: 2}
+
+
+def _as_utc(dt: datetime) -> datetime:
+    """Normalise a datetime to timezone-aware UTC.
+
+    A naive datetime is assumed to be UTC (the manifest's canonical zone); an
+    aware datetime is converted. This keeps all window comparisons total-ordered
+    and avoids the "can't compare naive and aware" trap that silently breaks
+    validity checks.
+    """
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+@dataclass(frozen=True)
+class KeyEntry:
+    """One signing key's identity, public material, window, and lifecycle state.
+
+    Frozen: a key's immutable facts (its id, public key, and validity window) do
+    not change. The *state* changes only through the manifest's monotonic
+    :meth:`Ed25519KeyManifest.retire` / :meth:`Ed25519KeyManifest.revoke`, which
+    replace the entry with a new frozen copy rather than mutating it — so a stale
+    reference can never silently observe a state downgrade.
+
+    Attributes
+    ----------
+    kid:
+        Key id (the ``kid`` field of a proof signature).
+    public_key:
+        The ed25519 public key, used for verification.
+    valid_from, valid_until:
+        UTC validity window. A proof signed/verified outside this window is not
+        trusted even if the signature is cryptographically valid.
+    state:
+        Current :class:`KeyState`.
+    """
+
+    kid: str
+    public_key: Ed25519PublicKey
+    valid_from: datetime
+    valid_until: datetime
+    state: KeyState = KeyState.ACTIVE
+
+    def is_within_window(self, at: datetime) -> bool:
+        """True iff ``at`` is within ``[valid_from, valid_until]`` (UTC, inclusive)."""
+        at_utc = _as_utc(at)
+        return _as_utc(self.valid_from) <= at_utc <= _as_utc(self.valid_until)
+
+    def can_sign(self, at: datetime) -> bool:
+        """True iff this key may produce a NEW signature at ``at`` (ACTIVE + in-window)."""
+        return self.state is KeyState.ACTIVE and self.is_within_window(at)
+
+    def is_verify_trusted(self, at: datetime) -> bool:
+        """True iff a signature from this key is TRUSTED at ``at``.
+
+        ACTIVE and RETIRED keys are verify-trusted within their window; a REVOKED
+        key is never trusted (its past signatures are repudiated on compromise).
+        """
+        if self.state is KeyState.REVOKED:
+            return False
+        return self.is_within_window(at)
+
+
+class Ed25519KeyManifest:
+    """Registry of ed25519 signing keys with windowed, lifecycle-gated trust.
+
+    Construct empty, then :meth:`register` keys. Use :meth:`sign` to produce a
+    signature with the (single) ACTIVE key for a kid, and :meth:`verify` to check
+    a proof's signature under the trust rules documented at module level.
+
+    The manifest is the single authority on which kid is trusted when; it holds
+    no global mutable trust beyond the per-key entries, so it is safe to share.
+    """
+
+    def __init__(self) -> None:
+        self._keys: dict[str, KeyEntry] = {}
+        # Private keys live here, separate from the public, shareable KeyEntry,
+        # and are dropped on retire()/revoke(). A verify-only manifest simply
+        # leaves this empty (see the module-level note on key handling).
+        self._private_keys: dict[str, Ed25519PrivateKey] = {}
+
+    # ---- registration -------------------------------------------------------
+
+    def register(
+        self,
+        kid: str,
+        public_key: Ed25519PublicKey,
+        valid_from: datetime,
+        valid_until: datetime,
+        state: KeyState = KeyState.ACTIVE,
+        private_key: Ed25519PrivateKey | None = None,
+    ) -> KeyEntry:
+        """Register a key under ``kid``.
+
+        ``private_key`` is held separately (never stored on the frozen
+        :class:`KeyEntry`, which is the public, shareable record) and is required
+        only to :meth:`sign`. Registering an ACTIVE key without a private key
+        yields a verify-only key (the common case for a verifier that holds only
+        public material).
+
+        Raises
+        ------
+        ValueError
+            If ``kid`` is empty, the window is inverted (``valid_until`` before
+            ``valid_from``), or ``kid`` is already registered (re-registration
+            could silently widen a window or swap a public key).
+        """
+        if not isinstance(kid, str) or not kid:
+            raise ValueError("kid must be a non-empty string")
+        if _as_utc(valid_until) < _as_utc(valid_from):
+            raise ValueError(
+                f"invalid validity window for {kid!r}: valid_until precedes valid_from"
+            )
+        if kid in self._keys:
+            raise ValueError(
+                f"kid {kid!r} is already registered; re-registration is refused "
+                f"to prevent silently swapping a key's public material or window"
+            )
+        entry = KeyEntry(
+            kid=kid,
+            public_key=public_key,
+            valid_from=valid_from,
+            valid_until=valid_until,
+            state=state,
+        )
+        self._keys[kid] = entry
+        if private_key is not None:
+            self._private_keys[kid] = private_key
+        return entry
+
+    def get(self, kid: str) -> KeyEntry:
+        """Return the :class:`KeyEntry` for ``kid`` or raise :class:`UnknownKidError`."""
+        try:
+            return self._keys[kid]
+        except KeyError:
+            raise UnknownKidError(kid) from None
+
+    def kids(self) -> tuple[str, ...]:
+        """Return all registered kids (registration order)."""
+        return tuple(self._keys)
+
+    # ---- lifecycle transitions (monotonic) ----------------------------------
+
+    def _transition(self, kid: str, new_state: KeyState) -> KeyEntry:
+        entry = self.get(kid)
+        if _STATE_RANK[new_state] <= _STATE_RANK[entry.state]:
+            raise IllegalKeyTransitionError(kid, entry.state, new_state)
+        # Replace with a new frozen copy (dataclasses.replace would also work;
+        # explicit construction keeps the field set auditable).
+        updated = KeyEntry(
+            kid=entry.kid,
+            public_key=entry.public_key,
+            valid_from=entry.valid_from,
+            valid_until=entry.valid_until,
+            state=new_state,
+        )
+        self._keys[kid] = updated
+        return updated
+
+    def retire(self, kid: str) -> KeyEntry:
+        """Move a key ACTIVE → RETIRED (verify-only). Drops its private material.
+
+        After retirement the key can no longer sign, so its private key (if held)
+        is discarded — there is no reason to keep signing material for a key that
+        may not sign, and discarding it shrinks the compromise surface.
+        """
+        updated = self._transition(kid, KeyState.RETIRED)
+        self._private_keys.pop(kid, None)
+        return updated
+
+    def revoke(self, kid: str) -> KeyEntry:
+        """Move a key to REVOKED from ACTIVE or RETIRED. Drops its private material.
+
+        REVOKED is terminal: the key can neither sign nor be verify-trusted, and
+        cannot be un-revoked. Use on compromise.
+        """
+        updated = self._transition(kid, KeyState.REVOKED)
+        self._private_keys.pop(kid, None)
+        return updated
+
+    # ---- sign / verify ------------------------------------------------------
+
+    def sign(self, kid: str, message: bytes, at: datetime | None = None) -> bytes:
+        """Sign ``message`` with ``kid``'s private key (ACTIVE + in-window only).
+
+        Parameters
+        ----------
+        kid:
+            Key id to sign with. Must be ACTIVE, in-window at ``at``, and have a
+            registered private key.
+        message:
+            The bytes to sign (typically the canonical proof bundle minus its
+            signature field).
+        at:
+            Signing instant; defaults to ``datetime.now(timezone.utc)``.
+
+        Raises
+        ------
+        UnknownKidError
+            If ``kid`` is not registered.
+        KeyNotSignableError
+            If the key is not ACTIVE, is outside its window, or has no private key.
+        """
+        when = _as_utc(at) if at is not None else datetime.now(timezone.utc)
+        entry = self.get(kid)
+        if not entry.can_sign(when):
+            raise KeyNotSignableError(
+                f"key {kid!r} cannot sign at {when.isoformat()}: state="
+                f"{entry.state.value}, in_window={entry.is_within_window(when)} "
+                f"(only an ACTIVE, in-window key may sign)"
+            )
+        private_key = self._private_keys.get(kid)
+        if private_key is None:
+            raise KeyNotSignableError(
+                f"key {kid!r} is ACTIVE and in-window but no private key is held; "
+                f"this manifest can verify but not sign with it"
+            )
+        return private_key.sign(message)
+
+    def verify(
+        self, kid: str, message: bytes, signature: bytes, at: datetime | None = None
+    ) -> bool:
+        """Return whether ``signature`` is trusted for ``message`` under ``kid`` at ``at``.
+
+        Returns ``True`` only if the kid is verify-trusted at ``at`` (ACTIVE or
+        RETIRED, within window — REVOKED always fails) AND the ed25519 signature
+        is cryptographically valid. Returns ``False`` (never raises) for an
+        untrusted kid or a bad signature, so a verifier can treat any falsey
+        result as "not tamper-proven" uniformly.
+
+        ``at`` is the instant whose trust is being asked about. To verify a
+        HISTORICAL proof, pass the proof's recording/creation time — the question
+        is "was this kid trusted to sign *when the proof was made*", not "is it
+        trusted now". Defaulting ``at`` to ``now()`` answers the present-tense
+        question and will reject a proof whose key window has since closed; that
+        is correct for "is this key trusted right now" but NOT for replaying a
+        valid old proof, so callers verifying archived proofs MUST pass the
+        recorded time explicitly. REVOKED is the one state that fails regardless
+        of ``at`` — a compromised key's past signatures are repudiated.
+
+        Raises
+        ------
+        UnknownKidError
+            If ``kid`` is not registered — an unknown signer is a caller error,
+            distinct from a known-but-untrusted or cryptographically-invalid
+            signature (both of which return ``False``).
+        """
+        when = _as_utc(at) if at is not None else datetime.now(timezone.utc)
+        entry = self.get(kid)
+        if not entry.is_verify_trusted(when):
+            return False
+        try:
+            entry.public_key.verify(signature, message)
+        except InvalidSignature:
+            return False
+        return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.58.1"
+version = "0.59.0"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Proprietary — see LICENSE"}

--- a/tests/test_governance/test_ed25519_key_manifest.py
+++ b/tests/test_governance/test_ed25519_key_manifest.py
@@ -1,0 +1,284 @@
+"""Tests for the ed25519 key-custody manifest (R25-EU01 Task 1.7 / C-P2-1).
+
+Covers the validity window, the monotonic ACTIVE→RETIRED→REVOKED lifecycle, and
+the sign/verify trust rules. Uses real ed25519 keys from ``cryptography`` (a core
+dependency) — no mocks of the crypto primitives, so the proofs are genuine.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from graqle.governance.custody import (
+    Ed25519KeyManifest,
+    KeyEntry,
+    KeyManifestError,
+    KeyState,
+)
+from graqle.governance.custody.ed25519_key_manifest import (
+    IllegalKeyTransitionError,
+    KeyNotSignableError,
+    UnknownKidError,
+)
+
+UTC = timezone.utc
+T0 = datetime(2026, 4, 1, tzinfo=UTC)  # window start
+T_MID = datetime(2026, 5, 15, tzinfo=UTC)  # within window
+T_END = datetime(2026, 7, 1, tzinfo=UTC)  # window end
+T_AFTER = datetime(2026, 8, 1, tzinfo=UTC)  # after window
+T_BEFORE = datetime(2026, 3, 1, tzinfo=UTC)  # before window
+
+
+def _keypair():
+    priv = Ed25519PrivateKey.generate()
+    return priv, priv.public_key()
+
+
+def _manifest_with_active(kid="graqle-sdk-signing-2026-Q2", with_private=True):
+    priv, pub = _keypair()
+    m = Ed25519KeyManifest()
+    m.register(
+        kid,
+        pub,
+        valid_from=T0,
+        valid_until=T_END,
+        private_key=priv if with_private else None,
+    )
+    return m, kid, priv, pub
+
+
+# ---- registration ----------------------------------------------------------
+
+
+class TestRegistration:
+    def test_register_returns_active_entry(self):
+        m, kid, _, pub = _manifest_with_active()
+        entry = m.get(kid)
+        assert isinstance(entry, KeyEntry)
+        assert entry.kid == kid
+        assert entry.state is KeyState.ACTIVE
+        assert entry.public_key is pub
+
+    def test_kids_lists_registered(self):
+        m, kid, _, _ = _manifest_with_active()
+        assert m.kids() == (kid,)
+
+    @pytest.mark.parametrize("bad", ["", None, 123])
+    def test_empty_or_nonstring_kid_raises(self, bad):
+        m = Ed25519KeyManifest()
+        _, pub = _keypair()
+        with pytest.raises(ValueError):
+            m.register(bad, pub, valid_from=T0, valid_until=T_END)
+
+    def test_inverted_window_raises(self):
+        m = Ed25519KeyManifest()
+        _, pub = _keypair()
+        with pytest.raises(ValueError, match="valid_until precedes valid_from"):
+            m.register("k", pub, valid_from=T_END, valid_until=T0)
+
+    def test_duplicate_kid_refused(self):
+        m, kid, _, _ = _manifest_with_active()
+        _, pub2 = _keypair()
+        with pytest.raises(ValueError, match="already registered"):
+            m.register(kid, pub2, valid_from=T0, valid_until=T_END)
+
+    def test_get_unknown_kid_raises(self):
+        m = Ed25519KeyManifest()
+        with pytest.raises(UnknownKidError):
+            m.get("nope")
+        # also a KeyError subclass
+        with pytest.raises(KeyError):
+            m.get("nope")
+
+    def test_verify_only_registration_without_private_key(self):
+        m, kid, _, _ = _manifest_with_active(with_private=False)
+        # can verify-trust but cannot sign
+        assert m.get(kid).is_verify_trusted(T_MID) is True
+        with pytest.raises(KeyNotSignableError, match="no private key is held"):
+            m.sign(kid, b"msg", at=T_MID)
+
+
+# ---- validity window -------------------------------------------------------
+
+
+class TestValidityWindow:
+    def test_within_window_inclusive_bounds(self):
+        entry = _manifest_with_active()[0].get("graqle-sdk-signing-2026-Q2")
+        assert entry.is_within_window(T0) is True  # inclusive start
+        assert entry.is_within_window(T_END) is True  # inclusive end
+        assert entry.is_within_window(T_MID) is True
+
+    def test_outside_window(self):
+        entry = _manifest_with_active()[0].get("graqle-sdk-signing-2026-Q2")
+        assert entry.is_within_window(T_BEFORE) is False
+        assert entry.is_within_window(T_AFTER) is False
+
+    def test_naive_datetime_treated_as_utc(self):
+        entry = _manifest_with_active()[0].get("graqle-sdk-signing-2026-Q2")
+        naive_mid = datetime(2026, 5, 15)  # no tzinfo
+        assert entry.is_within_window(naive_mid) is True
+
+    def test_aware_non_utc_datetime_converted(self):
+        entry = _manifest_with_active()[0].get("graqle-sdk-signing-2026-Q2")
+        # 2026-04-01T01:00+02:00 == 2026-03-31T23:00Z -> just BEFORE the window
+        before_in_other_tz = datetime(2026, 4, 1, 1, 0, tzinfo=timezone(timedelta(hours=2)))
+        assert entry.is_within_window(before_in_other_tz) is False
+
+
+# ---- lifecycle -------------------------------------------------------------
+
+
+class TestLifecycle:
+    def test_active_can_sign_and_verify(self):
+        e = _manifest_with_active()[0].get("graqle-sdk-signing-2026-Q2")
+        assert e.can_sign(T_MID) is True
+        assert e.is_verify_trusted(T_MID) is True
+
+    def test_retire_is_verify_only(self):
+        m, kid, _, _ = _manifest_with_active()
+        m.retire(kid)
+        e = m.get(kid)
+        assert e.state is KeyState.RETIRED
+        assert e.can_sign(T_MID) is False
+        assert e.is_verify_trusted(T_MID) is True
+
+    def test_revoke_rejects_everything(self):
+        m, kid, _, _ = _manifest_with_active()
+        m.revoke(kid)
+        e = m.get(kid)
+        assert e.state is KeyState.REVOKED
+        assert e.can_sign(T_MID) is False
+        assert e.is_verify_trusted(T_MID) is False
+
+    def test_active_to_retired_to_revoked_chain(self):
+        m, kid, _, _ = _manifest_with_active()
+        assert m.retire(kid).state is KeyState.RETIRED
+        assert m.revoke(kid).state is KeyState.REVOKED
+
+    def test_active_can_jump_straight_to_revoked(self):
+        m, kid, _, _ = _manifest_with_active()
+        assert m.revoke(kid).state is KeyState.REVOKED
+
+    def test_cannot_un_retire(self):
+        m, kid, _, _ = _manifest_with_active()
+        m.retire(kid)
+        # retiring again (same rank) is illegal, and there is no "activate"
+        with pytest.raises(IllegalKeyTransitionError):
+            m.retire(kid)
+
+    def test_cannot_un_revoke(self):
+        m, kid, _, _ = _manifest_with_active()
+        m.revoke(kid)
+        with pytest.raises(IllegalKeyTransitionError, match="monotonic"):
+            m.retire(kid)
+        with pytest.raises(IllegalKeyTransitionError):
+            m.revoke(kid)
+
+    def test_transition_on_unknown_kid_raises(self):
+        m = Ed25519KeyManifest()
+        with pytest.raises(UnknownKidError):
+            m.retire("nope")
+
+    def test_retire_drops_private_key(self):
+        m, kid, _, _ = _manifest_with_active()
+        m.retire(kid)
+        # even though the window is open, signing is impossible after retire
+        with pytest.raises(KeyNotSignableError):
+            m.sign(kid, b"msg", at=T_MID)
+
+    def test_illegal_transition_error_is_keymanifesterror(self):
+        m, kid, _, _ = _manifest_with_active()
+        m.revoke(kid)
+        with pytest.raises(KeyManifestError):
+            m.revoke(kid)
+
+
+# ---- sign / verify (real ed25519) ------------------------------------------
+
+
+class TestSignVerify:
+    def test_sign_then_verify_roundtrip(self):
+        m, kid, _, _ = _manifest_with_active()
+        msg = b"canonical proof bundle bytes"
+        sig = m.sign(kid, msg, at=T_MID)
+        assert m.verify(kid, msg, sig, at=T_MID) is True
+
+    def test_verify_rejects_tampered_message(self):
+        m, kid, _, _ = _manifest_with_active()
+        sig = m.sign(kid, b"original", at=T_MID)
+        assert m.verify(kid, b"tampered", sig, at=T_MID) is False
+
+    def test_verify_rejects_garbage_signature(self):
+        m, kid, _, _ = _manifest_with_active()
+        assert m.verify(kid, b"msg", b"not-a-signature", at=T_MID) is False
+
+    def test_retired_key_still_verifies_historical_proof(self):
+        m, kid, _, _ = _manifest_with_active()
+        sig = m.sign(kid, b"msg", at=T_MID)
+        m.retire(kid)
+        # the proof was made while ACTIVE; a retired key still verifies it
+        assert m.verify(kid, b"msg", sig, at=T_MID) is True
+
+    def test_revoked_key_rejects_even_valid_signature(self):
+        m, kid, _, _ = _manifest_with_active()
+        sig = m.sign(kid, b"msg", at=T_MID)
+        m.revoke(kid)
+        # cryptographically valid, but the key is revoked -> not trusted
+        assert m.verify(kid, b"msg", sig, at=T_MID) is False
+
+    def test_verify_rejects_out_of_window(self):
+        m, kid, _, _ = _manifest_with_active()
+        sig = m.sign(kid, b"msg", at=T_MID)
+        assert m.verify(kid, b"msg", sig, at=T_AFTER) is False
+        assert m.verify(kid, b"msg", sig, at=T_BEFORE) is False
+
+    def test_sign_out_of_window_raises(self):
+        m, kid, _, _ = _manifest_with_active()
+        with pytest.raises(KeyNotSignableError, match="in_window=False"):
+            m.sign(kid, b"msg", at=T_AFTER)
+
+    def test_sign_on_retired_raises(self):
+        m, kid, _, _ = _manifest_with_active()
+        m.retire(kid)
+        with pytest.raises(KeyNotSignableError):
+            m.sign(kid, b"msg", at=T_MID)
+
+    def test_verify_unknown_kid_raises(self):
+        m = Ed25519KeyManifest()
+        with pytest.raises(UnknownKidError):
+            m.verify("nope", b"msg", b"sig", at=T_MID)
+
+    def test_sign_unknown_kid_raises(self):
+        m = Ed25519KeyManifest()
+        with pytest.raises(UnknownKidError):
+            m.sign("nope", b"msg", at=T_MID)
+
+    def test_sign_and_verify_default_now(self):
+        # window spanning "now" so the default at=now() path is exercised
+        priv, pub = _keypair()
+        m = Ed25519KeyManifest()
+        now = datetime.now(UTC)
+        m.register(
+            "k-now",
+            pub,
+            valid_from=now - timedelta(days=1),
+            valid_until=now + timedelta(days=1),
+            private_key=priv,
+        )
+        sig = m.sign("k-now", b"msg")  # at defaults to now
+        assert m.verify("k-now", b"msg", sig) is True  # at defaults to now
+
+    def test_register_retired_then_verify_only(self):
+        priv, pub = _keypair()
+        m = Ed25519KeyManifest()
+        # register directly as RETIRED with a private key: verify-only, no sign
+        m.register(
+            "k", pub, valid_from=T0, valid_until=T_END, state=KeyState.RETIRED,
+            private_key=priv,
+        )
+        assert m.get("k").is_verify_trusted(T_MID) is True
+        with pytest.raises(KeyNotSignableError):
+            m.sign("k", b"msg", at=T_MID)

--- a/tests/test_governance/test_gate2_cond2_leaf_vs_wrapper.py
+++ b/tests/test_governance/test_gate2_cond2_leaf_vs_wrapper.py
@@ -1,0 +1,134 @@
+"""GATE2-COND-2: cross-module integration test of the leaf-input vs wrapper split.
+
+ADR-RT-003 §11.2 carries GATE2-COND-2 to PR-7: a cross-module integration test
+that the leaf-hash-input schema (the frozen subset hashed into Merkle leaves) is
+genuinely separate from the wrapper schema (everything else on a record).
+
+The binding contract (R25-EU08 / leaf_input_schema.py):
+
+* Adding a WRAPPER field (e.g. created_at_iso, rekor_signed_tree_head) is a safe,
+  additive change — it MUST NOT change any Merkle leaf hash or the tree root, so
+  an old verifier and a new producer agree on the same root.
+* Changing a LEAF field (one of LEAF_HASH_FIELDS) MUST change the leaf hash — that
+  is what makes tampering with a hashed field detectable.
+
+These tests exercise the real pipeline end-to-end:
+``leaf_input_schema.project_leaf_input`` → ``canonicalize.canon_leaf`` →
+``merkle.leaf_hash_for_record`` / ``MerkleTree`` — no mocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from graqle.governance.tamper_evidence.canonicalize import canon, canon_leaf
+from graqle.governance.tamper_evidence.leaf_input_schema import (
+    LEAF_HASH_FIELDS,
+    project_leaf_input,
+)
+from graqle.governance.tamper_evidence.merkle import (
+    MerkleTree,
+    leaf_hash_for_record,
+)
+
+
+def _base_record():
+    """A minimal record carrying every frozen leaf field plus a wrapper field."""
+    return {
+        "proof_format_version": "1.0.0",
+        "record_id": "rec-0001",
+        "content_hash": "sha256:abc123",
+        "timestamp_unix": 1_780_000_000,
+        "governance_metadata": {"decision": "ALLOW", "agent": "coordinator"},
+        # wrapper-only field (NOT in LEAF_HASH_FIELDS):
+        "created_at_iso": "2026-06-14T11:23:45Z",
+    }
+
+
+# ---- the split, at the projection layer ------------------------------------
+
+
+class TestLeafInputProjection:
+    def test_projection_keeps_only_leaf_fields(self):
+        rec = _base_record()
+        projected = project_leaf_input(rec)
+        assert set(projected) <= set(LEAF_HASH_FIELDS)
+        assert "created_at_iso" not in projected  # wrapper field dropped
+
+    def test_projection_omits_absent_leaf_fields(self):
+        rec = {"record_id": "r", "proof_format_version": "1.0.0"}
+        projected = project_leaf_input(rec)
+        assert set(projected) == {"record_id", "proof_format_version"}
+
+
+# ---- adding a wrapper field does not move the leaf hash ---------------------
+
+
+class TestWrapperAdditionIsLeafNeutral:
+    def test_adding_wrapper_field_does_not_change_canon_leaf(self):
+        rec = _base_record()
+        before = canon_leaf(rec)
+        rec_with_extra = {**rec, "rekor_signed_tree_head": "b64-sth", "extra_wrapper": 42}
+        after = canon_leaf(rec_with_extra)
+        assert before == after
+
+    def test_adding_wrapper_field_does_not_change_leaf_hash(self):
+        rec = _base_record()
+        before = leaf_hash_for_record(rec)
+        after = leaf_hash_for_record({**rec, "rekor_log_index": 99})
+        assert before == after
+
+    def test_wrapper_addition_preserves_merkle_root(self):
+        recs = [
+            {**_base_record(), "record_id": f"rec-{i}", "content_hash": f"sha256:{i}"}
+            for i in range(4)
+        ]
+        root_before = MerkleTree.from_records(recs).root_hex
+
+        # an old verifier (no wrapper field) and a new producer (extra wrapper
+        # fields) must compute the SAME root
+        recs_with_wrapper = [{**r, "created_at_iso": "2026-06-14T11:23:45Z"} for r in recs]
+        root_after = MerkleTree.from_records(recs_with_wrapper).root_hex
+        assert root_before == root_after
+
+    def test_canon_wrapper_does_include_wrapper_field(self):
+        # sanity: the WRAPPER canonicalization (used for signatures) DOES see a
+        # wrapper field — proving the two canon functions are genuinely different
+        # scopes. Start from a record WITHOUT the new field, then add it.
+        rec = _base_record()
+        before = canon(rec)
+        after = canon({**rec, "rekor_signed_tree_head": "b64-sth"})
+        assert before != after
+        # and the same wrapper addition is leaf-neutral (the whole point)
+        assert canon_leaf(rec) == canon_leaf({**rec, "rekor_signed_tree_head": "b64-sth"})
+
+
+# ---- changing a leaf field DOES move the leaf hash -------------------------
+
+
+class TestLeafFieldChangeIsDetected:
+    @pytest.mark.parametrize("field", LEAF_HASH_FIELDS)
+    def test_changing_each_leaf_field_changes_leaf_hash(self, field):
+        rec = _base_record()
+        before = leaf_hash_for_record(rec)
+        tampered = dict(rec)
+        # mutate the field to a different value of a JSON-native type
+        if field == "timestamp_unix":
+            tampered[field] = rec[field] + 1
+        elif field == "governance_metadata":
+            tampered[field] = {"decision": "DENY", "agent": "coordinator"}
+        else:
+            tampered[field] = str(rec[field]) + "-tampered"
+        after = leaf_hash_for_record(tampered)
+        assert before != after, f"tampering with leaf field {field!r} was not detected"
+
+    def test_leaf_field_change_changes_merkle_root(self):
+        recs = [
+            {**_base_record(), "record_id": f"rec-{i}", "content_hash": f"sha256:{i}"}
+            for i in range(4)
+        ]
+        root_before = MerkleTree.from_records(recs).root_hex
+        # tamper one record's content_hash (a leaf field)
+        recs[2] = {**recs[2], "content_hash": "sha256:TAMPERED"}
+        root_after = MerkleTree.from_records(recs).root_hex
+        assert root_before != root_after


### PR DESCRIPTION
## PR-7 — v0.59.0 release: Layer 5 cryptographic tamper-evidence

The **release PR** for Layer 5 (R25-EU01 Phase M1) and the final unit of the
PR-0…PR-7 sequence. Carries the single `0.58.1 → 0.59.0` version bump for the
whole layer (per the v0.59.0 version-bump rule — no per-PR bumps PR-0…PR-6.5).

Release gate: ADR-RT-003 §11 authorises the v0.59.0 build (EDL-003 §6 sole-approver
decision 2026-05-20); the v0.59.0 tag condition is "v0.58.0 + all M1 PRs merged +
**sole-approver sign-off on the final PR**" — this PR is that final PR.

### 1. `graqle/governance/custody/ed25519_key_manifest.py` (Task 1.7 / C-P2-1)

A per-`kid` ed25519 signing-key manifest with a **validity window**
(`valid_from`/`valid_until`) and a **monotonic lifecycle**:

| state | can sign | verify-trusted (within window) |
|-------|----------|--------------------------------|
| ACTIVE | yes | yes |
| RETIRED | no | yes — historical proofs stay valid |
| REVOKED | no | **no** — compromised key, past signatures repudiated |

Lets a verifier answer *"was this kid trusted to sign at the moment the proof was
made?"* — `verify(kid, msg, sig, at=<proof recording time>)`.

Security properties (all tested):
- **Monotonic, forward-only** lifecycle (`ACTIVE → RETIRED → REVOKED`); there is
  no `activate()` and `_transition` rejects any backward move → a REVOKED key can
  never be resurrected through the API.
- **UTC normalisation** (`_as_utc`) of naive (assume-UTC) and aware (convert)
  datetimes, so all window comparisons are total-ordered — no naive-vs-aware crash,
  no local-tz ambiguity at boundaries.
- **No injection surface** — ed25519 binary API, no string interpolation.
- `verify` returns `False` (never raises) for an untrusted kid / bad signature /
  out-of-window / revoked key, so a caller treats any falsey result as
  "not tamper-proven"; it raises `UnknownKidError` only for an unregistered kid.
- `register` refuses empty kid, inverted window, and duplicate kid (no silent
  public-key/window swap).
- Private keys live separate from the frozen, shareable `KeyEntry` and are dropped
  on `retire()`/`revoke()`.

**Known limitation (documented in the module docstring):** in-memory key
zeroization is deliberately not attempted — CPython gives no guaranteed memory
wipe and `cryptography`'s `Ed25519PrivateKey` hides its raw bytes, so it would be
security theater. Deployments needing hardware-backed at-rest custody supply the
private key from an HSM/KMS via a signing callback (out of C-P2-1 scope, which
governs *which kid is trusted when*).

Uses `cryptography` ed25519 (a **core** dependency) — no optional extras, runs in
CI unconditionally.

### 2. GATE2-COND-2 — leaf-input vs wrapper schema split (integration test)

`tests/test_governance/test_gate2_cond2_leaf_vs_wrapper.py` proves end-to-end
(`canonicalize` × `leaf_input_schema` × `merkle`, no mocks) that:
- adding a **wrapper** field never changes a Merkle leaf hash *or* the tree root
  (so an old verifier and a new producer agree on the same root), while
- changing **any** `LEAF_HASH_FIELDS` field changes the leaf hash (tampering with
  a hashed field is detectable).

### 3. Release: version bump + CHANGELOG

- `graqle/__version__.py` + `pyproject.toml`: `0.58.1 → 0.59.0` (single bump).
- `CHANGELOG.md`: v0.59.0 entry summarising the whole Layer 5 feature (Merkle,
  JCS, Sigstore Rekor, ed25519, monotonic-on, custody) — public-mechanism level,
  no trade-secret internals.

### Latency (AC-1 / AC-5)

Validated via the **cr-018 measurement-only spike** (already shipped as v0.58.0
documentation): Merkle commitment over 1,000 R18 traces at **~200× headroom** under
the AC-5 target (≤227ms P95, 10% over the R18 baseline); the batcher adds **0ms to
the write path** (commit is async, bounded by `T_batch + Rekor_P95`). A live
1hr/1000-RPS benchmark is operational telemetry, referenced not re-run here.

### Quality gates

- **Realistic 100% coverage** on new code (custody 102/102 + `__init__` 3/3). No
  `pragma: no cover`, no no-op tests, no dead-branch deletion.
- **0 regression** — 318 governance tests pass (1 skipped; `test_shacl.py` is a
  pre-existing `rdflib`→`isodate` collection error in CI's `--ignore` list, not
  introduced here).
- **ruff + mypy clean** on all new code.
- **Triple sentinel** converged: `review(all)` ×2 (pass-1 BLOCKERs were artifacts
  of an abbreviated review diff — the real file is complete, proven by mypy + 47
  passing tests; pass-2 drove a real simplification, replacing a clever
  `__dict__` lazy property with a plain `__init__` dict), `graq_predict` (5 latent
  security chains — clock-skew, revoked-historical-trust, out-of-window verify,
  lifecycle resurrection, canon integration — all already designed-for and tested;
  drove the `verify(at=...)` historical-proof docstring), `review(security)`
  **APPROVED 95%, 0 blockers**.

### Declined (documented)
- `isinstance` runtime checks on key types — mypy enforces them statically; a wrong
  type fails loudly at the crypto call. Runtime checks would be gold-plating.

### Post-merge (the irreversible step)
After this private PR **and** its public cherry-pick PR are merged (sole-approver),
the `v0.59.0` tag is pushed → triggers PyPI OIDC publish. The publish gate is
`needs:[test, audit]` — those jobs are green; the pre-existing "Release Gate (PyPI)"
check failure is unrelated infra drift and does not gate the tag publish.

### Files
- `graqle/governance/custody/__init__.py` + `ed25519_key_manifest.py` — new (Task 1.7)
- `tests/test_governance/test_ed25519_key_manifest.py` — new, 35 tests
- `tests/test_governance/test_gate2_cond2_leaf_vs_wrapper.py` — new, 12 tests
- `graqle/__version__.py`, `pyproject.toml` — 0.58.1 → 0.59.0
- `CHANGELOG.md` — v0.59.0 entry

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
