### PR TITLE
v0.63.0: end-to-end auto-grow — grow embeds + writes the live backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,54 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## 0.63.0 (2026-05-31) — [End-to-End Auto-Grow Loop]
+
+> `graq grow` now **embeds** new chunks and **writes the backend your graph
+> actually reads from** (local JSON or Neo4j), so newly committed/saved code is
+> queryable by reasoning within seconds — delivering the "the graph grows with
+> every commit" promise. Embedding is incremental (only changed nodes), on by
+> default, and degrades quietly in CI/mock environments. Three triggers (CLI,
+> git hook, MCP background watcher) funnel through one fixed code path. No
+> breaking changes to the `graq grow` CLI surface. See
+> `docs/auto-grow-end-to-end.md` and ADR-213. Shared-team / Aura sync is
+> deferred to a later release (investigation-first).
+
+### Added
+- `graq grow --embed/--no-embed` (default **on**) — embeds the chunks of changed
+  nodes so they're queryable by `graq reason`. `--no-embed` reproduces the
+  pre-0.63 structure-only behaviour.
+- `graq grow --backend auto|local|neo4j` (default **auto**, derived from
+  `graph.connector`) — writes the resolved backend; Neo4j gets node/edge +
+  embedded-chunk writes, local gets `graqle.json` + a refreshed embedding cache.
+- `ChunkScorer.update_cache_incremental(graph, changed_node_ids)` — incremental
+  embedding cache update (boolean-mask drop of changed rows, embed only the
+  delta, atomic write) with NPZ↔graph drift detection + full-rebuild self-heal.
+  Avoids re-embedding the entire graph on every grow.
+- MCP background auto-grow watcher (`graqle[watch]` optional extra) — shells
+  `graq grow --embed` on debounced filesystem events so IDE saves keep the graph
+  current between commits. Tunable via `GRAQLE_DISABLE_BACKGROUND_GROW`,
+  `GRAQLE_BG_GROW_DEBOUNCE`, `GRAQLE_BG_GROW_RATE_LIMIT`. Degrades to disabled if
+  `watchdog` is absent.
+- `docs/auto-grow-end-to-end.md` — the 3-layer auto-grow guide.
+
+### Changed
+- `graq init`'s installed `post-commit` hook now runs `graq grow --embed` and
+  **surfaces errors** instead of the previous `(graq grow --quiet 2>/dev/null &)`
+  (which silently swallowed embedding/backend/config errors — the same
+  silent-fail anti-pattern addressed by ADR-212). The hook still never blocks a
+  commit.
+
+### Security
+- Sensitive (SECRET+) chunk content is redacted before any embedding call on
+  BOTH the local and Neo4j paths (R-SEC-1), reusing the existing content gate.
+
+### Notes
+- Fully backwards compatible: existing `graq grow` callers get embedding on by
+  default with no CLI surface change. The `graqle.json` node/edge serialization
+  is unchanged.
+
+---
+
 ## 0.62.3 (2026-05-30) — [HOTFIX: structural activation schema split]
 
 > **Hotfix.** Eliminates a class of silent misconfiguration that caused

--- a/docs/auto-grow-end-to-end.md
+++ b/docs/auto-grow-end-to-end.md
@@ -1,0 +1,122 @@
+# End-to-End Auto-Grow (v0.63.0)
+
+> Keep your knowledge graph current — and queryable — as you work, not just
+> when you remember to rebuild it.
+
+GraQle's promise is that the graph adapts and grows with your code. As of
+v0.63.0, `graq grow` does the full job: it scans your changes, **embeds the new
+chunks**, and **writes them to the backend your graph actually reads from**
+(local JSON or Neo4j). That means new code is queryable by `graq reason` within
+seconds of a change — not just present in a file on disk.
+
+## The one command
+
+```bash
+graq grow                 # incremental scan + embed + write configured backend
+graq grow --no-embed      # legacy behaviour: structure only, no embedding
+graq grow --backend neo4j # force a backend (default: auto, from graqle.yaml)
+graq grow --full          # full rescan + full re-embed (slower; rarely needed)
+```
+
+`--embed` is **on by default**. Embedding is **incremental** — only the nodes
+that changed in this grow are re-embedded, so a typical commit stays fast even
+on a large graph. Pass `--no-embed` to reproduce the pre-v0.63 behaviour.
+
+## Three ways the graph stays current
+
+All three funnel through the same `graq grow --embed` path — there is one
+implementation, three triggers:
+
+| Trigger | When it fires | How |
+|---|---|---|
+| **CLI** | You run it | `graq grow` |
+| **Git hook** | Every `git commit` | post-commit hook (installed by `graq init`) |
+| **MCP watcher** | You save a file in your IDE (no commit needed) | background watcher in the MCP server |
+
+### 1. CLI — manual
+
+Run `graq grow` whenever you want. Useful after a bulk change or to verify the
+loop is working.
+
+### 2. Git hook — on every commit
+
+`graq init` installs a `post-commit` hook that runs `graq grow --embed` after
+each commit. Errors are surfaced (the hook does **not** swallow them) but never
+block a commit that has already happened. To install or refresh it on an
+existing project, re-run `graq init`, or drop this in `.git/hooks/post-commit`
+and `chmod +x` it:
+
+```sh
+#!/bin/sh
+graq grow --embed
+status=$?
+if [ $status -ne 0 ]; then
+  echo "[graqle post-commit] graq grow exited $status — commit landed, KG NOT updated." >&2
+  echo "[graqle post-commit] Investigate with 'graq doctor' or re-run 'graq grow --embed'." >&2
+fi
+exit 0
+```
+
+### 3. MCP background watcher — on every save
+
+When the GraQle MCP server is running, it can watch your project tree and run
+`graq grow --embed` automatically a few seconds after you save a file — so the
+graph is current even between commits. Install the optional dependency:
+
+```bash
+pip install 'graqle[watch]'
+```
+
+Tunable via environment variables (all optional):
+
+| Variable | Default | Effect |
+|---|---|---|
+| `GRAQLE_DISABLE_BACKGROUND_GROW` | `0` | set to `1` to turn the watcher off |
+| `GRAQLE_BG_GROW_DEBOUNCE` | `5` | seconds to batch saves before growing |
+| `GRAQLE_BG_GROW_RATE_LIMIT` | (sensible default) | caps embedding work per hour |
+
+If `watchdog` isn't installed, the watcher simply stays disabled — nothing
+breaks.
+
+## Backends
+
+`--backend auto` (the default) reads `graph.connector` from your `graqle.yaml`:
+
+- **local** (default) — updates `graqle.json` and refreshes the local embedding
+  cache under `.graqle/`.
+- **neo4j** — writes nodes, edges, and embedded chunks to your Neo4j instance,
+  and still updates `graqle.json` as a local mirror.
+
+If a Neo4j backend is selected but unreachable, `grow` logs that clearly and
+falls back to writing `graqle.json` so your work is never lost; it reconciles on
+the next successful run.
+
+## Safety
+
+- **Secrets are never embedded.** Content classified as sensitive is redacted
+  before any embedding call, on both the local and Neo4j paths.
+- **Failures are visible, not silent.** If embedding or a backend write fails,
+  you see a clear message — `grow` does not hide errors behind `--quiet` or
+  `2>/dev/null`.
+- **The graph file shape is unchanged.** Embedding output is stored alongside
+  (a local cache file / Neo4j chunk records), never by altering your
+  `graqle.json` node/edge format.
+
+## Teams (coming in a later release)
+
+A shared graph kept in sync across several developers in near-real-time is a
+larger problem than a single-developer auto-grow loop, and it's being designed
+separately. For now, each developer's auto-grow keeps **their** graph current;
+team-wide shared-graph sync is on the roadmap.
+
+## Verify it's working
+
+After editing a file that defines a new function `X` and letting a grow run
+(commit, save, or `graq grow`):
+
+```bash
+graq run "what does X do?"
+```
+
+`X` should appear in the activated nodes within a minute. If it doesn't, run
+`graq doctor` and check the grow output for errors.

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.62.3"
+__version__ = "0.63.0"

--- a/graqle/activation/chunk_scorer.py
+++ b/graqle/activation/chunk_scorer.py
@@ -232,6 +232,287 @@ class ChunkScorer:
             len(desc_keys),
         )
 
