### PR TITLE
fix(tests): catch typer.Exit (not click.exceptions.Exit) for cross-version robustness

### DIFF
--- a/tests/test_cli/test_govern_serve.py
+++ b/tests/test_cli/test_govern_serve.py
@@ -283,13 +283,17 @@ class TestCliSurface:
 
 class TestBuildWorkerConfigPaths:
     def test_build_worker_yaml_parse_error_exits_1(self, tmp_path):
-        import click
+        import typer
 
         from graqle.cli.commands.govern_serve import _build_worker
 
         bad = tmp_path / "graqle.yaml"
         bad.write_text("graph: [unclosed\n", encoding="utf-8")
-        with pytest.raises(click.exceptions.Exit) as exc:
+        # Catch typer.Exit (the production code raises this); newer typer versions
+        # vendor a separate `typer._click.exceptions.Exit` that isn't always identity-
+        # equal to `click.exceptions.Exit`, so use the production-facing class for
+        # cross-version robustness.
+        with pytest.raises(typer.Exit) as exc:
             _build_worker(str(bad))
         assert exc.value.exit_code == 1
 
@@ -297,7 +301,7 @@ class TestBuildWorkerConfigPaths:
         """attestation.security.fail_open_on_anchor_error=true triggers the worker's
         fail-closed precondition (via the _WorkerConfigView); CLI converts the
         WorkerError to a clean exit 1."""
-        import click
+        import typer
 
         from graqle.cli.commands.govern_serve import _build_worker
 
@@ -309,7 +313,9 @@ class TestBuildWorkerConfigPaths:
             "  security:\n    fail_open_on_anchor_error: true\n",
             encoding="utf-8",
         )
-        with pytest.raises(click.exceptions.Exit) as exc:
+        # Catch typer.Exit (production code), not click.exceptions.Exit — see the
+        # parallel test above for the cross-version rationale.
+        with pytest.raises(typer.Exit) as exc:
             _build_worker(str(cfg))
         assert exc.value.exit_code == 1
 


### PR DESCRIPTION
## fix(tests): catch `typer.Exit` (not `click.exceptions.Exit`) for cross-version robustness

**Hotfix on v0.62.0** — master CI on the **public** repo went red immediately after
merging the v0.62.0 release PR. **2 tests fail on Linux/Python 3.11**:

```
FAILED tests/test_cli/test_govern_serve.py::TestBuildWorkerConfigPaths::test_build_worker_yaml_parse_error_exits_1
  typer._click.exceptions.Exit: 1  (escaped pytest.raises)
FAILED tests/test_cli/test_govern_serve.py::TestBuildWorkerConfigPaths::test_build_worker_fail_open_misconfig_exits_1
  typer._click.exceptions.Exit: 1  (same)
```

### Root cause
Newer typer versions vendor a separate `typer._click.exceptions.Exit` (which
`typer.Exit` re-exports). The two are subclass-related but not always
identity-equal in `pytest.raises` matching on every typer build. On Windows
locally I had an older typer where the two paths aliased, so it passed. On
Linux CI the vendored vs upstream split surfaces and the test catch class no
longer matches.

### Fix
Catch `typer.Exit` (what `govern_serve.py` actually raises in production).
Works across every typer version we ship to.

### Touched
- `tests/test_cli/test_govern_serve.py` only (2 test methods). **Test-only change.**
- **NO production behaviour change.**
- **NO version bump** — this lands as a follow-up commit on v0.62.0 source. The
  tag still points at the (now-fixed) head once this and its public cherry-pick merge.

### Verified locally
- `pytest tests/test_cli/test_govern_serve.py` → 38 passed, 1 skipped (Windows
  SIGTERM, expected).
- `ruff check` → clean.

### After this merges
1. Cherry-pick to public master
2. Public PR → user merges
3. Wait for public master CI green
4. Tag `v0.62.0` on the now-green public master HEAD → PyPI publish via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)
