### PR TITLE
docs(README): dual-surface positioning (build-time + run-time governance substrate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,32 @@ A **governance-led multi-agent reasoning system for code.** Scan any codebase in
 
 ---
 
+## Two surfaces, one substrate — govern how your AI is *built*, and what it *decides*
+
+GraQle is an EU AI Act–aligned governance substrate with **two deployment surfaces** on the
+same engine (knowledge graph → governed trace → RFC 6962 Merkle → ed25519 → Sigstore Rekor):
+
+| | **Build-time** (author surface) | **Run-time** (production surface) |
+|---|---|---|
+| Governs | how your AI **writes code** | what your deployed AI **decides** |
+| Trigger | a code change | a production decision (loan, hiring, triage, …) |
+| Emits | reviewed, impact-analysed, audit-logged changes | a tamper-evident, third-party-verifiable record per decision |
+| Status | **GA** | **substrate GA in v0.59.0**; capture middleware on the roadmap (see ADR-221) |
+
+**Run-time, today (v0.59.0):** every governed decision your deployed system makes can be
+canonicalised (RFC 8785), committed to a Merkle batch (RFC 6962), ed25519-signed, and
+anchored to the public Sigstore Rekor transparency log — so **anyone can detect tampering
+of an audit record with no access to your infrastructure**. The batcher adds 0 ms to the
+write path (commit is asynchronous). A runnable, end-to-end walkthrough on a real use case
+(a loan decision → lock → Merkle → sign → anchor → auditor verifies → tamper detected →
+key revoked) ships in [`examples/`](./examples/v059_cryptographic_governance_usecase.py).
+
+> Build-time governance proves *we hold ourselves to this standard* — GraQle is developed
+> through its own governance. Run-time governance lets you hold *your deployed AI* to the
+> same cryptographically-verifiable standard. Same substrate, both surfaces.
+
+---
+
 ## 90-second proof
 
 ```bash


### PR DESCRIPTION
## docs(README): dual-surface positioning — GraQle as a build-time + run-time governance substrate

Repositions GraQle publicly to show **both deployment surfaces** on one engine, per
**ADR-221** (Runtime Governance Layer):

- **Build-time** (author surface) — govern how your AI writes code. **GA.**
- **Run-time** (production surface) — cryptographically prove what your deployed AI
  decides. **Substrate GA in v0.59.0**; capture middleware on the roadmap.

### Change
A single additive section, "Two surfaces, one substrate", inserted after "What is GraQle"
(before "90-second proof"). Includes the two-surface comparison table, the run-time-today
paragraph (RFC 8785 → RFC 6962 → ed25519 → Sigstore Rekor, 0ms write-path), and a link to
the runnable `examples/v059_cryptographic_governance_usecase.py` demo.

### Why it's safe (marketing/IP governance)
- **Additive only** — the hero, the EU-AI-Act article-by-article table, the canonical
  positioning markers, the two NOT-claims, and the shields.io badge URL are **untouched**.
- **README snapshot-lock (CG-MKT-05): 8/8 pass** — verified locally.
- **Zero forbidden marketing words** added (`compliant`/`certified`/`guaranteed`/
  `end-to-end solution` — none used; only the permitted "aligned" register).
- **Honest status labels** — run-time middleware is explicitly marked roadmap; only the
  cryptographic substrate + Mode A (explicit `attest()`) are claimed GA. No overclaiming.

### Companion (not in this PR)
- **ADR-221** (`.gsm/decisions/ADR-221-runtime-governance-layer-production-substrate.md`) —
  full feasibility + detailed design + technical base + R0–R5 phasing for the runtime layer.
  Lives in the GSM strategy store, not the SDK repo.

Docs-only; no code or version change.

> **Merge note:** the new section links to `examples/v059_cryptographic_governance_usecase.py`,
> which lands on public master via the examples PR (#166). Merge #166 first (or together)
> so the relative link resolves; no CI gate depends on it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
