### PR TITLE
v0.63.1: graq_learn persists to Neo4j + SAVE_FAILED guard + embed-engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## 0.63.1 (2026-05-31) — [Fix: graq_learn now persists to Neo4j]
+
+> Three fixes, all surfaced by dogfooding the v0.63.0 auto-grow loop on a
+> Neo4j-backed setup. The headline fix makes `graq_learn` actually persist on
+> Neo4j sessions for the first time (it previously failed with `SAVE_FAILED`
+> on every call and, even past that, never wrote the lesson to the backend).
+
+### Fixed
+- **`graq_learn` SAVE_FAILED on Neo4j sessions.** `_save_graph` guarded only
+  `if self._graph_file is None`, but a Neo4j session sets `_graph_file` to a
+  `neo4j://…` connection URI — so it fell through and tried to write a JSON file
+  literally named after the URI (invalid path → crash → `SAVE_FAILED`). A new
+  `_is_backend_only_graph_file()` now treats `neo4j://`/`bolt://`/`neptune://`/
+  `memgraph://` URIs the same as `None` → `NO_GRAPH_FILE` (a success state).
+- **`graq_learn` never persisted to Neo4j (latent).** `graph.add_node`/`add_edge`
+  are in-memory only; nothing flushed learned lesson/entity/knowledge nodes to
+  the Neo4j driver, so they were lost on restart. A new
+  `_persist_learn_to_backend()` writes the new node(s) + edges through via the
+  existing `Neo4jConnector.save` path when a backend connector is attached.
+  Backend write failure surfaces loudly (`SAVE_FAILED`) instead of a false
+  success. Local-JSON sessions are unchanged (the previous path still applies).
+- **`grow --embed` mis-routed Bedrock embeddings.** `grow`'s embed helpers built
+  a bare `EmbeddingEngine()` instead of the config-aware
+  `create_embedding_engine(cfg)`, so on a bedrock-backed project the Titan
+  model-id was fed to sentence-transformers and failed to load. Now both
+  `_embed_local` and the Neo4j `embed_fn` resolve the engine from config.
+
+### Notes
+- No CLI surface changes; fully backwards compatible. 16 new tests; the
+  existing `test_save_graph_status` suite continues to pass (the new backend
+  write-through is gated on a real connector being present).
+
+---
+
 ## 0.63.0 (2026-05-31) — [End-to-End Auto-Grow Loop]
 
 > `graq grow` now **embeds** new chunks and **writes the backend your graph

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.63.0"
+__version__ = "0.63.1"

--- a/graqle/cli/commands/grow.py
+++ b/graqle/cli/commands/grow.py
@@ -217,10 +217,17 @@ def _embed_local(graph_path: Path, changed_node_ids: set[str], quiet: bool) -> N
     """
     try:
         from graqle.activation.chunk_scorer import ChunkScorer
+        from graqle.activation.embeddings import create_embedding_engine
+        from graqle.config._resolver_compat import load_via_resolver_or_legacy
         from graqle.core.graph import Graqle
 
         graph = Graqle.from_json(str(graph_path))
-        scorer = ChunkScorer()
+        # v0.63.1 (Fix C): build the embedding engine from CONFIG so a
+        # bedrock-backed project routes to Titan V2, instead of a bare
+        # EmbeddingEngine() that feeds the Titan model-id to sentence-
+        # transformers and fails to load.
+        _cfg = load_via_resolver_or_legacy()
+        scorer = ChunkScorer(embedding_engine=create_embedding_engine(_cfg))
         stats = scorer.update_cache_incremental(graph, changed_node_ids)
         if not quiet:
             console.print(
@@ -344,9 +351,13 @@ def _make_redacting_embed_fn():
     used by ChunkScorer so SECRET+ content never reaches the embedding API.
     """
     from graqle.activation.chunk_scorer import ChunkScorer
-    from graqle.activation.embeddings import EmbeddingEngine
+    from graqle.activation.embeddings import create_embedding_engine
+    from graqle.config._resolver_compat import load_via_resolver_or_legacy
 