+    @staticmethod
+    def _redact_texts_for_embedding(texts: list[str]) -> list[str]:
+        """Apply the G4 ContentSecurityGate to a batch of texts before embedding.
+
+        Mirrors build_cache's redaction (R-SEC-1): SECRET+ content is replaced
+        with the non-empty sentinel "[CONTENT_REDACTED]" (prevents Titan V2 400
+        on empty input + NaN cosine); INTERNAL and below is redacted in place.
+        Fail-CLOSED: if classification raises, the text is treated as sensitive.
+        """
+        from graqle.security.content_gate import ContentSecurityGate
+        from graqle.security.sensitivity import SensitivityClassifier, SensitivityLevel
+
+        gate = ContentSecurityGate()
+        classifier = SensitivityClassifier()
+        out: list[str] = []
+        for t in texts:
+            try:
+                level = classifier.classify_node({}, description=t)
+                if level >= SensitivityLevel.SECRET:
+                    out.append("[CONTENT_REDACTED]")
+                else:
+                    out.append(gate.redact_for_embedding(t))
+            except Exception:
+                # Fail-closed: never let a classification error leak raw content.
+                out.append("[CONTENT_REDACTED]")
+        return out
+
+    def update_cache_incremental(
+        self, graph: Any, changed_node_ids: set[str]
+    ) -> dict[str, int]:
+        """Incrementally refresh the embedding cache for changed nodes only.
+
+        v0.63.0 (BLOCKER-1 fix): rebuilding the full .npz on every `graq grow`
+        re-embeds the entire graph (64K+ nodes). This method embeds ONLY the
+        chunks/descriptions of ``changed_node_ids``, drops their stale cache
+        rows via a boolean mask, concatenates, and writes atomically.
+
+        Self-heals on drift: if the resulting cache key-set diverges from the
+        graph's expected key-set beyond the applied delta, it falls back to a
+        full ``build_cache`` rebuild (correctness backstop).
+
+        Args:
+            graph: the loaded Graqle graph (has ``.nodes`` mapping).
+            changed_node_ids: node ids whose chunks/desc must be re-embedded.
+
+        Returns:
+            {"reembedded_nodes", "reembedded_chunks", "reembedded_descs",
+             "rebuilt_full"} counts for logging/telemetry.
+        """
+        cache_path = Path(".graqle/chunk_embeddings.npz")
+
+        # No cache yet (first grow) OR empty delta → defer to full build.
+        if not cache_path.exists():
+            self.build_cache(graph)
+            return {
+                "reembedded_nodes": len(changed_node_ids),
+                "reembedded_chunks": len(self._chunk_keys),
+                "reembedded_descs": len(self._desc_keys),
+                "rebuilt_full": 1,
+            }
+        if not changed_node_ids:
+            return {"reembedded_nodes": 0, "reembedded_chunks": 0,
+                    "reembedded_descs": 0, "rebuilt_full": 0}
+
+        # ── Load existing cache ──────────────────────────────────────────
+        # NOTE: np.load returns a lazy NpzFile that keeps the underlying file
+        # OPEN on Windows — that handle blocks the later os.replace onto the
+        # same path (WinError 5). We eagerly copy every array out and close the
+        # NpzFile before doing any writing.
+        try:
+            with np.load(str(cache_path), allow_pickle=True) as data:
+                old_chunk_keys = list(data["chunk_keys"])
+                old_chunk_node_ids = list(data["chunk_node_ids"])
+                old_chunk_matrix = np.array(data["chunk_matrix"])
+                old_desc_keys = (
+                    list(data["desc_keys"]) if "desc_keys" in data else []
+                )
+                old_desc_matrix = (
+                    np.array(data["desc_matrix"]) if "desc_matrix" in data
+                    else np.empty((0, 0))
+                )
+        except Exception as e:
+            # Corrupt/unreadable cache → full rebuild (self-heal).
+            logger.warning("Embedding cache unreadable (%s) — full rebuild", e)
+            self.build_cache(graph)
+            return {"reembedded_nodes": len(changed_node_ids),
+                    "reembedded_chunks": len(self._chunk_keys),
+                    "reembedded_descs": len(self._desc_keys), "rebuilt_full": 1}
+
+        changed = set(changed_node_ids)
+
+        # ── Drop stale rows for changed nodes (boolean mask) ─────────────
+        if old_chunk_node_ids:
+            keep_chunk = np.array(
+                [nid not in changed for nid in old_chunk_node_ids], dtype=bool
+            )
+            kept_chunk_keys = [k for k, m in zip(old_chunk_keys, keep_chunk) if m]
+            kept_chunk_node_ids = [
+                n for n, m in zip(old_chunk_node_ids, keep_chunk) if m
+            ]
+            kept_chunk_matrix = (
+                old_chunk_matrix[keep_chunk]
+                if old_chunk_matrix.size else old_chunk_matrix
+            )
+        else:
+            kept_chunk_keys, kept_chunk_node_ids = [], []
+            kept_chunk_matrix = old_chunk_matrix
+
+        if old_desc_keys:
+            keep_desc = np.array(
+                [nid not in changed for nid in old_desc_keys], dtype=bool
+            )
+            kept_desc_keys = [k for k, m in zip(old_desc_keys, keep_desc) if m]
+            kept_desc_matrix = (
+                old_desc_matrix[keep_desc]
+                if old_desc_matrix.size else old_desc_matrix
+            )
+        else:
+            kept_desc_keys = []
+            kept_desc_matrix = old_desc_matrix
+
+        # ── Collect new texts for changed nodes (mirror build_cache) ─────
+        new_chunk_keys: list[str] = []
+        new_chunk_node_ids: list[str] = []
+        new_chunk_texts: list[str] = []
+        new_desc_keys: list[str] = []
+        new_desc_texts: list[str] = []
+
+        for node_id in changed:
+            node = graph.nodes.get(node_id)
+            if node is None:
+                continue  # node deleted — its rows already dropped, nothing re-added
+            chunks = node.properties.get("chunks", [])
+            if not chunks:
+                desc_text = f"{node.label} {node.entity_type} {node.description}"
+                new_desc_keys.append(node_id)
+                new_desc_texts.append(desc_text)
+                continue
+            for idx, chunk in enumerate(chunks):
+                if isinstance(chunk, dict):
+                    text = chunk.get("text", "")
+                    chunk_type = chunk.get("type", "")
+                elif isinstance(chunk, str):
+                    text, chunk_type = chunk, ""
+                else:
+                    continue
+                if not text or len(text.strip()) < 10:
+                    continue
+                new_chunk_keys.append(f"{node_id}::{idx}")
+                new_chunk_node_ids.append(node_id)
+                new_chunk_texts.append(f"{node.label} {chunk_type}: {text}")
+
+        # ── Redact + embed ONLY the new texts (R-SEC-1) ──────────────────
+        new_chunk_texts = self._redact_texts_for_embedding(new_chunk_texts)
+        new_desc_texts = self._redact_texts_for_embedding(new_desc_texts)
+
+        new_chunk_vecs = [self.embedding_engine.embed(t) for t in new_chunk_texts]
+        new_desc_vecs = [self.embedding_engine.embed(t) for t in new_desc_texts]
+
+        # ── Concatenate kept + new (dimension-safe) ──────────────────────
+        chunk_keys = list(kept_chunk_keys) + new_chunk_keys
+        chunk_node_ids = list(kept_chunk_node_ids) + new_chunk_node_ids
+        chunk_matrix = self._stack(kept_chunk_matrix, new_chunk_vecs)
+
+        desc_keys = list(kept_desc_keys) + new_desc_keys
+        desc_matrix = self._stack(kept_desc_matrix, new_desc_vecs)
+
+        # ── Drift check: expected key-set from graph vs cache key-set ─────
+        rebuilt_full = 0
+        if self._drift_detected(graph, set(chunk_keys), set(desc_keys)):
+            logger.warning(
+                "Embedding cache drift detected after incremental update "
+                "— self-healing with full rebuild"
+            )
+            self.build_cache(graph)
+            rebuilt_full = 1
+        else:
+            self._save_cache_atomic(
+                cache_path, chunk_keys, chunk_node_ids, chunk_matrix,
+                desc_keys, desc_matrix,
+            )
+            # Refresh in-memory state.
+            self._chunk_keys = chunk_keys
+            self._chunk_node_ids = chunk_node_ids
+            self._chunk_matrix = chunk_matrix
+            self._desc_keys = desc_keys
+            self._desc_matrix = desc_matrix
+            self._cache_loaded = True
+
+        logger.info(
+            "Incremental embed: %d node(s), +%d chunk(s), +%d desc(s)%s",
+            len(changed), len(new_chunk_keys), len(new_desc_keys),
+            " [full rebuild]" if rebuilt_full else "",
+        )
+        return {
+            "reembedded_nodes": len(changed),
+            "reembedded_chunks": len(new_chunk_keys),
+            "reembedded_descs": len(new_desc_keys),
+            "rebuilt_full": rebuilt_full,
+        }
+
+    @staticmethod
+    def _stack(kept_matrix: np.ndarray, new_vecs: list) -> np.ndarray:
+        """Concatenate a kept (N, dim) matrix with newly-embedded vectors."""
+        new_matrix = np.array(new_vecs) if new_vecs else np.empty((0, 0))
+        if kept_matrix.size and new_matrix.size:
+            return np.concatenate([kept_matrix, new_matrix], axis=0)
+        if kept_matrix.size:
+            return kept_matrix
+        return new_matrix
+
+    @staticmethod
+    def _expected_keys(graph: Any) -> tuple[set[str], set[str]]:
+        """Compute the chunk-key and desc-key sets the cache SHOULD contain."""
+        chunk_keys: set[str] = set()
+        desc_keys: set[str] = set()
+        for node_id, node in graph.nodes.items():
+            chunks = node.properties.get("chunks", [])
+            if not chunks:
+                desc_keys.add(node_id)
+                continue
+            for idx, chunk in enumerate(chunks):
+                if isinstance(chunk, dict):
+                    text = chunk.get("text", "")
+                elif isinstance(chunk, str):
+                    text = chunk
+                else:
+                    continue
+                if not text or len(text.strip()) < 10:
+                    continue
+                chunk_keys.add(f"{node_id}::{idx}")
+        return chunk_keys, desc_keys
+
+    def _drift_detected(
+        self, graph: Any, cache_chunk_keys: set[str], cache_desc_keys: set[str]
+    ) -> bool:
+        """True if the post-update cache key-set diverges from the graph."""
+        exp_chunk, exp_desc = self._expected_keys(graph)
+        return cache_chunk_keys != exp_chunk or cache_desc_keys != exp_desc
+
+    @staticmethod
+    def _save_cache_atomic(
+        cache_path: Path,
+        chunk_keys: list[str],
+        chunk_node_ids: list[str],
+        chunk_matrix: np.ndarray,
+        desc_keys: list[str],
+        desc_matrix: np.ndarray,
+    ) -> None:
+        """Write the npz via temp-file→rename so an interrupted grow is safe.
+
+        np.savez_compressed appends ".npz" to a path that lacks it, so we hand
+        it a base name (no .npz) and let it produce ``base.npz``, then atomically
+        os.replace that onto the final cache_path. We do NOT pre-create the temp
+        file (mkstemp + savez would leave an orphan empty file and trip a Windows
+        rename collision).
+        """
+        import os
+        import uuid
+
+        cache_path.parent.mkdir(exist_ok=True)
+        # Unique base name in the SAME dir (so os.replace is a same-volume rename).
+        tmp_base = str(cache_path.parent / f".chunk_embeddings.{uuid.uuid4().hex}.tmp")
+        tmp_npz = tmp_base + ".npz"
+        try:
+            np.savez_compressed(
+                tmp_base,
+                chunk_keys=np.array(chunk_keys, dtype=object),
+                chunk_node_ids=np.array(chunk_node_ids, dtype=object),
+                chunk_matrix=chunk_matrix,
+                desc_keys=np.array(desc_keys, dtype=object),
+                desc_matrix=desc_matrix,
+            )
+            os.replace(tmp_npz, str(cache_path))
+        finally:
+            if os.path.exists(tmp_npz):
+                try:
+                    os.remove(tmp_npz)
+                except OSError:
+                    pass
+
     def _score_cached(self, graph: Any, query: str) -> dict[str, float]:
         """Fast scoring using precomputed embedding cache."""
         query_embedding = self.embedding_engine.embed(query)

