### PR TITLE
release: v0.62.1 — docs-only patch to refresh PyPI rendered description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## 0.62.1 (2026-05-27) — [docs-only: README v0.62.0 positioning rework on PyPI surface]
+
+> **Doc-only patch.** Functionally byte-identical to v0.62.0 — no production code, no
+> tests, no dependencies changed. Ships only to refresh the PyPI rendered description
+> with the v0.62.0 positioning rework that already landed on GitHub master (PR #174).
+> Updates: dev-first hero, runtime governance surfaced on top fold, `graqle govern serve`
+> + `graqle govern health` quickstart, new Article 72 row in EU AI Act table, "Independently
+> verifiable" callout, open-core pricing direction, all three patent numbers listed.
+> Trade-secret discipline locked: CI `ip_content_scan.py` PASS + 11-pattern custom scan
+> 0 violations + graq_predict combinatorial-disclosure mitigation applied.
+
+### Changed
+- `README.md` only (+140 / −135 lines, 287 → 292) — see PR #174 for full diff.
+
+### Verifiable
+- `pip install graqle==0.62.1 && pip show graqle` → version 0.62.1
+- `pip install graqle==0.62.1 && python -c "import graqle; print(graqle.__version__)"` → 0.62.1
+- All v0.62.0 surfaces (`govern serve`, `govern health`, `attest`, `@governed`, Layer 5) byte-identical.
+
+---
+
 ## 0.62.0 (2026-05-26) — [Runtime Governance Layer (R2): the anchoring worker turns Layer 5 into a continuously, publicly verifiable production audit trail]
 
 > **The "verifiable in production" story is now end-to-end shippable.** v0.59.0 shipped

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.62.0"
+__version__ = "0.62.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.62.0"
+version = "0.62.1"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Proprietary — see LICENSE"}


### PR DESCRIPTION
# release: v0.62.1 — docs-only patch to refresh PyPI rendered description

Cherry-pick of private PR [#158](https://github.com/quantamixsol/research-development-graqle/pull/158) (merged 2026-05-27 as `f56b5190`).

## TL;DR
Bumps `0.62.0` → `0.62.1`. **NO production code change, NO test change, NO dependency change.** Functionally byte-identical to v0.62.0. This patch ships ONLY to refresh PyPI's rendered description with the v0.62.0 positioning rework that already landed on this branch via PR #174 (merged `c5bd1655`).

## Why this is needed
PyPI bakes the `long_description` into the wheel at publish time. It does NOT pull README updates from GitHub master. To update the rendered description at https://pypi.org/project/graqle/, a new tagged release must publish through OIDC.

## What v0.62.0 → v0.62.1 changes
3 files in this PR:

| File | Change |
|---|---|
| `pyproject.toml` | `version = "0.62.0"` → `"0.62.1"` |
| `graqle/__version__.py` | `__version__ = "0.62.0"` → `"0.62.1"` |
| `CHANGELOG.md` | New `## 0.62.1` entry above `## 0.62.0` |

`README.md` is unchanged in this PR — already updated via PR #174 on this branch.

## Verifiability post-publish
- `pip install graqle==0.62.1 && python -c "import graqle; print(graqle.__version__)"` → `0.62.1`
- https://pypi.org/project/graqle/0.62.1/ — rendered description matches GitHub master README
- All v0.62.0 surfaces byte-identical:
  - `graqle govern serve --help` — unchanged
  - `graqle govern health --help` — unchanged
  - `GovernedRuntime.attest(...)` — unchanged
  - `@governed` FastAPI middleware — unchanged
  - Layer 5 substrate — unchanged

## After this merges
1. Tag `v0.62.1` on the green public master HEAD
2. PyPI OIDC publish fires automatically
3. Verify rendered description on pypi.org/project/graqle/0.62.1/
4. Dogfood from clean v0.62.1 wheel

🤖 Generated with [Claude Code](https://claude.com/claude-code)