-    engine = EmbeddingEngine()
+    # v0.63.1 (Fix C): config-aware engine — routes to Bedrock Titan V2 when
+    # the project config is bedrock-backed, instead of a bare EmbeddingEngine()
+    # that mis-loads the Titan model-id via sentence-transformers.
+    engine = create_embedding_engine(load_via_resolver_or_legacy())
 
     def embed_fn(text: str) -> list:
         redacted = ChunkScorer._redact_texts_for_embedding([text])[0]

--- a/graqle/plugins/mcp_dev_server.py
+++ b/graqle/plugins/mcp_dev_server.py
@@ -167,6 +167,23 @@ class SaveGraphResult:
         raise IndexError(idx)
 
 
+# v0.63.1 (Bug A): a Neo4j/backend-backed session stores its _graph_file as a
+# connection URI ("neo4j://...", "bolt://...") rather than a filesystem path or
+# None. _save_graph must treat those exactly like None (no JSON to write) — a
+# bare `is None` check let the URI fall through to _write_with_lock, which then
+# tried to create a file literally named "neo4j://bolt://localhost:7687" and
+# crashed with SAVE_FAILED on every learn. Centralised so any future scheme
+# (neptune://, memgraph://, ...) is covered in one place.
+_BACKEND_ONLY_GRAPH_FILE_SCHEMES = ("neo4j://", "bolt://", "neptune://", "memgraph://")
+
+
+def _is_backend_only_graph_file(graph_file: object) -> bool:
+    """True if graph_file is a backend connection URI (not a writable path)."""
+    return isinstance(graph_file, str) and graph_file.startswith(
+        _BACKEND_ONLY_GRAPH_FILE_SCHEMES
+    )
+
+
 
 
 try:
@@ -7068,6 +7085,32 @@ class KogniDevServer:
                     )
                     graph.add_edge(edge)
 
+            # v0.63.1 (Bug B): on a Neo4j-backed session, write the new lesson
+            # node + LEARNED_FROM edges + reweighted edges THROUGH to the
+            # backend (add_node/add_edge are in-memory only). Scoped to just
+            # what this learn touched. A backend failure surfaces as SAVE_FAILED
+            # rather than a false success.
+            _backend_persisted = False
+            if getattr(graph, "_neo4j_connector", None) is not None:
+                try:
+                    touched_edges = [u["edge"] for u in updates]
+                    if lesson_node_id:
+                        touched_edges += [
+                            e.id for e in graph.edges.values()
+                            if e.source_id == lesson_node_id
+                        ]
+                    _backend_persisted = self._persist_learn_to_backend(
+                        graph,
+                        node_ids=([lesson_node_id] if lesson_node_id else []),
+                        edge_ids=touched_edges,
+                    )
+                except Exception as _be_exc:  # noqa: BLE001
+                    return json.dumps({
+                        "recorded": False, "mode": "outcome",
+                        "error_code": "SAVE_FAILED",
+                        "message": f"Neo4j backend persist failed: {type(_be_exc).__name__}",
+                    })
+
             # CR-008: status-aware save (see _learn_response_for_save_failure
             # for the COLLISION / SHRINK_REFUSED / SAVE_FAILED branches).
             # NO_GRAPH_FILE folds into success: Neo4j-backed sessions already
@@ -7079,7 +7122,9 @@ class KogniDevServer:
                     self._learn_response_for_save_failure(_save_result, "mode", "outcome")
                 )
             _retries = _save_result.retries
-            _persistence = _save_result.status.value
+            _persistence = (
+                "neo4j" if _backend_persisted else _save_result.status.value
+            )
         else:
             _retries = 0
             _persistence = "SKIPPED"
@@ -7135,6 +7180,25 @@ class KogniDevServer:
         auto_edges = 0
         if hasattr(graph, "auto_connect"):
             auto_edges = graph.auto_connect([entity_id])