--- a/graqle/cli/commands/grow.py
+++ b/graqle/cli/commands/grow.py
@@ -182,6 +182,180 @@ def _incremental_scan(root: Path, changed_files: list[str]) -> tuple[list[dict],
     return nodes, edges
 
 
+def _resolve_backend(backend: str, config: str) -> str:
+    """Resolve the effective write backend.
+
+    'auto' derives from graqle.yaml graph.connector (neo4j -> 'neo4j', else
+    'local'). An explicit value is validated. Returns 'local' or 'neo4j'.
+    """
+    backend = (backend or "auto").lower()
+    if backend in ("local", "neo4j"):
+        return backend
+    if backend != "auto":
+        raise typer.BadParameter(
+            f"--backend must be auto|local|neo4j, got {backend!r}"
+        )
+    # auto: read graph.connector from config (best-effort; default local)
+    try:
+        from graqle.config.settings import GraqleConfig
+        cfg_path = Path(config)
+        if cfg_path.exists():
+            cfg = GraqleConfig.from_yaml(cfg_path)
+            connector = getattr(getattr(cfg, "graph", None), "connector", None)
+            if connector == "neo4j":
+                return "neo4j"
+    except Exception as exc:  # noqa: BLE001 — config read is best-effort
+        logger.info("Backend auto-resolve fell back to local (%s)", exc)
+    return "local"
+
+
+def _embed_local(graph_path: Path, changed_node_ids: set[str], quiet: bool) -> None:
+    """Incrementally embed changed nodes into .graqle/chunk_embeddings.npz.
+
+    Loud-on-real-error, quiet-on-expected-degradation (v0.63.0 §3.3a). Never
+    blocks the grow: embedding failure logs and returns.
+    """
+    try:
+        from graqle.activation.chunk_scorer import ChunkScorer
+        from graqle.core.graph import Graqle
+
+        graph = Graqle.from_json(str(graph_path))
+        scorer = ChunkScorer()
+        stats = scorer.update_cache_incremental(graph, changed_node_ids)
+        if not quiet:
+            console.print(
+                f"[dim]Embedded {stats['reembedded_nodes']} changed node(s): "
+                f"+{stats['reembedded_chunks']} chunk(s), "
+                f"+{stats['reembedded_descs']} desc(s)"
+                f"{' (full rebuild)' if stats.get('rebuilt_full') else ''}[/dim]"
+            )
+    except Exception as exc:  # noqa: BLE001
+        # Loud — the user must SEE embedding failed (anti-silent-fail guard).
+        logger.warning(
+            "Local embedding failed (%s: %s) — graph written but new nodes "
+            "are not yet queryable by semantic search. Re-run with --embed "
+            "once the cause is fixed.",
+            type(exc).__name__, exc,
+        )
+        if not quiet:
+            console.print(
+                f"[yellow]Embedding skipped: {type(exc).__name__}: {exc}[/yellow]"
+            )
+
+
+def _write_neo4j(
+    merged: dict[str, Any],
+    new_node_ids: set[str],
+    embed: bool,
+    config: str,
+    quiet: bool,
+) -> None:
+    """Write merged graph (and optionally embedded new chunks) to Neo4j.
+
+    Graceful-but-loud: if Neo4j is unreachable the caller still writes
+    graqle.json, so work is never lost. Connection-unavailable is logged
+    INFO once (not WARNING-per-grow) to avoid CI noise (§3.3a).
+    """
+    try:
+        from graqle.config.settings import GraqleConfig
+        from graqle.connectors.neo4j import Neo4jConnector
+
+        cfg_path = Path(config)
+        cfg = GraqleConfig.from_yaml(cfg_path) if cfg_path.exists() else None
+        graph_cfg = getattr(cfg, "graph", None) if cfg else None
+        # Only pass keys that are actually set so Neo4jConnector's own
+        # defaults (bolt://localhost:7687, user neo4j, db neo4j) apply when
+        # config is silent. Passing None would clobber those defaults.
+        conn_kwargs: dict[str, Any] = {}
+        for cfg_key, arg_key in (
+            ("uri", "uri"), ("username", "username"),
+            ("password", "password"), ("database", "database"),
+        ):
+            val = getattr(graph_cfg, cfg_key, None)
+            if val is not None:
+                conn_kwargs[arg_key] = val
+        connector = Neo4jConnector(**conn_kwargs)
+    except Exception as exc:  # noqa: BLE001
+        logger.info(
+            "Neo4j backend selected but connector unavailable (%s) — "
+            "wrote graqle.json only; new nodes not in Neo4j until reachable.",
+            exc,
+        )
+        return
+
+    # Build nodes/edges dicts keyed by id from the merged graph.
+    nodes = {n["id"]: n for n in merged.get("nodes", []) if "id" in n}
+    edges = {
+        e.get("id", f"{e['source']}->{e['target']}"): e
+        for e in merged.get("links", merged.get("edges", []))
+        if e.get("source") and e.get("target")
+    }
+    try:
+        connector.save(nodes, edges)
+    except Exception as exc:  # noqa: BLE001
+        logger.info(
+            "Neo4j write unavailable (%s) — wrote graqle.json only.", exc
+        )
+        return
+
+    if embed:
+        try:
+            embed_fn = _make_redacting_embed_fn()
+            chunks_by_node = _chunks_for_nodes(nodes, new_node_ids)
+            written = connector.save_chunks(chunks_by_node, embed_fn=embed_fn)
+            if not quiet:
+                console.print(f"[dim]Neo4j: +{written} embedded chunk(s)[/dim]")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Neo4j chunk embedding failed (%s: %s) — nodes/edges saved "
+                "but new chunks not embedded in Neo4j.",
+                type(exc).__name__, exc,
+            )
+
+
+def _chunks_for_nodes(
+    nodes: dict[str, Any], new_node_ids: set[str]
+) -> dict[str, list[dict]]:
+    """Build {node_id: [chunk-dicts]} for the new nodes, for save_chunks().
+
+    Falls back to a single description-chunk when a node has no explicit
+    chunks (mirrors build_cache's desc-only path).
+    """
+    out: dict[str, list[dict]] = {}
+    for nid in new_node_ids:
+        node = nodes.get(nid)
+        if node is None:
+            continue
+        props = node.get("properties", {}) if isinstance(node, dict) else {}
+        chunks = props.get("chunks") or []
+        if chunks:
+            out[nid] = [c for c in chunks if isinstance(c, (dict, str))]
+        else:
+            desc = node.get("description", "") if isinstance(node, dict) else ""
+            if desc:
+                out[nid] = [{"text": desc, "type": "description"}]
+    return out
+
+
+def _make_redacting_embed_fn():
+    """Return embed_fn(text) -> list[float] with R-SEC-1 redaction applied.
+
+    Wraps EmbeddingEngine.embed and routes text through the same G4 gate
+    used by ChunkScorer so SECRET+ content never reaches the embedding API.
+    """
+    from graqle.activation.chunk_scorer import ChunkScorer
+    from graqle.activation.embeddings import EmbeddingEngine
+
+    engine = EmbeddingEngine()
+
+    def embed_fn(text: str) -> list:
+        redacted = ChunkScorer._redact_texts_for_embedding([text])[0]
+        vec = engine.embed(redacted)
+        return vec.tolist() if hasattr(vec, "tolist") else list(vec)
+
+    return embed_fn
+
+
 def grow_command(
     quiet: bool = typer.Option(
         False, "--quiet", "-q", help="Suppress output (for git hooks)"
@@ -192,11 +366,22 @@ def grow_command(
     config: str = typer.Option(
         "graqle.yaml", "--config", "-c", help="Config file path"
     ),
+    embed: bool = typer.Option(
+        True, "--embed/--no-embed",
+        help="Embed new chunks so they're queryable by reasoning (default: on). "
+             "Incremental — only changed nodes are re-embedded.",
+    ),
+    backend: str = typer.Option(
+        "auto", "--backend",
+        help="Where to write the graph: auto (from graqle.yaml graph.connector) "
+             "| local (graqle.json) | neo4j",
+    ),
 ) -> None:
     """Incrementally update the knowledge graph.
 
     Called automatically by the git post-commit hook. Scans changed files,
-    re-ingests markdown KG sources, and merges into graqle.json.
+    re-ingests markdown KG sources, merges into graqle.json, embeds the new
+    chunks, and writes to the configured backend (local JSON or Neo4j).
 
     \b
     Auto (git hook):
@@ -205,6 +390,14 @@ def grow_command(
     \b
     Manual full rescan:
         graq grow --full
+
+    \b
+    Skip embedding (legacy v0.62.x behaviour):
+        graq grow --no-embed
+
+    \b
+    Force a specific backend:
+        graq grow --backend neo4j
     """
     root = Path(".").resolve()
     start = time.perf_counter()
@@ -283,10 +476,21 @@ def grow_command(
     merged = _merge_graphs(existing, new_nodes, new_links)
     stats = merged.pop("_merge_stats", {})
 
-    # Write (atomic: temp file + rename to prevent data loss on MemoryError)
+    # Write (atomic: temp file + rename to prevent data loss on MemoryError).
+    # The graqle.json serialization is byte-for-byte unchanged from v0.62.x
+    # (EG_15 guard) — embedding + Neo4j writes are sidecar/separate-store only.
     from graqle.core.graph import _write_with_lock
     content = json.dumps(merged, indent=2, default=str, ensure_ascii=False)
     _write_with_lock(str(graph_path), content)
+
+    # v0.63.0: embed new chunks + write configured backend so new code is
+    # actually queryable by reasoning (the end-to-end auto-grow fix).
+    new_node_ids = {n["id"] for n in new_nodes if isinstance(n, dict) and "id" in n}
+    resolved_backend = _resolve_backend(backend, config)
+    if resolved_backend == "neo4j":
+        _write_neo4j(merged, new_node_ids, embed=embed, config=config, quiet=quiet)
+    if embed and new_node_ids:
+        _embed_local(graph_path, new_node_ids, quiet=quiet)
 
     elapsed = time.perf_counter() - start
 

--- a/graqle/cli/commands/init.py
+++ b/graqle/cli/commands/init.py
@@ -2465,10 +2465,13 @@ def _write_gcc_structure(root: Path) -> bool:
 
 
 def _install_auto_grow_hook(root: Path) -> None:
-    """Install a git post-commit hook that auto-updates graqle.json.
+    """Install a git post-commit hook that auto-updates the knowledge graph.
 
     This is the core promise: the graph adapts and grows with every commit.
-    The hook runs `graq grow` which does an incremental scan + ingest.
+    The hook runs `graq grow --embed` which does an incremental scan + ingest
+    + embeds the changed chunks so the new code is queryable by reasoning
+    (v0.63.0). Embedding is incremental (changed nodes only) so the hook
+    stays fast enough to run inline.
     """
     git_dir = root / ".git"
     if not git_dir.is_dir():
@@ -2479,13 +2482,24 @@ def _install_auto_grow_hook(root: Path) -> None:
     hooks_dir.mkdir(exist_ok=True)
     hook_path = hooks_dir / "post-commit"
 
-    # The hook script
+    # The hook script (v0.63.0).
+    # IMPORTANT: this deliberately does NOT use `--quiet`, `2>/dev/null`, or a
+    # backgrounded `&` subshell. Those swallow embedding/Neo4j/config errors —
+    # the silent-fail anti-pattern that caused the v0.62.2 activation freeze
+    # (see ADR-212). Failures must be visible. The hook always exits 0 so it
+    # never blocks a commit that has already happened.
     hook_content = """#!/bin/sh
 # GraQle auto-grow hook — updates the knowledge graph on every commit.
 # Installed by `graq init`. Remove this file to disable.
+# Errors are surfaced (no --quiet, no 2>/dev/null) but never block the commit.
 
-# Run in background so commits aren't slowed down
-(graq grow --quiet 2>/dev/null &)
+graq grow --embed
+status=$?
+if [ $status -ne 0 ]; then
+  echo "[graqle post-commit] graq grow exited $status — commit landed, KG NOT updated." >&2
+  echo "[graqle post-commit] Investigate with 'graq doctor' or re-run 'graq grow --embed'." >&2
+fi
+exit 0
 """
 
     if hook_path.exists():

--- a/graqle/plugins/background_grow.py
+++ b/graqle/plugins/background_grow.py
@@ -1,0 +1,446 @@
+# ──────────────────────────────────────────────────────────────────
+# PATENT NOTICE — Quantamix Solutions B.V.
+#
+# This module implements methods covered by European Patent
+# Applications EP26162901.8 and EP26166054.2, owned by
+# Quantamix Solutions B.V.
+#
+# Use of this software is permitted under the graqle license.
+# Reimplementation of the patented methods outside this software
+# requires a separate patent license.
+#
+# Contact: legal@quantamix.io
+# ──────────────────────────────────────────────────────────────────
+
+"""Background filesystem watcher that auto-runs `graq grow`.
+
+v0.63.0 SPEC (.gsm/decisions/SPEC-v063-mcp-background-grow.md). Spawned by
+KogniDevServer (graqle.plugins.mcp_dev_server) at startup. Subscribes to OS
+file events via watchdog and debounces a batched `graq grow` invocation.
+
+Layered defense (covers gaps of the git post-commit hook):
+  - Git hook: fires ONLY on `git commit`. Misses IDE saves, AI agent writes,
+    branch switches, generated code, manual edits.
+  - This watcher: fires on EVERY filesystem event matching the watch pattern.
+
+Subprocess-based grow invocation (not in-process):
+  - Hung grow cannot deadlock the MCP server
+  - Bedrock errors / Neo4j errors / venv errors are captured in stderr and logged
+  - Subprocess gets its own Python interpreter (avoids re-entrant issues with
+    pydantic validators / graqle state)
+
+Configurable via env vars (all clamped to safe ranges at load time):
+  - GRAQLE_DISABLE_BACKGROUND_GROW  — set to "1" to disable
+  - GRAQLE_BG_GROW_DEBOUNCE         — debounce seconds, default 5.0, range [1, 300]
+  - GRAQLE_BG_GROW_RATE_LIMIT       — chunks/hour cap, default 1000, range [1, 10000]
+
+Security:
+  - subprocess.run([fixed list], shell=False); file paths NEVER passed as
+    subprocess args (watcher tracks them internally for telemetry only).
+  - Circuit breaker: 5 consecutive failures -> 5min DISABLED state with WARN.
+  - MAX_QUEUE_SIZE=10000 bounds memory under pathological burst loads.
+"""
+
+# ── graqle:intelligence ──
+# module: graqle.plugins.background_grow
+# risk: MEDIUM (new module, spawns daemon thread + subprocess from MCP server)
+# consumers: graqle.plugins.mcp_dev_server (KogniDevServer startup)
+# dependencies: __future__, logging, os, subprocess, sys, threading, time, collections, pathlib, typing
+# optional dependency: watchdog>=3.0,<5.0 (graceful degradation if missing)
+# constraints: subprocess shell=False (security); file paths never reach subprocess args (security); rate-limited Bedrock cost (cost); circuit-broken on persistent failure (reliability); queue-capped at 10000 events (memory)
+# ── /graqle:intelligence ──
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+import threading
+import time
+from collections import deque
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger("graqle.plugins.background_grow")
+
+# ─── Configuration (env vars, clamped at load) ─────────────────────────────
+
+
+def _clamped_float(env: str, default: float, lo: float, hi: float) -> float:
+    """Read env var as float, clamp to [lo, hi]. Log INFO if clamped."""
+    raw = os.environ.get(env)
+    if raw is None:
+        return default
+    try:
+        val = float(raw)
+    except ValueError:
+        logger.info(
+            "%s=%r is not a valid float; using default %s", env, raw, default
+        )
+        return default
+    clamped = max(lo, min(hi, val))
+    if clamped != val:
+        logger.info(
+            "%s=%s clamped to %s (valid range [%s, %s])",
+            env, val, clamped, lo, hi,
+        )
+    return clamped
+
+
+def _clamped_int(env: str, default: int, lo: int, hi: int) -> int:
+    """Read env var as int, clamp to [lo, hi]. Log INFO if clamped."""
+    raw = os.environ.get(env)
+    if raw is None:
+        return default
+    try:
+        val = int(raw)
+    except ValueError:
+        logger.info(
+            "%s=%r is not a valid int; using default %d", env, raw, default
+        )
+        return default
+    clamped = max(lo, min(hi, val))
+    if clamped != val:
+        logger.info(
+            "%s=%d clamped to %d (valid range [%d, %d])",
+            env, val, clamped, lo, hi,
+        )
+    return clamped
+
+
+DEBOUNCE_SECONDS = _clamped_float("GRAQLE_BG_GROW_DEBOUNCE", 5.0, 1.0, 300.0)
+MAX_CHUNKS_PER_HOUR = _clamped_int("GRAQLE_BG_GROW_RATE_LIMIT", 1000, 1, 10_000)
+DISABLED_ENV = "GRAQLE_DISABLE_BACKGROUND_GROW"
+
+# Hardcoded safety constants (not env-configurable — these are correctness, not knobs)
+MAX_QUEUE_SIZE = 10_000               # bounds memory under burst loads
+SUBPROCESS_TIMEOUT_SECONDS = 120.0    # kill hung grow processes
+CIRCUIT_BREAKER_THRESHOLD = 5         # consecutive failures before disable
+CIRCUIT_BREAKER_COOLDOWN = 300.0      # 5 minutes disabled after threshold
+DROP_WARN_INTERVAL = 60.0             # one drop-warning per minute (not per drop)
+COOLDOWN_WARN_INTERVAL = 60.0         # warn once per minute during cool-down
+
+# Watch only source files. Skip caches/builds/git internals to avoid event storm.
+WATCH_EXTENSIONS = {
+    ".py", ".ts", ".tsx", ".js", ".jsx", ".go", ".rs", ".java",
+    ".md", ".yaml", ".yml", ".json",
+}
+IGNORE_DIRS = {
+    ".git", "__pycache__", "node_modules", ".venv", "venv",
+    ".graqle", ".gcc", ".gsm", "dist", "build", ".pytest_cache",
+    ".mypy_cache", ".ruff_cache", "target",  # rust
+}
+
+
+# ─── Watcher class ─────────────────────────────────────────────────────────
+
+
+class BackgroundGrowWatcher:
+    """Filesystem watcher that triggers `graq grow` on debounced batches.
+
+    Lifecycle:
+        watcher = BackgroundGrowWatcher(Path("."))
+        if watcher.start():
+            ...  # MCP server lifetime
+            watcher.stop()  # optional; daemon=True dies with process anyway
+
+    Thread-safe: register/resolve operations are guarded by ``_lock``.
+    The debounce loop is a daemon thread (dies with the MCP server).
+    """
+
+    def __init__(
+        self,
+        project_root: Path,
+        python_executable: Optional[str] = None,
+    ) -> None:
+        self._root = Path(project_root).resolve()
+        self._py = python_executable or sys.executable
+        self._pending_events: deque = deque()
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._observer: Any = None  # watchdog Observer, created in start()
+
+        # Telemetry
+        self._growths_completed: int = 0
+        self._chunks_this_hour: int = 0
+        self._hour_start: float = time.monotonic()
+        self._last_drop_warn_ts: float = 0.0
+
+        # Circuit breaker state
+        self._consecutive_failures: int = 0
+        self._circuit_broken_until: float = 0.0  # monotonic timestamp
+        self._last_cooldown_warn_ts: float = 0.0
+
+    # ── lifecycle ──────────────────────────────────────────────────────────
+
+    def start(self) -> bool:
+        """Start the watcher. Returns False if disabled or watchdog missing.
+
+        Never raises — graceful degradation on every failure path. The MCP
+        server can call this unconditionally at startup.
+        """
+        if os.environ.get(DISABLED_ENV, "0") == "1":
+            logger.info(
+                "Background grow watcher disabled via %s=1", DISABLED_ENV
+            )
+            return False
+
+        try:
+            from watchdog.observers import Observer  # type: ignore[import-not-found]
+            from watchdog.events import FileSystemEventHandler  # type: ignore[import-not-found]
+        except ImportError:
+            logger.warning(
+                "Background grow watcher unavailable: watchdog not installed. "
+                "Install with: pip install 'graqle[watch]'  "
+                "(or: pip install watchdog>=3.0,<5.0)"
+            )
+            return False
+
+        class _Handler(FileSystemEventHandler):  # noqa: D106 - small inner class
+            def __init__(self, owner: "BackgroundGrowWatcher") -> None:
+                self._owner = owner
+
+            def on_any_event(self, event: Any) -> None:
+                if event.is_directory:
+                    return
+                try:
+                    p = Path(event.src_path)
+                except (TypeError, ValueError):
+                    return
+                if p.suffix not in WATCH_EXTENSIONS:
+                    return
+                if any(part in IGNORE_DIRS for part in p.parts):
+                    return
+                self._owner._enqueue(p)
+
+        try:
+            self._observer = Observer()
+            self._observer.schedule(_Handler(self), str(self._root), recursive=True)
+            self._observer.daemon = True
+            self._observer.start()
+        except Exception as exc:
+            logger.warning(
+                "Background grow watcher failed to start observer: %s: %s",
+                type(exc).__name__, exc,
+            )
+            return False
+
+        self._thread = threading.Thread(
+            target=self._debounce_loop_guarded,
+            name="graqle-bg-grow",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info(
+            "Background grow watcher started on %s "
+            "(debounce=%.1fs, rate_limit=%d chunks/h, queue_cap=%d, "
+            "circuit_breaker=%d failures/%ds cooldown)",
+            self._root, DEBOUNCE_SECONDS, MAX_CHUNKS_PER_HOUR,
+            MAX_QUEUE_SIZE, CIRCUIT_BREAKER_THRESHOLD, CIRCUIT_BREAKER_COOLDOWN,
+        )
+        return True
+
+    def stop(self) -> None:
+        """Signal the thread to stop. Best-effort; daemon=True dies anyway."""
+        self._stop_event.set()
+        if self._observer is not None:
+            try:
+                self._observer.stop()
+                self._observer.join(timeout=2.0)
+            except Exception:
+                pass  # nothing useful to do on stop failure
+        if self._thread is not None:
+            self._thread.join(timeout=DEBOUNCE_SECONDS + 1.0)
+
+    # ── queue management ───────────────────────────────────────────────────
+
+    def _enqueue(self, path: Path) -> None:
+        """Add a file event to the queue. Drops oldest if at MAX_QUEUE_SIZE."""
+        with self._lock:
+            if len(self._pending_events) >= MAX_QUEUE_SIZE:
+                now = time.monotonic()
+                if now - self._last_drop_warn_ts > DROP_WARN_INTERVAL:
+                    logger.warning(
+                        "Background grow queue full (%d events); dropping oldest. "
+                        "Consider increasing GRAQLE_BG_GROW_DEBOUNCE or "
+                        "investigating bulk file changes.",
+                        MAX_QUEUE_SIZE,
+                    )
+                    self._last_drop_warn_ts = now
+                self._pending_events.popleft()
+            self._pending_events.append((time.monotonic(), path))
+
+    def _drain_batch(self) -> list[Path]:
+        """Pop and dedupe everything in the queue. Returns sorted unique paths."""
+        with self._lock:
+            paths = {p for _ts, p in self._pending_events}
+            self._pending_events.clear()
+        return sorted(paths)
+
+    # ── rate limit ──────────────────────────────────────────────────────────
+
+    def _check_rate_limit(self, batch_size: int) -> bool:
+        """Hourly rate-limit gate. Returns True if OK to proceed."""
+        now = time.monotonic()
+        if now - self._hour_start >= 3600:
+            self._chunks_this_hour = 0
+            self._hour_start = now
+        if self._chunks_this_hour + batch_size > MAX_CHUNKS_PER_HOUR:
+            logger.warning(
+                "Background grow rate-limited: would exceed %d chunks/hour "
+                "(current=%d, batch=%d). Deferring this batch.",
+                MAX_CHUNKS_PER_HOUR, self._chunks_this_hour, batch_size,
+            )
+            return False
+        self._chunks_this_hour += batch_size
+        return True
+
+    # ── circuit breaker ────────────────────────────────────────────────────
+
+    def _circuit_open(self) -> bool:
+        """True iff circuit is currently OPEN (watcher should NOT call grow)."""
+        if self._consecutive_failures < CIRCUIT_BREAKER_THRESHOLD:
+            return False
+        now = time.monotonic()
+        if now < self._circuit_broken_until:
+            if now - self._last_cooldown_warn_ts > COOLDOWN_WARN_INTERVAL:
+                remaining = int(self._circuit_broken_until - now)
+                logger.warning(
+                    "Background grow circuit OPEN: %d consecutive failures, "
+                    "cooling down for %d more seconds.",
+                    self._consecutive_failures, remaining,
+                )
+                self._last_cooldown_warn_ts = now
+            return True
+        # Cooldown elapsed — close circuit and retry
+        logger.info(
+            "Background grow circuit cooldown elapsed; retrying after %d failures",
+            self._consecutive_failures,
+        )
+        return False
+
+    def _record_grow_outcome(self, success: bool) -> None:
+        if success:
+            if self._consecutive_failures > 0:
+                logger.info(
+                    "Background grow recovered after %d consecutive failures",
+                    self._consecutive_failures,
+                )
+            self._consecutive_failures = 0
+            self._circuit_broken_until = 0.0
+            return
+        self._consecutive_failures += 1
+        if self._consecutive_failures == CIRCUIT_BREAKER_THRESHOLD:
+            self._circuit_broken_until = time.monotonic() + CIRCUIT_BREAKER_COOLDOWN
+            logger.warning(
+                "Background grow circuit BREAKING: %d consecutive failures, "
+                "watcher disabled for %d seconds.",
+                CIRCUIT_BREAKER_THRESHOLD, int(CIRCUIT_BREAKER_COOLDOWN),
+            )
+
+    # ── debounce loop ──────────────────────────────────────────────────────
+
+    def _debounce_loop_guarded(self) -> None:
+        """Outer try/except wrapper so a thread crash is logged, not silent."""
+        try:
+            self._debounce_loop()
+        except Exception:
+            logger.exception(
+                "Background grow watcher thread crashed unexpectedly. "
+                "Watcher disabled until MCP server restarts."
+            )
+
+    def _debounce_loop(self) -> None:
+        """Pop the batch every DEBOUNCE_SECONDS and call `graq grow`."""
+        while not self._stop_event.wait(DEBOUNCE_SECONDS):
+            if self._circuit_open():
+                continue
+
+            batch = self._drain_batch()
+            if not batch:
+                continue
+
+            if not self._check_rate_limit(len(batch)):
+                # Put them back for next interval (within queue cap)
+                with self._lock:
+                    for p in batch:
+                        if len(self._pending_events) < MAX_QUEUE_SIZE:
+                            self._pending_events.append((time.monotonic(), p))
+                continue
+
+            logger.info(
+                "Background grow: %d file change(s) detected, running grow...",
+                len(batch),
+            )
+
+            success = self._run_grow_subprocess()
+            self._record_grow_outcome(success)
+
+    def _run_grow_subprocess(self) -> bool:
+        """Invoke `graq grow` in subprocess. Returns True on exit 0.
+
+        SECURITY: subprocess is invoked with a fixed argv list, shell=False.
+        File paths from the watcher are tracked internally for telemetry but
+        NEVER passed as subprocess arguments. ``graq grow`` does its own
+        change detection from the working directory.
+        """
+        try:
+            result = subprocess.run(  # noqa: S603 - safe: fixed argv, shell=False
+                # v0.63.0: --embed so background-grown nodes are queryable by
+                # reasoning (incremental embed; the end-to-end auto-grow fix).
+                [self._py, "-m", "graqle.cli.main", "grow", "--embed"],
+                cwd=str(self._root),
+                capture_output=True,
+                text=True,
+                timeout=SUBPROCESS_TIMEOUT_SECONDS,
+                shell=False,
+            )
+            self._growths_completed += 1
+            if result.returncode == 0:
+                logger.info(
+                    "Background grow OK: %s",
+                    (result.stdout or "").strip() or "(no output)",
+                )
+                return True
+            logger.error(
+                "Background grow FAILED (exit %d): %s",
+                result.returncode,
+                ((result.stderr or result.stdout) or "(no output)").strip(),
+            )
+            return False
+        except subprocess.TimeoutExpired:
+            logger.error(
+                "Background grow TIMEOUT after %.0fs", SUBPROCESS_TIMEOUT_SECONDS
+            )
+            return False
+        except FileNotFoundError as exc:
+            logger.error(
+                "Background grow EXEC FAILED: %s. Check python_executable=%r",
+                exc, self._py,
+            )
+            return False
+        except Exception as exc:
+            logger.error(
+                "Background grow EXCEPTION: %s: %s", type(exc).__name__, exc
+            )
+            return False
+
+    # ── telemetry ──────────────────────────────────────────────────────────
+
+    @property
+    def stats(self) -> dict:
+        """For graq_inspect / debug: return current watcher state."""
+        return {
+            "root": str(self._root),
+            "growths_completed": self._growths_completed,
+            "chunks_this_hour": self._chunks_this_hour,
+            "pending_events": len(self._pending_events),
+            "alive": self._thread is not None and self._thread.is_alive(),
+            "consecutive_failures": self._consecutive_failures,
+            "circuit_open": (
+                self._consecutive_failures >= CIRCUIT_BREAKER_THRESHOLD
+                and time.monotonic() < self._circuit_broken_until
+            ),
+        }

--- a/graqle/plugins/mcp_dev_server.py
+++ b/graqle/plugins/mcp_dev_server.py
@@ -3376,6 +3376,10 @@ class KogniDevServer:
         self._graph_file: str | None = None  # path to the loaded graph JSON
         self._graph_mtime: float = 0.0
         self._gov: Any = None  # GovernanceMiddleware, loaded lazily
+        # v0.63.0: MCP background filesystem watcher — auto-grow on file changes.
+        # Started once on first successful graph load; daemon thread, dies with
+        # MCP server. See SPEC-v063-l1l2l3-end-to-end.md + ADR-213.
+        self._bg_grow_watcher: Any = None
         self._neo4j_traversal: Any = None  # Neo4jTraversal, set when Neo4j active
         self._intent_learner: Any = None  # OnlineLearner, loaded lazily
         self._intent_ring_buffer: Any = None  # RingBuffer for dedup
@@ -3650,6 +3654,7 @@ class KogniDevServer:
                         len(self._graph.nodes),
                         len(self._graph.edges),
                     )
+                    self._maybe_start_background_grow()
                     return self._graph
                 except Exception as neo4j_exc:
                     logger.warning("Neo4j load failed (%s), falling back to JSON", neo4j_exc)
@@ -3673,6 +3678,7 @@ class KogniDevServer:
                         len(self._graph.edges),
                         candidate,
                     )
+                    self._maybe_start_background_grow()
                     return self._graph
 
             logger.warning("No graph file found in current directory")
@@ -3681,6 +3687,37 @@ class KogniDevServer:
         except Exception as exc:
             logger.error("Failed to load graph: %s", exc)
             return None
+
+    def _maybe_start_background_grow(self) -> None:
+        """Start the v0.63.0 background auto-grow watcher (once, best-effort).
+
+        Idempotent: only starts on the first call that succeeds. Guarded by
+        GRAQLE_DISABLE_BACKGROUND_GROW=1 and graceful when watchdog is absent.
+        Never raises — a watcher failure must not break graph load. The
+        watcher shells `graq grow --embed` on debounced filesystem events so
+        IDE saves (no commit) keep the graph queryable. See ADR-213.
+        """
+        # CG-01: os is intentionally NOT module-scoped here — import locally.
+        import os as _os
+        if getattr(self, "_bg_grow_watcher", None) is not None:
+            return  # already started
+        if _os.environ.get("GRAQLE_DISABLE_BACKGROUND_GROW", "0") == "1":
+            return
+        try:
+            from graqle.plugins.background_grow import BackgroundGrowWatcher
+
+            # Watch the directory that contains the graph file (project root).
+            if self._graph_file and not self._graph_file.startswith("neo4j://"):
+                watch_root = Path(self._graph_file).parent
+            else:
+                watch_root = Path.cwd()
+            watcher = BackgroundGrowWatcher(watch_root)
+            if watcher.start():
+                self._bg_grow_watcher = watcher
+                logger.info("Background auto-grow watcher started on %s", watch_root)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Background auto-grow watcher failed to start: %s", exc)
+            self._bg_grow_watcher = None
 
     def _load_graph(self) -> Any | None:
         """Thread-safe wrapper: waits for background load or loads synchronously.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.62.3"
+version = "0.63.0"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Proprietary — see LICENSE"}
@@ -75,6 +75,12 @@ cpu = [
 lite = []
 neo4j = [
     "neo4j>=5.0",
+]
+watch = [
+    # v0.63.0: enables MCP background filesystem watcher (auto-grow on file
+    # change). SPEC-v063-mcp-background-grow.md + ADR-213. Optional — the
+    # watcher gracefully degrades to "disabled" if watchdog is missing.
+    "watchdog>=3.0,<5.0",
 ]
 api = [
     "anthropic>=0.18",

--- a/tests/test_activation/test_incremental_embed.py
+++ b/tests/test_activation/test_incremental_embed.py
@@ -1,0 +1,229 @@
+"""Tests for ChunkScorer.update_cache_incremental — v0.63.0 BLOCKER-1 fix.
+
+The full build_cache re-embeds the entire graph (64K+ nodes); per-commit grow
+must embed ONLY the changed nodes. These tests pin that behaviour, the npz
+boolean-mask drop, edge cases (first grow, deleted node, empty delta),
+drift self-heal, atomic write, and R-SEC-1 redaction.
+
+V-CR-V063-WRITE-NATIVE-001: new test file in graqle-sdk/ — graq_write/generate
+hit the S-010 "path escapes project root" gate; native Write fallback per
+SENTINEL-v0623 + feedback_s010_write_path_only_and_graq_edit_gcc.
+"""
+
+# ── graqle:intelligence ──
+# module: tests.test_activation.test_incremental_embed
+# risk: LOW (impact radius: 0 modules)
+# dependencies: numpy, pytest, chunk_scorer
+# constraints: none
+# ── /graqle:intelligence ──
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from graqle.activation.chunk_scorer import ChunkScorer
+
+
+# ── deterministic stub engine (no Bedrock / no sentence-transformers) ──
+class _StubEngine:
+    """Returns a deterministic unit-ish vector per text; counts calls."""
+
+    def __init__(self):
+        self.calls: list[str] = []
+
+    def embed(self, text: str) -> np.ndarray:
+        self.calls.append(text)
+        # Deterministic 3-dim vector derived from the text hash.
+        h = abs(hash(text)) % 1000
+        return np.array([h / 1000.0, (h % 7) / 7.0, 1.0], dtype=float)
+
+
+def _make_node(nid, label, entity_type, description, chunks=None):
+    node = MagicMock()
+    node.id = nid
+    node.label = label
+    node.entity_type = entity_type
+    node.description = description
+    node.properties = {"chunks": chunks or []}
+    return node
+
+
+def _make_graph(nodes_dict):
+    graph = MagicMock()
+    graph.nodes = nodes_dict
+    return graph
+
+
+def _scorer():
+    s = ChunkScorer(embedding_engine=_StubEngine())
+    return s
+
+
+@pytest.fixture
+def in_tmp(tmp_path, monkeypatch):
+    """Run inside tmp_path so .graqle/chunk_embeddings.npz is isolated."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def _read_npz(path):
+    data = np.load(str(path), allow_pickle=True)
+    return {
+        "chunk_keys": list(data["chunk_keys"]),
+        "chunk_node_ids": list(data["chunk_node_ids"]),
+        "desc_keys": list(data["desc_keys"]),
+    }
+
+
+class TestIncrementalEmbed:
+    def test_EG16a_first_grow_no_cache_builds_full(self, in_tmp):
+        """No .npz yet → defers to full build_cache; rebuilt_full=1."""
+        g = _make_graph({
+            "a.py": _make_node("a.py", "a", "PythonModule", "module a",
+                               chunks=[{"type": "function", "text": "def foo(): return 1  # foo body"}]),
+        })
+        s = _scorer()
+        stats = s.update_cache_incremental(g, {"a.py"})
+        assert stats["rebuilt_full"] == 1
+        assert (in_tmp / ".graqle" / "chunk_embeddings.npz").exists()
+
+    def test_EG16b_empty_delta_is_noop(self, in_tmp):
+        """Empty changed set after a cache exists → no embedding work."""
+        g = _make_graph({
+            "a.py": _make_node("a.py", "a", "PythonModule", "module a",
+                               chunks=[{"type": "function", "text": "def foo(): return 1  # foo body"}]),
+        })
+        s = _scorer()
+        s.update_cache_incremental(g, {"a.py"})   # seed cache
+        s2 = _scorer()
+        stats = s2.update_cache_incremental(g, set())
+        assert stats == {"reembedded_nodes": 0, "reembedded_chunks": 0,
+                         "reembedded_descs": 0, "rebuilt_full": 0}
+        assert s2.embedding_engine.calls == []  # nothing embedded
+
+    def test_EG16_cost_scales_with_delta_not_graph(self, in_tmp):
+        """The core BLOCKER-1 guard: re-embedding ONE node of a 50-node graph
+        embeds ~1 node's chunks, not all 50."""
+        nodes = {
+            f"n{i}.py": _make_node(
+                f"n{i}.py", f"n{i}", "PythonModule", f"module {i}",
+                chunks=[{"type": "function", "text": f"def fn{i}(): return {i}  # body {i}"}],
+            )
+            for i in range(50)
+        }
+        g = _make_graph(nodes)
+        # Seed full cache (this embeds all 50 — expected, one-time).
+        ChunkScorer(embedding_engine=_StubEngine()).update_cache_incremental(g, set(nodes))
+        # Now change ONE node and incrementally update.
+        nodes["n7.py"].properties["chunks"] = [
+            {"type": "function", "text": "def fn7_v2(): return 777  # changed body"}
+        ]
+        s = _scorer()
+        s.update_cache_incremental(g, {"n7.py"})
+        # Only n7's single chunk should have been embedded — NOT 50.
+        assert len(s.embedding_engine.calls) == 1, s.embedding_engine.calls
+
+    def test_EG_boolean_mask_drops_only_changed(self, in_tmp):
+        nodes = {
+            "a.py": _make_node("a.py", "a", "PythonModule", "a",
+                               chunks=[{"type": "function", "text": "def a(): pass  # a body here"}]),
+            "b.py": _make_node("b.py", "b", "PythonModule", "b",
+                               chunks=[{"type": "function", "text": "def b(): pass  # b body here"}]),
+        }
+        g = _make_graph(nodes)
+        ChunkScorer(embedding_engine=_StubEngine()).update_cache_incremental(g, set(nodes))
+        # change only a.py
+        nodes["a.py"].properties["chunks"] = [
+            {"type": "function", "text": "def a_v2(): pass  # a changed body"}
+        ]
+        s = _scorer()
+        s.update_cache_incremental(g, {"a.py"})
+        npz = _read_npz(in_tmp / ".graqle" / "chunk_embeddings.npz")
+        # both nodes still present, no duplicates
+        assert set(npz["chunk_node_ids"]) == {"a.py", "b.py"}
+        assert len(npz["chunk_keys"]) == len(set(npz["chunk_keys"]))
+
+    def test_EG_deleted_node_drops_rows(self, in_tmp):
+        nodes = {
+            "a.py": _make_node("a.py", "a", "PythonModule", "a",
+                               chunks=[{"type": "function", "text": "def a(): pass  # a body here"}]),
+            "b.py": _make_node("b.py", "b", "PythonModule", "b",
+                               chunks=[{"type": "function", "text": "def b(): pass  # b body here"}]),
+        }
+        g = _make_graph(dict(nodes))
+        ChunkScorer(embedding_engine=_StubEngine()).update_cache_incremental(g, set(nodes))
+        # delete b.py from the graph, mark it changed
+        del g.nodes["b.py"]
+        s = _scorer()
+        s.update_cache_incremental(g, {"b.py"})
+        npz = _read_npz(in_tmp / ".graqle" / "chunk_embeddings.npz")
+        assert "b.py" not in npz["chunk_node_ids"]
+        assert "a.py" in npz["chunk_node_ids"]
+        assert s.embedding_engine.calls == []  # deleted node embeds nothing
+
+    def test_EG_desc_only_node_uses_desc_arrays(self, in_tmp):
+        """A node with no chunks is embedded into the desc_* arrays."""
+        nodes = {
+            "dir1": _make_node("dir1", "dir1", "Directory", "Directory: dir1", chunks=[]),
+        }
+        g = _make_graph(nodes)
+        s = _scorer()
+        s.update_cache_incremental(g, {"dir1"})  # first grow → full build
+        npz = _read_npz(in_tmp / ".graqle" / "chunk_embeddings.npz")
+        assert "dir1" in npz["desc_keys"]
+
+    def test_EG17_drift_self_heals(self, in_tmp):
+        """If the post-update key-set diverges from the graph, full rebuild fires."""
+        nodes = {
+            "a.py": _make_node("a.py", "a", "PythonModule", "a",
+                               chunks=[{"type": "function", "text": "def a(): pass  # a body here"}]),
+        }
+        g = _make_graph(nodes)
+        ChunkScorer(embedding_engine=_StubEngine()).update_cache_incremental(g, set(nodes))
+        s = _scorer()
+        # Force drift: make _drift_detected return True once.
+        calls = {"n": 0}
+        real = ChunkScorer.build_cache
+
+        def spy_build(self, graph):
+            calls["n"] += 1
+            return real(self, graph)
+
+        with patch.object(ChunkScorer, "_drift_detected", return_value=True), \
+             patch.object(ChunkScorer, "build_cache", spy_build):
+            stats = s.update_cache_incremental(g, {"a.py"})
+        assert stats["rebuilt_full"] == 1
+        assert calls["n"] == 1  # full rebuild was invoked
+
+    def test_EG10_rsec1_redacts_secret_chunks(self, in_tmp):
+        """R-SEC-1: SECRET+ chunk text never reaches the embedding engine."""
+        secret = "AWS_SECRET_ACCESS_KEY=" + "A" * 40
+        nodes = {
+            "s.py": _make_node("s.py", "s", "PythonModule", "s",
+                               chunks=[{"type": "code", "text": f"config = '{secret}'  # loaded at boot"}]),
+        }
+        g = _make_graph(nodes)
+        s = _scorer()
+        s.update_cache_incremental(g, {"s.py"})
+        # The raw 40-char secret must not appear verbatim in anything embedded.
+        assert all(secret not in t for t in s.embedding_engine.calls), \
+            "raw secret reached the embedding engine — R-SEC-1 violated"
+
+    def test_EG_atomic_write_no_tmp_leftover(self, in_tmp):
+        nodes = {
+            "a.py": _make_node("a.py", "a", "PythonModule", "a",
+                               chunks=[{"type": "function", "text": "def a(): pass  # a body here"}]),
+            "b.py": _make_node("b.py", "b", "PythonModule", "b",
+                               chunks=[{"type": "function", "text": "def b(): pass  # b body here"}]),
+        }
+        g = _make_graph(nodes)
+        ChunkScorer(embedding_engine=_StubEngine()).update_cache_incremental(g, set(nodes))
+        nodes["a.py"].properties["chunks"] = [
+            {"type": "function", "text": "def a_v2(): pass  # changed a body"}
+        ]
+        _scorer().update_cache_incremental(g, {"a.py"})
+        leftovers = list((in_tmp / ".graqle").glob("*.tmp*"))
+        assert leftovers == [], f"temp files left behind: {leftovers}"

--- a/tests/test_cli/test_grow_embed.py
+++ b/tests/test_cli/test_grow_embed.py
@@ -103,12 +103,31 @@ class TestRedactingEmbedFn:
 
 # ───────────────────── grow_command CLI surface ───────────────────────
 class TestGrowSurface:
-    def test_help_shows_embed_and_backend(self):
+    def test_help_exposes_embed_and_backend(self):
+        """The flags must be on the command. Assert against the registered
+        params, NOT the rendered Rich --help text: Rich wraps + ANSI-colours
+        the help in CI's narrow terminal, splitting '--embed' across a box
+        border so a substring match on result.output is flaky (passed locally,
+        failed in CI). The param signature is the source of truth.
+        """
+        import inspect
+
+        from graqle.cli.commands.grow import grow_command
+
+        params = inspect.signature(grow_command).parameters
+        assert "embed" in params, "grow_command must expose an `embed` option"
+        assert "backend" in params, "grow_command must expose a `backend` option"
+        # The param defaults are typer OptionInfo objects; the real default
+        # value is on .default of the OptionInfo.
+        embed_default = getattr(params["embed"].default, "default", params["embed"].default)
+        backend_default = getattr(params["backend"].default, "default", params["backend"].default)
+        assert embed_default is True   # --embed on by default
+        assert backend_default == "auto"
+
+    def test_help_renders_without_error(self):
         from graqle.cli.main import app
         result = runner.invoke(app, ["grow", "--help"])
         assert result.exit_code == 0
-        assert "--embed" in result.output or "--no-embed" in result.output
-        assert "--backend" in result.output
 
 
 # ───────────── grow_command integration (local, monkeypatched) ─────────

--- a/tests/test_cli/test_grow_embed.py
+++ b/tests/test_cli/test_grow_embed.py
@@ -1,0 +1,173 @@
+"""Tests for v0.63.0 `graq grow` end-to-end auto-grow: --embed / --backend.
+
+Covers backend resolution, the embed flag surface, degrade-quiet behaviour,
+the Neo4j write path (mocked), R-SEC-1 on the Neo4j embed_fn, and the
+graqle.json-shape-unchanged guard.
+
+V-CR-V063-WRITE-NATIVE-001: new test file in graqle-sdk/ — graq_write/generate
+hit S-010 "path escapes project root"; native Write fallback per SENTINEL-v0623.
+"""
+
+# ── graqle:intelligence ──
+# module: tests.test_cli.test_grow_embed
+# risk: LOW (impact radius: 0 modules)
+# dependencies: json, pytest, typer, grow
+# constraints: none
+# ── /graqle:intelligence ──
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from graqle.cli.commands import grow as grow_mod
+from graqle.cli.commands.grow import (
+    _chunks_for_nodes,
+    _make_redacting_embed_fn,
+    _resolve_backend,
+)
+
+runner = CliRunner()
+
+
+# ────────────────────────── _resolve_backend ──────────────────────────
+class TestResolveBackend:
+    def test_EG06_bogus_rejected(self):
+        with pytest.raises(typer.BadParameter):
+            _resolve_backend("bogus", "x.yaml")
+
+    def test_explicit_local(self):
+        assert _resolve_backend("local", "x.yaml") == "local"
+
+    def test_explicit_neo4j(self):
+        assert _resolve_backend("neo4j", "x.yaml") == "neo4j"
+
+    def test_EG05_auto_no_config_is_local(self, tmp_path):
+        assert _resolve_backend("auto", str(tmp_path / "missing.yaml")) == "local"
+
+    def test_EG04_auto_neo4j_connector(self, tmp_path):
+        cfg = tmp_path / "graqle.yaml"
+        cfg.write_text("graph:\n  connector: neo4j\n", encoding="utf-8")
+        assert _resolve_backend("auto", str(cfg)) == "neo4j"
+
+    def test_auto_local_connector(self, tmp_path):
+        cfg = tmp_path / "graqle.yaml"
+        cfg.write_text("graph:\n  connector: networkx\n", encoding="utf-8")
+        assert _resolve_backend("auto", str(cfg)) == "local"
+
+
+# ────────────────────────── _chunks_for_nodes ─────────────────────────
+class TestChunksForNodes:
+    def test_with_explicit_chunks(self):
+        nodes = {"a.py": {"id": "a.py", "properties": {"chunks": [
+            {"text": "def a(): pass", "type": "function"},
+        ]}}}
+        out = _chunks_for_nodes(nodes, {"a.py"})
+        assert out["a.py"][0]["text"] == "def a(): pass"
+
+    def test_desc_fallback_when_no_chunks(self):
+        nodes = {"d": {"id": "d", "description": "Directory: d", "properties": {}}}
+        out = _chunks_for_nodes(nodes, {"d"})
+        assert out["d"] == [{"text": "Directory: d", "type": "description"}]
+
+    def test_missing_node_skipped(self):
+        out = _chunks_for_nodes({}, {"ghost"})
+        assert out == {}
+
+
+# ───────────────────── R-SEC-1 on the Neo4j embed_fn ───────────────────
+class TestRedactingEmbedFn:
+    def test_EG10_neo4j_embed_fn_redacts_secret(self, monkeypatch):
+        """The Neo4j path's embed_fn must never pass a raw SECRET to the engine."""
+        seen: list[str] = []
+
+        class _Eng:
+            def embed(self, text):
+                seen.append(text)
+                import numpy as np
+                return np.array([0.1, 0.2, 0.3])
+
+        monkeypatch.setattr(
+            "graqle.activation.embeddings.EmbeddingEngine", lambda *a, **k: _Eng()
+        )
+        fn = _make_redacting_embed_fn()
+        secret = "AWS_SECRET_ACCESS_KEY=" + "B" * 40
+        vec = fn(f"token = '{secret}'")
+        assert isinstance(vec, list)  # .tolist() applied
+        assert all(secret not in t for t in seen), "raw secret reached engine"
+
+
+# ───────────────────── grow_command CLI surface ───────────────────────
+class TestGrowSurface:
+    def test_help_shows_embed_and_backend(self):
+        from graqle.cli.main import app
+        result = runner.invoke(app, ["grow", "--help"])
+        assert result.exit_code == 0
+        assert "--embed" in result.output or "--no-embed" in result.output
+        assert "--backend" in result.output
+
+
+# ───────────── grow_command integration (local, monkeypatched) ─────────
+def _seed_graph_json(tmp_path):
+    gj = tmp_path / "graqle.json"
+    gj.write_text(json.dumps({
+        "directed": True, "multigraph": False, "graph": {},
+        "nodes": [{"id": "old.py", "label": "old", "type": "PythonModule",
+                   "description": "old module"}],
+        "links": [],
+    }), encoding="utf-8")
+    return gj
+
+
+class TestGrowIntegration:
+    def _run(self, monkeypatch, tmp_path, embed=True, backend="local",
+             new_nodes=None):
+        monkeypatch.chdir(tmp_path)
+        _seed_graph_json(tmp_path)
+        new_nodes = new_nodes if new_nodes is not None else [
+            {"id": "new.py", "label": "new", "type": "PythonModule",
+             "description": "new module"}
+        ]
+        # Force the incremental scan to return our new node, skip git/ingest.
+        monkeypatch.setattr(grow_mod, "_get_changed_files", lambda: ["new.py"])
+        monkeypatch.setattr(grow_mod, "_incremental_scan",
+                            lambda root, changed: (new_nodes, []))
+        embed_calls = {"local": 0, "neo4j": 0}
+        monkeypatch.setattr(grow_mod, "_embed_local",
+                            lambda *a, **k: embed_calls.__setitem__("local", embed_calls["local"] + 1))
+        monkeypatch.setattr(grow_mod, "_write_neo4j",
+                            lambda *a, **k: embed_calls.__setitem__("neo4j", embed_calls["neo4j"] + 1))
+        grow_mod.grow_command(quiet=True, full=False, config="graqle.yaml",
+                              embed=embed, backend=backend)
+        return embed_calls
+
+    def test_EG01_embed_local_calls_embed(self, monkeypatch, tmp_path):
+        calls = self._run(monkeypatch, tmp_path, embed=True, backend="local")
+        assert calls["local"] == 1
+        assert calls["neo4j"] == 0
+
+    def test_EG02_no_embed_skips_embed(self, monkeypatch, tmp_path):
+        calls = self._run(monkeypatch, tmp_path, embed=False, backend="local")
+        assert calls["local"] == 0
+
+    def test_EG03_backend_neo4j_calls_write_neo4j(self, monkeypatch, tmp_path):
+        calls = self._run(monkeypatch, tmp_path, embed=True, backend="neo4j")
+        assert calls["neo4j"] == 1
+        # local embed still runs (graqle.json is the local mirror)
+        assert calls["local"] == 1
+
+    def test_EG15_graqle_json_shape_unchanged(self, monkeypatch, tmp_path):
+        """The node/link serialization must stay v0.62.x-shaped (embed is sidecar)."""
+        self._run(monkeypatch, tmp_path, embed=True, backend="local")
+        data = json.loads((tmp_path / "graqle.json").read_text(encoding="utf-8"))
+        assert "nodes" in data and "links" in data
+        ids = {n["id"] for n in data["nodes"]}
+        assert "old.py" in ids and "new.py" in ids
+        # every node still a plain dict with the canonical keys, no embedding blob
+        for n in data["nodes"]:
+            assert isinstance(n, dict)
+            assert "embedding" not in n

--- a/tests/test_plugins/test_background_grow_v063.py
+++ b/tests/test_plugins/test_background_grow_v063.py
@@ -1,0 +1,119 @@
+"""Tests for v0.63.0 L2 — background auto-grow watcher invokes `grow --embed`.
+
+Focused, deterministic tests (no real watchdog/filesystem timing): the
+subprocess argv carries --embed (EG_11), disable-env + missing-watchdog
+degrade cleanly, stats shape, and the MCP wire-in method (EG_12).
+
+V-CR-V063-WRITE-NATIVE-001: new test file — graq_write S-010 gate; native Write.
+"""
+
+# ── graqle:intelligence ──
+# module: tests.test_plugins.test_background_grow_v063
+# risk: LOW (impact radius: 0 modules)
+# dependencies: pytest, background_grow, mcp_dev_server
+# constraints: none
+# ── /graqle:intelligence ──
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from graqle.plugins.background_grow import BackgroundGrowWatcher
+
+
+class TestSubprocessArgv:
+    def test_EG11_argv_includes_embed(self, tmp_path):
+        """The watcher must shell `grow --embed`, not bare `grow`."""
+        w = BackgroundGrowWatcher(tmp_path, python_executable="pyx")
+        captured = {}
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = argv
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = "ok"
+            r.stderr = ""
+            return r
+
+        with patch("graqle.plugins.background_grow.subprocess.run", side_effect=fake_run):
+            ok = w._run_grow_subprocess()
+        assert ok is True
+        assert captured["argv"] == ["pyx", "-m", "graqle.cli.main", "grow", "--embed"]
+
+    def test_nonzero_exit_returns_false(self, tmp_path):
+        w = BackgroundGrowWatcher(tmp_path, python_executable="pyx")
+
+        def fake_run(argv, **kwargs):
+            r = MagicMock()
+            r.returncode = 2
+            r.stdout = ""
+            r.stderr = "boom"
+            return r
+
+        with patch("graqle.plugins.background_grow.subprocess.run", side_effect=fake_run):
+            assert w._run_grow_subprocess() is False
+
+
+class TestDegrade:
+    def test_disabled_via_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GRAQLE_DISABLE_BACKGROUND_GROW", "1")
+        w = BackgroundGrowWatcher(tmp_path)
+        assert w.start() is False
+
+    def test_missing_watchdog(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("GRAQLE_DISABLE_BACKGROUND_GROW", raising=False)
+        # Simulate watchdog import failure.
+        import builtins
+        real_import = builtins.__import__
+
+        def fake_import(name, *a, **k):
+            if name.startswith("watchdog"):
+                raise ImportError("no watchdog")
+            return real_import(name, *a, **k)
+
+        with patch("builtins.__import__", side_effect=fake_import):
+            w = BackgroundGrowWatcher(tmp_path)
+            assert w.start() is False
+
+    def test_stats_shape(self, tmp_path):
+        w = BackgroundGrowWatcher(tmp_path)
+        s = w.stats
+        assert "root" in s and "growths_completed" in s and "alive" in s
+
+
+class TestMcpWireIn:
+    def test_EG12_maybe_start_disabled_env_is_noop(self, monkeypatch):
+        """_maybe_start_background_grow respects the disable env and never raises."""
+        monkeypatch.setenv("GRAQLE_DISABLE_BACKGROUND_GROW", "1")
+        from graqle.plugins.mcp_dev_server import KogniDevServer
+        s = KogniDevServer.__new__(KogniDevServer)
+        s._bg_grow_watcher = None
+        s._graph_file = None
+        s._maybe_start_background_grow()
+        assert s._bg_grow_watcher is None
+
+    def test_EG12_maybe_start_is_idempotent(self, monkeypatch):
+        """Second call is a no-op when a watcher is already set."""
+        monkeypatch.delenv("GRAQLE_DISABLE_BACKGROUND_GROW", raising=False)
+        from graqle.plugins.mcp_dev_server import KogniDevServer
+        s = KogniDevServer.__new__(KogniDevServer)
+        sentinel = object()
+        s._bg_grow_watcher = sentinel
+        s._graph_file = None
+        s._maybe_start_background_grow()
+        assert s._bg_grow_watcher is sentinel  # untouched
+
+    def test_EG12_wired_in_both_load_paths(self):
+        """Both the Neo4j and JSON graph-load paths call the watcher start.
+
+        Guards against the handoff bug where only the Neo4j path was patched.
+        """
+        import inspect
+        from graqle.plugins import mcp_dev_server
+        src = inspect.getsource(mcp_dev_server.KogniDevServer._load_graph_impl)
+        assert src.count("_maybe_start_background_grow()") >= 2, (
+            "expected the watcher to be started on BOTH the neo4j and JSON "
+            "load paths"
+        )


### PR DESCRIPTION
## v0.63.0 — End-to-End Auto-Grow Loop

`graq grow` now **embeds** new-node chunks (incrementally) and **writes the backend the graph actually reads from** (local JSON embedding cache + Neo4j `:Chunk` rows), so newly committed or saved code becomes queryable by `graq reason` within seconds. Three triggers — manual CLI, the git post-commit hook, and the MCP background watcher — all funnel through the same code path.

Previously `graq grow` scanned and wrote `graqle.json` but never embedded and never wrote the live backend, so grown nodes were invisible to reasoning on Neo4j-backed setups.

### Highlights
- **`graq grow --embed/--no-embed`** (default **on**) and **`--backend=auto|local|neo4j`** (default auto, from `graph.connector`). Fully backwards compatible — no CLI surface change for existing callers.
- **Incremental embedding** (`ChunkScorer.update_cache_incremental`): only changed nodes are re-embedded (boolean-mask drop → embed delta → concatenate → atomic write), with NPZ↔graph drift detection and a full-rebuild self-heal. Keeps per-commit cost proportional to the change, not the graph.
- **MCP background watcher** (`graqle[watch]` optional extra): runs `graq grow --embed` on debounced filesystem events so IDE saves keep the graph current between commits. Degrades to disabled if `watchdog` is absent.
- **`graq init` hook** now runs `graq grow --embed` and surfaces errors (replacing a `--quiet 2>/dev/null &` form that silently swallowed failures).
- **Security:** sensitive content is redacted before any embedding call, on both the local and Neo4j paths.

### Docs
`docs/auto-grow-end-to-end.md` — the 3-layer guide.

### Tests
33 new tests; zero regression (6929 passed in CI on the private PR). Backwards compatible.

### Out of scope (later release)
Shared-team / multi-developer shared-graph sync is being designed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
