### PR TITLE
examples: v0.59.0 Layer 5 cryptographic-governance use case + dogfood + README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,177 @@
+# GraQle Examples
+
+Runnable examples for GraQle. Each is self-contained and uses only the public API.
+
+| File | What it shows | Run time |
+|------|---------------|----------|
+| `quickstart.py` | Build a KG and ask a governed question | ~30s |
+| `governance_example.py` | Governance primitives | ~10s |
+| **`v059_cryptographic_governance_usecase.py`** | **Layer 5 cryptographic tamper-evidence, a real use case, step by step** | ~3s |
+| **`v059_e2e_dogfood.py`** | Smoke-test every Layer 5 feature against the installed package | ~2s |
+
+---
+
+## 1. Setup (zero to running, ~60 seconds)
+
+```bash
+# 1. a clean virtual environment
+python -m venv graqle-demo
+source graqle-demo/bin/activate          # Windows: graqle-demo\Scripts\activate
+
+# 2. install GraQle from PyPI (Layer 5 ships in 0.59.0+)
+pip install graqle                       # or: pip install graqle==0.59.0
+
+# 3. confirm
+python -c "import graqle, graqle.__version__ as v; print('graqle', v.__version__)"
+```
+
+`cryptography` (for ed25519) ships as a core dependency — nothing else to install.
+
+---
+
+## 2. Run the cryptographic-governance use case (the headline demo)
+
+```bash
+# from a checkout of the repo:
+python examples/v059_cryptographic_governance_usecase.py
+
+# or fetch just the one file and run it anywhere:
+#   curl -O https://raw.githubusercontent.com/quantamixsol/graqle/master/examples/v059_cryptographic_governance_usecase.py
+#   python v059_cryptographic_governance_usecase.py
+```
+
+**The story it runs** — a bank's AI declines a loan, and you watch the decision become
+tamper-evident, end to end:
+
+1. **Governed decision** — the AI returns `DECLINE` on a loan application.
+2. **Layer 5 locks (monotonic-on)** — first governed write locks the layer; trying to
+   disable it is **refused and itself audited** (EU AI Act Article 12).
+3. **Canonicalize (RFC 8785)** — and *prove* the leaf/wrapper split (operational fields
+   don't change the cryptographic hash).
+4. **Merkle commit (RFC 6962)** — the day's decisions reduce to one root.
+5. **ed25519 sign** under a key with a validity window.
+6. **Anchor** — `{root, kid, signature}` published to a public transparency log
+   (Sigstore Rekor in production).
+7. **Auditor verifies, six months later, with zero access** → **AUTHENTIC**.
+8. **Tamperer flips DECLINE→APPROVE** → **TAMPER DETECTED**.
+9. **Key compromised → revoked** → even its original valid signature stops verifying.
+
+Expected final banner: `USE CASE COMPLETE` (exit code 0).
+
+### Verify the published package end-to-end
+
+```bash
+python examples/v059_e2e_dogfood.py
+# -> 10/10 passed
+# -> ALL NEW v0.59.0 FEATURES VERIFIED WORKING
+```
+
+---
+
+## 3. Use it in your own code (the minimal real-life recipe)
+
+```python
+from datetime import datetime, timezone
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from graqle.governance.tamper_evidence.merkle import MerkleTree
+from graqle.governance.custody import Ed25519KeyManifest
+
+UTC = timezone.utc
+
+# your governed decisions for this batch (dicts with the leaf fields)
+records = [
+    {"proof_format_version": "1.0.0", "record_id": "decision-1",
+     "content_hash": "sha256:...", "timestamp_unix": 1780000000,
+     "governance_metadata": {"decision": "DECLINE", "reason_code": "..."}},
+]
+
+# 1. commit to a Merkle root
+root_hex = MerkleTree.from_records(records).root_hex
+
+# 2. sign the root with a windowed ed25519 key
+priv = Ed25519PrivateKey.generate()
+keys = Ed25519KeyManifest()
+keys.register("my-signing-key-2026-Q2", priv.public_key(),
+              valid_from=datetime(2026, 1, 1, tzinfo=UTC),
+              valid_until=datetime(2026, 12, 31, tzinfo=UTC),
+              private_key=priv)
+signature = keys.sign("my-signing-key-2026-Q2", bytes.fromhex(root_hex))
+
+# 3. publish {root_hex, kid, signature} to your transparency log (Sigstore Rekor).
+# 4. anyone with the records + that public anchor + the public key can now verify:
+verifier = Ed25519KeyManifest()
+verifier.register("my-signing-key-2026-Q2", priv.public_key(),  # public key only
+                  valid_from=datetime(2026, 1, 1, tzinfo=UTC),
+                  valid_until=datetime(2026, 12, 31, tzinfo=UTC))
+ok = (MerkleTree.from_records(records).root_hex == root_hex
+      and verifier.verify("my-signing-key-2026-Q2", bytes.fromhex(root_hex), signature))
+print("AUTHENTIC" if ok else "TAMPERED")
+```
+
+To enable Layer 5 in a real deployment, set `attestation.enabled: true` in `graqle.yaml`
+(it is off by default — with it off, output is byte-identical to a pre-Layer-5 release).
+
+---
+
+## 4. Run it through the MCP server (Claude Code / Cursor / VS Code)
+
+GraQle ships an MCP server exposing its tools as `graq_*` commands inside your AI IDE,
+so you can drive a real-life governed workflow conversationally — no scripts.
+
+### Start the server
+
+```bash
+pip install "graqle[api]"
+graq mcp serve            # exposes the graq_* / kogni_* tools over MCP
+```
+
+Register it with your client (Claude Code example, `.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "graqle": { "command": "graq", "args": ["mcp", "serve"] }
+  }
+}
+```
+
+### A real-life workflow, end to end, in MCP commands
+
+Build a graph of your codebase, then reason and govern over it:
+
+```text
+graq_inspect                      # graph stats + hub nodes (start here)
+graq_context(query="loan decision audit path", deep=true)
+                                  # focused context: which modules/decisions matter
+graq_reason(question="Does our loan-decision path produce a tamper-evident audit record?")
+                                  # multi-agent answer with confidence + traced activation
+graq_impact(component="governance/tamper_evidence")
+                                  # blast radius before any change
+graq_preflight(action="enable Layer 5 cryptographic tamper-evidence in production")
+                                  # safety check + relevant lessons
+graq_reason(question="Walk the full journey: decision -> Merkle commit -> Rekor anchor -> auditor verify")
+graq_learn(action="enabled Layer 5", outcome="success",
+           lesson="monotonic-on locks the layer on first governed write")
+                                  # teach the graph the outcome
+```
+
+Or use the smart router slash command in Claude Code:
+
+```text
+/graq Does enabling Layer 5 change our write-path latency, and what gets anchored to Rekor?
+```
+
+The same five layers the script demonstrates (substrate → reasoning → governed trace →
+permit enforcement → cryptographic tamper-evidence) are what the MCP tools reason over —
+the script shows the *cryptographic mechanics*, the MCP commands show *governed reasoning
+about your own system* on top of them.
+
+---
+
+## Troubleshooting
+
+- **`ModuleNotFoundError: graqle.governance.custody`** — you're on a pre-0.59.0 install.
+  `pip install --upgrade graqle==0.59.0` (Layer 5 landed in 0.59.0).
+- **The dogfood prints a version other than 0.59.0** — your `python` is resolving an
+  older install; use the venv's interpreter explicitly (`graqle-demo/bin/python ...`).
+- **`graq: command not found`** — install the CLI extras: `pip install "graqle[api]"`.

--- a/examples/v059_cryptographic_governance_usecase.py
+++ b/examples/v059_cryptographic_governance_usecase.py
@@ -1,0 +1,195 @@
+"""GraQle v0.59.0 — cryptographic governance, a real use case, step by step.
+
+Scenario: a bank's AI declines a loan application. That governed decision must be
+recorded so that — months later — an auditor can prove the record was not altered,
+WITHOUT any access to the bank's or GraQle's systems. A tamperer then tries to
+change the recorded decision, and a key is compromised. We show, step by step,
+that the tamper is caught and the revocation is enforced.
+
+This walks all five GraQle governance layers end to end (L1 substrate + L2 reasoning
+are the foundation; this script exercises L3 governed-trace shape, L5 cryptographic
+tamper-evidence, the runtime layer-switch / monotonic-on rule, and ed25519 key
+custody). Nothing is mocked: real ed25519 keys, real RFC 8785 canonicalization,
+real RFC 6962 Merkle tree.
+
+Run it against the published package to prove the public artifact works:
+
+    python -m venv demo-venv
+    demo-venv/bin/python -m pip install graqle           # or graqle==0.59.0
+    demo-venv/bin/python examples/v059_cryptographic_governance_usecase.py
+
+Expected: nine steps print, ending with "USE CASE COMPLETE". Exit code 0.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from graqle.__version__ import __version__
+from graqle.governance.custody import Ed25519KeyManifest
+from graqle.governance.layer_status import LayerMonotonicityViolation, LayerStatusRegistry
+from graqle.governance.tamper_evidence.canonicalize import canon_leaf
+from graqle.governance.tamper_evidence.merkle import MerkleTree, leaf_hash_for_record
+
+UTC = timezone.utc
+NOW = datetime(2026, 5, 24, 13, 0, tzinfo=UTC)
+L5 = "l5_cryptographic_tamper_evidence"
+_STEP = 0
+
+
+def step(title: str) -> None:
+    global _STEP
+    _STEP += 1
+    print(f"\n{'=' * 70}\nSTEP {_STEP}: {title}\n{'=' * 70}")
+
+
+def main() -> None:
+    print(f"GraQle v{__version__}  -  loan-denial governed-decision use case")
+    print("(running against the installed package)")
+
+    # -----------------------------------------------------------------------
+    step("The bank's AI makes a governed decision (the raw event)")
+    # -----------------------------------------------------------------------
+    decision = {
+        "proof_format_version": "1.0.0",
+        "record_id": "loan-app-88213",
+        "timestamp_unix": int(NOW.timestamp()),
+        "governance_metadata": {
+            "decision": "DECLINE",
+            "applicant_ref": "anon-7f3a",  # pseudonymous, no PII in the trace
+            "model": "credit-risk-v4",
+            "reason_code": "DTI_ABOVE_THRESHOLD",
+            "human_review": "not_required",
+        },
+        # WRAPPER fields (operational metadata) — must NOT affect the leaf hash:
+        "content_hash": "sha256:" + hashlib.sha256(b"loan-app-88213/DECLINE").hexdigest(),
+        "created_at_iso": NOW.isoformat().replace("+00:00", "Z"),
+    }
+    md = decision["governance_metadata"]
+    print(f"Decision: {md['decision']} for {decision['record_id']} reason {md['reason_code']}")
+
+    # -----------------------------------------------------------------------
+    step("Layer 5 turns ON in production - and locks (monotonic-on, Article 12)")
+    # -----------------------------------------------------------------------
+    registry = LayerStatusRegistry(environment="production")
+    state = registry.record_first_write(L5, first_record_id=decision["record_id"])
+    print(f"  L5 enabled={state.enabled}  monotonic_on={state.monotonic_on}")
+    print(f"  first governed record at: {state.first_record_at_iso}")
+    print("  Compliance officer now tries to quietly switch L5 OFF...")
+    try:
+        registry.request_enabled(L5, False)
+        print("  !!! disabled (THIS WOULD BE A BUG)")
+    except LayerMonotonicityViolation:
+        print("  REFUSED: LayerMonotonicityViolation - and the attempt itself is audited.")
+    print(f"  audit timeline for L5: {[h['event'] for h in registry.history(L5)]}")
+
+    # -----------------------------------------------------------------------
+    step("Canonicalize (RFC 8785) - and prove the leaf/wrapper split")
+    # -----------------------------------------------------------------------
+    leaf_bytes = canon_leaf(decision)
+    print(f"  leaf canonical bytes ({len(leaf_bytes)} B): {leaf_bytes[:72]!r}...")
+    print("  -> 'created_at_iso' and 'content_hash' are WRAPPER fields; they appear")
+    print("     in the wrapper canon but NOT in the leaf hash input.")
+    assert canon_leaf({**decision, "ingest_node": "eu-central-1b"}) == leaf_bytes
+    print("  PROVEN: adding a wrapper field did NOT change the leaf bytes.")
+
+    # -----------------------------------------------------------------------
+    step("Commit to a Merkle batch (RFC 6962) - the day's governed decisions")
+    # -----------------------------------------------------------------------
+    batch = [
+        decision,
+        {"proof_format_version": "1.0.0", "record_id": "loan-app-88214",
+         "timestamp_unix": int(NOW.timestamp()) + 5, "content_hash": "sha256:bbb",
+         "governance_metadata": {"decision": "APPROVE", "reason_code": "OK"}},
+        {"proof_format_version": "1.0.0", "record_id": "loan-app-88215",
+         "timestamp_unix": int(NOW.timestamp()) + 9, "content_hash": "sha256:ccc",
+         "governance_metadata": {"decision": "DECLINE", "reason_code": "THIN_FILE"}},
+    ]
+    root_hex = MerkleTree.from_records(batch).root_hex
+    print(f"  batch size: {len(batch)} governed decisions")
+    print(f"  our decision's leaf hash: {leaf_hash_for_record(decision).hex()[:32]}...")
+    print(f"  MERKLE ROOT: {root_hex}")
+    print("  ^ this single root commits to all decisions in the batch.")
+
+    # -----------------------------------------------------------------------
+    step("Sign the batch root with an ed25519 key under a validity window (C-P2-1)")
+    # -----------------------------------------------------------------------
+    signing_priv = Ed25519PrivateKey.generate()
+    kid = "graqle-bank-signing-2026-Q2"
+    window = dict(valid_from=datetime(2026, 4, 1, tzinfo=UTC),
+                  valid_until=datetime(2026, 7, 1, tzinfo=UTC))
+    keys = Ed25519KeyManifest()
+    keys.register(kid, signing_priv.public_key(), private_key=signing_priv, **window)
+    signature = keys.sign(kid, bytes.fromhex(root_hex), at=NOW)
+    print(f"  signed root with kid={kid}")
+    print(f"  ed25519 signature ({len(signature)} B): {signature.hex()[:48]}...")
+
+    # -----------------------------------------------------------------------
+    step("Anchor: publish {root, kid, signature} to a public transparency log")
+    # -----------------------------------------------------------------------
+    # In production this is Sigstore Rekor (an external, append-only public log
+    # GraQle does not control). Here we model the published, immutable anchor.
+    anchor = {"merkle_root": root_hex, "kid": kid, "signature_hex": signature.hex(),
+              "anchored_at": NOW.isoformat().replace("+00:00", "Z")}
+    print(f"  ANCHOR (public, immutable): root={anchor['merkle_root'][:24]}... kid={anchor['kid']}")
+    print("  In production this lands in Sigstore Rekor - anyone can fetch it later.")
+
+    # -----------------------------------------------------------------------
+    step("SIX MONTHS LATER - an auditor verifies, with NO access to bank/GraQle")
+    # -----------------------------------------------------------------------
+    # The auditor holds only: the decision record, the public anchor, and the
+    # public key for the kid. They re-derive everything themselves.
+    auditor = Ed25519KeyManifest()
+    auditor.register(kid, signing_priv.public_key(), **window)  # public key only, no private
+    root_ok = MerkleTree.from_records(batch).root_hex == anchor["merkle_root"]
+    sig_ok = auditor.verify(kid, bytes.fromhex(anchor["merkle_root"]),
+                            bytes.fromhex(anchor["signature_hex"]), at=NOW)
+    print(f"  recomputed Merkle root matches anchor? {root_ok}")
+    print(f"  ed25519 signature valid for that root? {sig_ok}")
+    verdict = "AUTHENTIC - record provably unaltered" if root_ok and sig_ok else "FAILED"
+    print(f"  VERDICT: {verdict}")
+    assert root_ok and sig_ok
+
+    # -----------------------------------------------------------------------
+    step("A TAMPERER flips the decision DECLINE -> APPROVE and re-presents it")
+    # -----------------------------------------------------------------------
+    tampered = {**decision,
+                "governance_metadata": {**decision["governance_metadata"], "decision": "APPROVE"}}
+    tampered_root = MerkleTree.from_records([tampered, batch[1], batch[2]]).root_hex
+    roots_differ = tampered_root != anchor["merkle_root"]
+    sig_on_tamper = auditor.verify(kid, bytes.fromhex(tampered_root),
+                                   bytes.fromhex(anchor["signature_hex"]), at=NOW)
+    print(f"  tampered decision: {tampered['governance_metadata']['decision']}")
+    print(f"  original anchored root : {anchor['merkle_root'][:32]}...")
+    print(f"  tampered recomputed root: {tampered_root[:32]}...")
+    print(f"  root changed by the tamper? {roots_differ}")
+    print(f"  signature still valid on tampered root? {sig_on_tamper}")
+    caught = roots_differ and not sig_on_tamper
+    print(f"  VERDICT: {'TAMPER DETECTED - math does not lie' if caught else 'MISSED'}")
+    assert caught
+
+    # -----------------------------------------------------------------------
+    step("Key compromised? Revoke it - past forgeries with that key stop verifying")
+    # -----------------------------------------------------------------------
+    auditor.revoke(kid)
+    print(f"  key {kid} state -> {auditor.get(kid).state.value}")
+    after_revoke = auditor.verify(kid, bytes.fromhex(anchor["merkle_root"]),
+                                  bytes.fromhex(anchor["signature_hex"]), at=NOW)
+    print(f"  even the ORIGINAL valid signature now verifies? {after_revoke}")
+    print("  REVOKED keys are rejected unconditionally - the compromise escape hatch.")
+    assert after_revoke is False
+
+    print(f"\n{'#' * 70}")
+    print("USE CASE COMPLETE - all steps executed against the installed graqle:")
+    print("  decision -> monotonic-on lock -> RFC8785 canon -> RFC6962 Merkle ->")
+    print("  ed25519 sign (windowed key) -> public anchor -> auditor verifies AUTHENTIC")
+    print("  -> tamper DETECTED -> revocation enforced.")
+    print("Tampering with a governed AI decision is mathematically detectable by anyone.")
+    print("#" * 70)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/v059_e2e_dogfood.py
+++ b/examples/v059_e2e_dogfood.py
@@ -1,0 +1,214 @@
+"""GraQle v0.59.0 — end-to-end feature check (dogfood) against the installed package.
+
+Exercises every NEW Layer 5 feature against whatever `import graqle` resolves to in
+the current environment. Prints PASS/FAIL per feature and a final verdict; exits
+non-zero on any failure. No mocks — real ed25519 keys, real hashes.
+
+Use it as a smoke test of a published release:
+
+    python -m venv check-venv
+    check-venv/bin/python -m pip install graqle           # or graqle==0.59.0
+    check-venv/bin/python examples/v059_e2e_dogfood.py
+
+Expected last line: "ALL NEW v0.59.0 FEATURES VERIFIED WORKING".
+"""
+
+from __future__ import annotations
+
+import sys
+import traceback
+from datetime import datetime, timezone
+
+UTC = timezone.utc
+results: list[tuple[str, bool, str]] = []
+
+
+def check(name, fn):
+    try:
+        fn()
+        results.append((name, True, ""))
+        print(f"PASS  {name}")
+    except Exception as exc:  # noqa: BLE001
+        results.append((name, False, f"{type(exc).__name__}: {exc}"))
+        print(f"FAIL  {name}\n      {traceback.format_exc().splitlines()[-1]}")
+
+
+def t_version():
+    from graqle.__version__ import __version__
+    assert __version__ == "0.59.0", f"expected 0.59.0, got {__version__}"
+
+
+def t_imports():
+    from graqle.governance.custody import (  # noqa: F401
+        Ed25519KeyManifest,
+        KeyEntry,
+        KeyManifestError,
+        KeyState,
+    )
+    from graqle.governance.layer_status import (  # noqa: F401
+        LayerMonotonicityViolation,
+        LayerStatusRegistry,
+        flip_to_monotonic_on_atomic,
+    )
+    from graqle.governance.tamper_evidence.canonicalize import canon, canon_leaf  # noqa: F401
+    from graqle.governance.tamper_evidence.leaf_input_schema import (  # noqa: F401
+        LEAF_HASH_FIELDS,
+        project_leaf_input,
+    )
+    from graqle.governance.tamper_evidence.merkle import (  # noqa: F401
+        MerkleTree,
+        leaf_hash_for_record,
+    )
+
+
+def t_custody_sign_verify():
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    from graqle.governance.custody import Ed25519KeyManifest
+    priv = Ed25519PrivateKey.generate()
+    m = Ed25519KeyManifest()
+    t0, t_end = datetime(2026, 4, 1, tzinfo=UTC), datetime(2026, 7, 1, tzinfo=UTC)
+    at = datetime(2026, 5, 15, tzinfo=UTC)
+    m.register("graqle-sdk-signing-2026-Q2", priv.public_key(), t0, t_end, private_key=priv)
+    sig = m.sign("graqle-sdk-signing-2026-Q2", b"governed proof bundle", at=at)
+    assert m.verify("graqle-sdk-signing-2026-Q2", b"governed proof bundle", sig, at=at) is True
+    assert m.verify("graqle-sdk-signing-2026-Q2", b"TAMPERED", sig, at=at) is False
+
+
+def t_custody_lifecycle():
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    from graqle.governance.custody import Ed25519KeyManifest, KeyState
+    priv = Ed25519PrivateKey.generate()
+    m = Ed25519KeyManifest()
+    t0, t_end = datetime(2026, 4, 1, tzinfo=UTC), datetime(2026, 7, 1, tzinfo=UTC)
+    at = datetime(2026, 5, 15, tzinfo=UTC)
+    m.register("k", priv.public_key(), t0, t_end, private_key=priv)
+    sig = m.sign("k", b"msg", at=at)
+    m.retire("k")
+    assert m.get("k").state is KeyState.RETIRED
+    assert m.verify("k", b"msg", sig, at=at) is True  # historical proof still trusted
+    try:
+        m.sign("k", b"new", at=at)
+        raise AssertionError("retired key signed!")
+    except Exception as exc:  # noqa: BLE001
+        assert "Signable" in type(exc).__name__ or "sign" in type(exc).__name__.lower()
+    m.revoke("k")
+    assert m.get("k").state is KeyState.REVOKED
+    assert m.verify("k", b"msg", sig, at=at) is False
+    try:
+        m.retire("k")
+        raise AssertionError("un-revoked!")
+    except Exception as exc:  # noqa: BLE001
+        assert "Transition" in type(exc).__name__ or "monotonic" in str(exc).lower()
+
+
+def t_custody_window():
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    from graqle.governance.custody import Ed25519KeyManifest
+    priv = Ed25519PrivateKey.generate()
+    m = Ed25519KeyManifest()
+    t0, t_end = datetime(2026, 4, 1, tzinfo=UTC), datetime(2026, 7, 1, tzinfo=UTC)
+    m.register("k", priv.public_key(), t0, t_end, private_key=priv)
+    sig = m.sign("k", b"msg", at=datetime(2026, 5, 15, tzinfo=UTC))
+    assert m.verify("k", b"msg", sig, at=datetime(2026, 8, 1, tzinfo=UTC)) is False
+
+
+def t_merkle_roundtrip():
+    from graqle.governance.tamper_evidence.merkle import MerkleTree
+    recs = [
+        {"proof_format_version": "1.0.0", "record_id": f"r{i}",
+         "content_hash": f"sha256:{i}", "timestamp_unix": 1_780_000_000 + i,
+         "governance_metadata": {"decision": "ALLOW"}}
+        for i in range(5)
+    ]
+    root1 = MerkleTree.from_records(recs).root_hex
+    assert isinstance(root1, str) and len(root1) == 64
+    assert MerkleTree.from_records(recs).root_hex == root1
+
+
+def t_leaf_vs_wrapper():
+    from graqle.governance.tamper_evidence.merkle import leaf_hash_for_record
+    base = {"proof_format_version": "1.0.0", "record_id": "r1",
+            "content_hash": "sha256:abc", "timestamp_unix": 1_780_000_000,
+            "governance_metadata": {"d": "ALLOW"}}
+    h = leaf_hash_for_record(base)
+    assert leaf_hash_for_record({**base, "created_at_iso": "2026-06-14T11:23:45Z"}) == h
+    assert leaf_hash_for_record({**base, "content_hash": "sha256:TAMPERED"}) != h
+
+
+def t_canon_rejects_nonfinite():
+    # NaN/Inf in an ALLOWLISTED leaf field (governance_metadata) reaches the float
+    # validator; a non-allowlisted field is projected out first (the leaf/wrapper split).
+    from graqle.governance.tamper_evidence.canonicalize import canon, canon_leaf
+    for bad in (float("nan"), float("inf"), float("-inf")):
+        rec = {"proof_format_version": "1.0.0", "record_id": "r",
+               "content_hash": "sha256:x", "timestamp_unix": 1,
+               "governance_metadata": {"score": bad}}
+        for fn, arg in ((canon_leaf, rec), (canon, {"a": bad})):
+            try:
+                fn(arg)
+                raise AssertionError(f"{fn.__name__} accepted non-finite {bad}")
+            except Exception as exc:  # noqa: BLE001
+                assert "Float" in type(exc).__name__, f"unexpected {type(exc).__name__}"
+
+
+def t_monotonic_on(tmpdir):
+    from graqle.governance.layer_status import LayerMonotonicityViolation, LayerStatusRegistry
+    layer = "l5_cryptographic_tamper_evidence"
+    reg = LayerStatusRegistry(environment="production", transition_dir=tmpdir)
+    assert reg.record_first_write(layer).monotonic_on is True
+    try:
+        reg.request_enabled(layer, False)
+        raise AssertionError("disabled a monotonic-on layer!")
+    except LayerMonotonicityViolation:
+        pass
+    reg.record_first_write(layer)
+    assert len([h for h in reg.history(layer) if h["event"] == "monotonic_on"]) == 1
+
+
+def t_cas_persist_fn(tmpdir):
+    from graqle.governance.layer_status import LayerStatusRegistry
+    layer = "l5_cryptographic_tamper_evidence"
+    calls = []
+    reg = LayerStatusRegistry(
+        environment="production", transition_dir=tmpdir,
+        persist_fn=lambda lid, iso, rid: calls.append((lid, rid)) or True,
+    )
+    reg.record_first_write(layer, first_record_id="rec-1")
+    reg.record_first_write(layer, first_record_id="rec-2")  # idempotent
+    assert calls == [(layer, "rec-1")]
+    flip = next(h for h in reg.history(layer) if h["event"] == "monotonic_on")
+    assert flip["detail"]["cas_won"] is True
+
+
+def main():
+    import tempfile
+    check("version == 0.59.0", t_version)
+    check("all new v0.59.0 modules import", t_imports)
+    check("custody: ed25519 sign/verify + tamper-detect", t_custody_sign_verify)
+    check("custody: ACTIVE->RETIRED->REVOKED lifecycle + monotonic", t_custody_lifecycle)
+    check("custody: validity window enforced", t_custody_window)
+    check("merkle: RFC6962 tree root deterministic", t_merkle_roundtrip)
+    check("leaf-vs-wrapper split (wrapper-neutral, leaf-sensitive)", t_leaf_vs_wrapper)
+    check("canonicalize: rejects NaN/Inf", t_canon_rejects_nonfinite)
+    with tempfile.TemporaryDirectory() as d1:
+        check("layer_status: monotonic-on enforced + idempotent", lambda: t_monotonic_on(d1))
+    with tempfile.TemporaryDirectory() as d2:
+        check("layer_status: LS-7 CAS persist_fn driven once", lambda: t_cas_persist_fn(d2))
+
+    passed = sum(1 for _, ok, _ in results if ok)
+    total = len(results)
+    print(f"\n{'=' * 60}\nv0.59.0 E2E DOGFOOD: {passed}/{total} passed")
+    if passed != total:
+        print("FAILURES:")
+        for name, ok, err in results:
+            if not ok:
+                print(f"  - {name}: {err}")
+        sys.exit(1)
+    print("ALL NEW v0.59.0 FEATURES VERIFIED WORKING")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## examples: v0.59.0 Layer 5 — easy-to-run cryptographic-governance demo + dogfood + README

Makes the Layer 5 (cryptographic tamper-evidence) story trivial for anyone to set up
and run — a runnable real use case, a smoke test, and a step-by-step README that also
covers the MCP command path. Public-API-only; ships with the package in `examples/`.

### New files
- **`examples/v059_cryptographic_governance_usecase.py`** — a real, step-by-step use
  case. A bank's AI declines a loan; the decision is locked (monotonic-on),
  RFC 8785-canonicalized, RFC 6962-Merkle-committed, ed25519-signed, and anchored;
  an auditor verifies it **AUTHENTIC** with zero access; a **tamperer is caught**; a
  compromised key is **revoked**. Nine printed steps, no mocks (real ed25519 + hashes).
- **`examples/v059_e2e_dogfood.py`** — 10-check smoke test of every Layer 5 feature
  against the installed package → "ALL NEW v0.59.0 FEATURES VERIFIED WORKING".
- **`examples/README.md`** — zero-to-running setup (venv + `pip install graqle`), how to
  run the demo, a minimal real-life code recipe, and the full **MCP path**
  (`graq mcp serve` + a `graq_*` command walkthrough + the `/graq` slash command).

### Verification
- Both scripts run **green from a clean `pip install graqle==0.59.0`** (use case exits
  0; dogfood prints 10/10).
- **ruff clean** on both scripts + the README.

### Notes
- Net-new example files using only the public API — **zero trade-secret content** (safe
  for public). Following ABSOLUTE RULE #0: private PR first → merge → public cherry-pick.
- Does not change any shipped module or the package version (docs/examples only).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