+
+        # v0.63.1 (Bug B): persist the new entity node + its edges through to
+        # Neo4j when backend-backed (add_node_simple is in-memory only).
+        _backend_persisted = False
+        if getattr(graph, "_neo4j_connector", None) is not None:
+            try:
+                _ent_edges = [
+                    e.id for e in graph.edges.values()
+                    if e.source_id == entity_id or e.target_id == entity_id
+                ]
+                _backend_persisted = self._persist_learn_to_backend(
+                    graph, node_ids=[entity_id], edge_ids=_ent_edges
+                )
+            except Exception as _be_exc:  # noqa: BLE001
+                return json.dumps({
+                    "recorded": False, "mode": "entity",
+                    "error_code": "SAVE_FAILED",
+                    "message": f"Neo4j backend persist failed: {type(_be_exc).__name__}",
+                })
 
         # CR-008: status-aware save. Neo4j-backed sessions (NO_GRAPH_FILE)
         # fold into success — the backend driver already persisted the entity.
@@ -7193,6 +7257,25 @@ class KogniDevServer:
         auto_edges = 0
         if hasattr(graph, "auto_connect"):
             auto_edges = graph.auto_connect([node_id])
+
+        # v0.63.1 (Bug B): persist the new knowledge node + its edges through
+        # to Neo4j when backend-backed (add_node_simple is in-memory only).
+        _backend_persisted = False
+        if getattr(graph, "_neo4j_connector", None) is not None:
+            try:
+                _kn_edges = [
+                    e.id for e in graph.edges.values()
+                    if e.source_id == node_id or e.target_id == node_id
+                ]
+                _backend_persisted = self._persist_learn_to_backend(
+                    graph, node_ids=[node_id], edge_ids=_kn_edges
+                )
+            except Exception as _be_exc:  # noqa: BLE001
+                return json.dumps({
+                    "recorded": False, "mode": "knowledge",
+                    "error_code": "SAVE_FAILED",
+                    "message": f"Neo4j backend persist failed: {type(_be_exc).__name__}",
+                })
 
         # CR-008: status-aware save. NO_GRAPH_FILE (Neo4j sessions) is NOT
         # a failure — the knowledge node was already created in-memory and
@@ -11952,6 +12035,74 @@ class KogniDevServer:
             "detail": result.detail,
         }
 
+    def _persist_learn_to_backend(
+        self,
+        graph: Any,
+        node_ids: list[str] | None = None,
+        edge_ids: list[str] | None = None,
+    ) -> bool:
+        """v0.63.1 (Bug B): write learned nodes/edges through to the Neo4j backend.
+
+        ``graph.add_node`` / ``add_edge`` only mutate the in-memory graph; on a
+        Neo4j-backed session nothing flushed those to the driver, so every
+        ``graq_learn`` was lost on MCP restart (and ``_save_graph`` could only
+        write a JSON file, which a backend-only session does not have). This
+        helper persists exactly the nodes/edges a learn handler just created
+        via the existing ``Neo4jConnector.save`` path.
+
+        Scoped write: only the given node_ids/edge_ids (defaults to all) are
+        sent, so a learn of one lesson does not re-upload the whole graph.
+
+        Returns True if a backend write happened, False if there is no backend
+        (local JSON session — caller relies on ``_save_graph`` instead). Never
+        raises: a backend failure is logged and reported via the return value
+        so the caller can surface it without crashing the learn.
+        """
+        connector = getattr(graph, "_neo4j_connector", None)
+        if connector is None:
+            return False
+        try:
+            raw_nodes: dict[str, Any] = {}
+            ids = node_ids if node_ids is not None else list(graph.nodes.keys())
+            for nid in ids:
+                node = graph.nodes.get(nid)
+                if node is None:
+                    continue
+                raw_nodes[nid] = {
+                    "label": node.label,
+                    "type": node.entity_type,
+                    "description": node.description,
+                    "properties": node.properties,
+                }
+
+            raw_edges: dict[str, Any] = {}
+            eids = edge_ids if edge_ids is not None else list(graph.edges.keys())
+            for eid in eids:
+                edge = graph.edges.get(eid)
+                if edge is None:
+                    continue
+                raw_edges[eid] = {
+                    "source": edge.source_id,
+                    "target": edge.target_id,
+                    "relationship": edge.relationship,
+                    "weight": edge.weight,
+                }
+
+            if raw_nodes or raw_edges:
+                connector.save(raw_nodes, raw_edges)
+            logger.info(
+                "graq_learn persisted to Neo4j: %d node(s), %d edge(s)",
+                len(raw_nodes), len(raw_edges),
+            )
+            return True
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "graq_learn backend persist FAILED (%s: %s) — lesson is in "
+                "memory only and will be lost on MCP restart.",
+                type(exc).__name__, exc,
+            )
+            raise
+
     def _save_graph(self, graph: Any) -> SaveGraphResult:
         """Persist graph back to its source JSON file.
 
@@ -11995,14 +12146,19 @@ class KogniDevServer:
         Phase 2: after every local write, schedule a background S3 push
         so learned nodes are never lost on restart or machine change.
         """
-        if self._graph_file is None:
-            # CR-008: explicit status — Neo4j-backed (or any backend-only)
-            # session. NOT a collision — the in-memory mutation already
-            # happened via graph.add_node_simple / graph.add_edge.
+        if self._graph_file is None or _is_backend_only_graph_file(self._graph_file):
+            # CR-008 + v0.63.1 (Bug A): explicit status — Neo4j-backed (or any
+            # backend-only) session. The session sets _graph_file to a
+            # "neo4j://..."/"bolt://..." URI, NOT None — so a bare `is None`
+            # check let it fall through and try to write a JSON file literally
+            # named after the URI (invalid path -> SAVE_FAILED crash). Treat any
+            # non-filesystem scheme the same as None. NOT a collision — the
+            # in-memory mutation already happened; backend write-through is the
+            # caller's responsibility (see _persist_learn_to_backend).
             return SaveGraphResult(
                 status=SaveStatus.NO_GRAPH_FILE,
                 retries=0,
-                detail="No JSON file configured; in-memory + backend write only.",
+                detail="Backend-only session (no JSON path); in-memory + backend write.",
             )
 
         import os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.63.0"
+version = "0.63.1"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Proprietary — see LICENSE"}

--- a/tests/test_cli/test_grow_embed.py
+++ b/tests/test_cli/test_grow_embed.py
@@ -91,8 +91,11 @@ class TestRedactingEmbedFn:
                 import numpy as np
                 return np.array([0.1, 0.2, 0.3])
 
+        # v0.63.1 (Fix C): _make_redacting_embed_fn now builds the engine via
+        # create_embedding_engine(cfg), so patch THAT, not EmbeddingEngine.
         monkeypatch.setattr(
-            "graqle.activation.embeddings.EmbeddingEngine", lambda *a, **k: _Eng()
+            "graqle.activation.embeddings.create_embedding_engine",
+            lambda *a, **k: _Eng(),
         )
         fn = _make_redacting_embed_fn()
         secret = "AWS_SECRET_ACCESS_KEY=" + "B" * 40

--- a/tests/test_plugins/test_learn_neo4j_persist_v0631.py
+++ b/tests/test_plugins/test_learn_neo4j_persist_v0631.py
@@ -1,0 +1,178 @@
+"""v0.63.1 — graq_learn persists to Neo4j; SAVE_FAILED URI-guard; embed-engine.
+
+Three bugs fixed:
+- Fix A: _save_graph treated a `neo4j://`/`bolt://` _graph_file URI as a JSON
+  path → tried to write a file named after the URI → SAVE_FAILED on every learn.
+- Fix B: learn handlers never wrote the new node/edges through to the Neo4j
+  connector (add_node is in-memory only) → lessons lost on restart.
+- Fix C: grow embed helpers used bare EmbeddingEngine() not create_embedding_engine.
+
+V-CR-V0631-WRITE-NATIVE-001: new test file — graq_write S-010 gate; native Write.
+"""
+
+# ── graqle:intelligence ──
+# module: tests.test_plugins.test_learn_neo4j_persist_v0631
+# risk: LOW (impact radius: 0 modules)
+# dependencies: asyncio, json, pytest, mcp_dev_server
+# constraints: none
+# ── /graqle:intelligence ──
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from graqle.core.edge import CogniEdge
+from graqle.core.graph import Graqle
+from graqle.core.node import CogniNode
+from graqle.plugins.mcp_dev_server import (
+    KogniDevServer,
+    SaveStatus,
+    _is_backend_only_graph_file,
+)
+
+
+# ── Fix A: URI guard ──────────────────────────────────────────────────
+class TestBackendOnlyGraphFileGuard:
+    @pytest.mark.parametrize("uri", [
+        "neo4j://bolt://localhost:7687", "bolt://localhost:7687",
+        "neptune://x", "memgraph://y",
+    ])
+    def test_uris_are_backend_only(self, uri):
+        assert _is_backend_only_graph_file(uri) is True
+
+    @pytest.mark.parametrize("path", [
+        "C:/Users/x/graqle.json", "graqle.json", "./g.json", "",
+    ])
+    def test_paths_are_not_backend_only(self, path):
+        assert _is_backend_only_graph_file(path) is False
+
+    def test_none_is_not_backend_only(self):
+        assert _is_backend_only_graph_file(None) is False
+
+    def test_save_graph_returns_no_graph_file_for_uri(self):
+        """The core SAVE_FAILED fix: a neo4j URI _graph_file → NO_GRAPH_FILE,
+        not a crash from trying to write a file named after the URI."""
+        s = KogniDevServer.__new__(KogniDevServer)
+        s._graph_file = "neo4j://bolt://localhost:7687"
+        g = Graqle(nodes={}, edges={})
+        result = s._save_graph(g)
+        assert result.status is SaveStatus.NO_GRAPH_FILE
+        assert result.recorded is True  # folds into success
+
+
+# ── Fix B: learn write-through to Neo4j ───────────────────────────────
+class _SpyConnector:
+    """Captures connector.save(nodes, edges) calls."""
+    def __init__(self):
+        self.saved_nodes = {}
+        self.saved_edges = {}
+        self.calls = 0
+
+    def save(self, nodes, edges):
+        self.calls += 1
+        self.saved_nodes.update(nodes)
+        self.saved_edges.update(edges)
+
+
+def _server_with_neo4j_graph():
+    """A server whose loaded graph is Neo4j-backed (spy connector)."""
+    s = KogniDevServer.__new__(KogniDevServer)
+    s._graph_file = "neo4j://bolt://localhost:7687"
+    # two real code nodes + an edge so outcome-mode has something to reweight
+    g = Graqle(
+        nodes={
+            "a.py": CogniNode(id="a.py", label="a", entity_type="PythonModule",
+                              description="module a"),
+            "b.py": CogniNode(id="b.py", label="b", entity_type="PythonModule",
+                              description="module b"),
+        },
+        edges={
+            "e1": CogniEdge(id="e1", source_id="a.py", target_id="b.py",
+                            relationship="IMPORTS", weight=1.0),
+        },
+    )
+    spy = _SpyConnector()
+    g._neo4j_connector = spy
+    s._graph = g
+    s._kg_load_state = "LOADED"
+    # _load_graph fast-path returns the cached graph
+    s._load_graph = lambda: g  # type: ignore[method-assign]
+    return s, g, spy
+
+
+class TestLearnPersistsToNeo4j:
+    def test_persist_helper_writes_scoped_nodes_edges(self):
+        s, g, spy = _server_with_neo4j_graph()
+        ok = s._persist_learn_to_backend(g, node_ids=["a.py"], edge_ids=["e1"])
+        assert ok is True
+        assert spy.calls == 1
+        assert "a.py" in spy.saved_nodes
+        assert "e1" in spy.saved_edges
+
+    def test_persist_helper_returns_false_without_connector(self):
+        s = KogniDevServer.__new__(KogniDevServer)
+        g = Graqle(nodes={}, edges={})  # no _neo4j_connector
+        assert s._persist_learn_to_backend(g) is False
+
+    def test_learn_outcome_persists_lesson_to_neo4j(self):
+        """End-to-end: graq_learn outcome on a Neo4j session writes the LESSON
+        node through to the connector AND reports recorded=True (no SAVE_FAILED)."""
+        s, g, spy = _server_with_neo4j_graph()
+        raw = asyncio.run(s._handle_learn_outcome({
+            "action": "fixed the connector alias bug",
+            "outcome": "success",
+            "components": ["a.py", "b.py"],
+            "lesson": "neo4j URI graph_file must be treated like None in _save_graph",
+        }))
+        resp = json.loads(raw)
+        assert resp.get("recorded") is True, resp
+        assert resp.get("error_code") != "SAVE_FAILED"
+        # the lesson node reached the connector
+        assert spy.calls >= 1
+        lesson_ids = [nid for nid in spy.saved_nodes if nid.startswith("lesson_")]
+        assert lesson_ids, f"no lesson node persisted to neo4j: {list(spy.saved_nodes)}"
+        assert resp.get("persistence") == "neo4j"
+
+    def test_learn_entity_persists_to_neo4j(self):
+        s, g, spy = _server_with_neo4j_graph()
+        raw = asyncio.run(s._handle_learn_entity({
+            "entity_id": "the regulatory product",
+            "entity_type": "PRODUCT",
+            "description": "TraceGov regulatory product",
+            "connects_to": ["a.py"],
+        }))
+        resp = json.loads(raw)
+        assert resp.get("recorded") is True, resp
+        assert "the regulatory product" in spy.saved_nodes
+
+    def test_learn_knowledge_persists_to_neo4j(self):
+        s, g, spy = _server_with_neo4j_graph()
+        raw = asyncio.run(s._handle_learn_knowledge({
+            "description": "Free tier allows 1000 anchors/month per ADR-BIZ-001",
+            "domain": "product",
+            "tags": ["pricing"],
+        }))
+        resp = json.loads(raw)
+        assert resp.get("recorded") is True, resp
+        kn = [n for n in spy.saved_nodes if n.startswith("knowledge_")]
+        assert kn, f"no knowledge node persisted: {list(spy.saved_nodes)}"
+
+    def test_learn_outcome_surfaces_backend_failure(self):
+        """If the connector.save raises, learn reports SAVE_FAILED (loud),
+        not a false success."""
+        s, g, spy = _server_with_neo4j_graph()
+
+        def boom(nodes, edges):
+            raise RuntimeError("neo4j down")
+        spy.save = boom  # type: ignore[method-assign]
+
+        raw = asyncio.run(s._handle_learn_outcome({
+            "action": "x", "outcome": "success", "components": ["a.py", "b.py"],
+            "lesson": "this should fail to persist",
+        }))
+        resp = json.loads(raw)
+        assert resp.get("recorded") is False
+        assert resp.get("error_code") == "SAVE_FAILED"


### PR DESCRIPTION
## v0.63.1 — `graq_learn` persists to Neo4j (+ SAVE_FAILED guard + embed-engine)

A patch release fixing three issues surfaced by dogfooding the v0.63.0 auto-grow loop on a Neo4j-backed setup.

### Fixed
- **`graq_learn` crashed with SAVE_FAILED on Neo4j sessions.** The internal save guard checked only `if graph_file is None`, but a Neo4j session uses a `neo4j://…` connection URI — so it tried to write a JSON file named after the URI. A new check treats `neo4j://`/`bolt://`/`neptune://`/`memgraph://` URIs the same as "no file" (backend-only session).
- **`graq_learn` never persisted to the graph backend (latent).** Learned lesson/entity/knowledge nodes were created in memory but never flushed to the Neo4j driver, so they were lost on restart. They are now written through via the backend connector when one is attached. Local-JSON sessions are unchanged. A backend write failure surfaces clearly instead of a false success.
- **`grow --embed` mis-routed embeddings on Bedrock-backed projects.** The embed step built a bare embedding engine instead of resolving it from config, so the Bedrock Titan model-id was handed to sentence-transformers and failed to load. Both embed paths now resolve the engine from config; non-Bedrock projects get the same default engine as before.

### Notes
- No CLI surface changes; fully backwards compatible.
- 16 new tests; the existing save-status suite continues to pass (backend write-through is gated on a real connector being present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
