### PR TITLE
v0.64.0: standalone offline proof verifier (moat M2) + graq attest verify + import-isolation gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## 0.64.0 (2026-05-31) — [Standalone offline proof verifier + `graq attest verify`]
+
+> The canonical, free-forever offline verifier for GraQle-format tamper-evidence
+> proof bundles. Given a proof bundle and the signer's public key(s) — and
+> nothing else: no network, no GraQle service, no proprietary code — anyone can
+> verify a proof. This engineers the "survive-our-disappearance" guarantee: if
+> GraQle vanished, every proof we ever emitted still verifies.
+
+**Added**
+
+- `graqle.governance.tamper_evidence.verifier.verify_bundle(proof_bundle, trusted_keys)`
+  — composes leaf-hash recompute, Merkle inclusion, ed25519 windowed/3-state-lifecycle
+  trust, and an optional **offline** Rekor binding check into one verifier.
+  Returns a typed `VerifyResult` (never raises on a bad proof). Pure standard
+  library + `cryptography`; imports nothing from the server/studio/anchoring
+  surfaces. A runtime import-isolation guard enforces that at import time.
+- `graq attest verify <bundle.json> --key <pub.pem>` CLI (also `--keys <keyring.json>`
+  for explicit per-key validity windows + lifecycle states, `--rekor-sth`, and
+  `--format text|json`), plus the dependency-light `python -m graqle.verify`
+  entrypoint. Exit codes: `0` verified, `1` not verified, `2` usage error.
+- An import-isolation CI gate (AST allowlist) that fails the build if the verifier
+  or its surface ever imports outside the standard library, `cryptography`, and the
+  four tamper-evidence primitives — so the offline-verifiability guarantee cannot
+  silently regress.
+
+110 tests at 100% statement + branch coverage (real signed + Merkle-anchored
+fixtures, fault injection for every failure mode, and a studio-free subprocess
+invariant proving the verifier runs standalone).
+
 ## 0.63.1 (2026-05-31) — [Fix: graq_learn now persists to Neo4j]
 
 > Three fixes, all surfaced by dogfooding the v0.63.0 auto-grow loop on a

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.63.1"
+__version__ = "0.64.0"

--- a/graqle/cli/commands/attest.py
+++ b/graqle/cli/commands/attest.py
@@ -1,0 +1,125 @@
+"""``graq attest`` CLI sub-app — offline proof-bundle verification (WS-A2).
+
+The ``attest`` group is the CLI home for tamper-evidence attestation operations.
+Its first command is ``verify``, a thin Typer shell over
+:func:`graqle.verify.run_verify` (WS-A1's ``verify_bundle``):
+
+    graq attest verify <bundle.json> --key <pub.pem>
+    graq attest verify <bundle.json> --keys <keyring.json> --format json
+    graq attest verify <bundle.json> --key <pub.pem> --rekor-sth <sth.json>
+
+Why a new ``attest`` group rather than ``graq verify``: ``graq verify`` is
+already taken by the dev-intelligence "verify staged changes vs compiled
+intelligence" command (``graqle.intelligence.verify``). ``attest`` matches the
+runtime attestation domain (``attest()`` / ``AttestationSink`` / anchoring) and
+leaves room for future ``graq attest`` subcommands. The equivalent
+dependency-light entrypoint is ``python -m graqle.verify``.
+
+This sub-app NEVER imports a GraQle-internal trade-secret module and stays in the
+verifier's isolation domain (stdlib + cryptography + the verify core).
+
+Exit codes: 0 verified · 1 not verified · 2 bad CLI input / unreadable file.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import typer
+
+from graqle.cli.console import create_console
+from graqle.verify import EXIT_OK, VerifyUsageError, run_verify
+
+console = create_console()
+
+
+attest_app = typer.Typer(
+    name="attest",
+    help="Tamper-evidence attestation operations — verify proof bundles offline.",
+    no_args_is_help=True,
+)
+
+
+@attest_app.command(name="verify")
+def verify_command(
+    bundle: str = typer.Argument(
+        ...,
+        help="Path to the proof-bundle JSON file to verify.",
+    ),
+    key: str = typer.Option(
+        None,
+        "--key",
+        "-k",
+        help="Path to a single ed25519 public-key PEM trusted for this proof.",
+    ),
+    keys: str = typer.Option(
+        None,
+        "--keys",
+        help=(
+            "Path to a JSON keyring with explicit per-kid windows + lifecycle "
+            "states (audit a proof under its historical trust state)."
+        ),
+    ),
+    rekor_sth: str = typer.Option(
+        None,
+        "--rekor-sth",
+        help=(
+            "Optional Rekor signed-tree-head JSON to check against (offline; "
+            "treated as data, never fetched)."
+        ),
+    ),
+    output_format: str = typer.Option(
+        "text",
+        "--format",
+        help="Output format: text (default) or json.",
+    ),
+) -> None:
+    """Verify a GraQle-format tamper-evidence proof bundle offline.
+
+    Composes leaf-recompute + Merkle inclusion + ed25519 trust + optional offline
+    Rekor binding. No network, no proprietary code — free forever.
+    """
+    if output_format not in ("text", "json"):
+        console.print(
+            f"[red]error: --format must be 'text' or 'json', got "
+            f"{output_format!r}[/red]"
+        )
+        raise typer.Exit(2)
+
+    try:
+        exit_code, result = run_verify(
+            bundle_path=Path(bundle),
+            key_path=Path(key) if key else None,
+            keys_path=Path(keys) if keys else None,
+            rekor_sth_path=Path(rekor_sth) if rekor_sth else None,
+        )
+    except VerifyUsageError as exc:
+        if output_format == "json":
+            # Plain (un-highlighted) JSON to stdout so a consumer can parse it;
+            # the non-zero exit still signals the usage failure.
+            typer.echo(json.dumps({"ok": False, "error": str(exc)}))
+        else:
+            console.print(f"[red]error: {exc}[/red]")
+        raise typer.Exit(2) from exc
+
+    if output_format == "json":
+        # Plain JSON (NOT console.print_json, which injects Rich ANSI colour
+        # codes that break `... --format json | jq`).
+        typer.echo(json.dumps(result))
+    else:
+        if result["ok"]:
+            console.print(f"[green]VERIFIED[/green]: {result['failure']}")
+        else:
+            console.print(f"[red]FAILED[/red]: {result['failure']}")
+        for step, passed in result["checks"].items():
+            mark = "[green]pass[/green]" if passed else "[red]FAIL[/red]"
+            console.print(f"  {step}: {mark}")
+        if not result["rekor_checked"]:
+            console.print(
+                "  rekor: [yellow]not checked[/yellow] (no receipt in bundle)"
+            )
+
+    # Map verified/failed to the process exit code (0/1). Exit(0) is clean
+    # success; Exit(1) signals a proof that did not verify.
+    raise typer.Exit(EXIT_OK if exit_code == EXIT_OK else 1)

--- a/graqle/cli/main.py
+++ b/graqle/cli/main.py
@@ -47,6 +47,7 @@ from graqle.cli.commands.pr_guardian import pr_guardian_command
 from graqle.cli.commands.release_gate import release_gate_command
 from graqle.cli.commands.auto import auto_command
 from graqle.cli.commands.compliance import compliance_app
+from graqle.cli.commands.attest import attest_app
 from graqle.cli.commands.pct import pct_app
 from graqle.cli.commands.neo4j_import import neo4j_import_cmd
 from graqle.cli.commands.govern_serve import govern_app
@@ -117,6 +118,7 @@ app.command(name="release-gate")(release_gate_command)
 app.command(name="auto")(auto_command)
 app.add_typer(compliance_app, name="compliance")
 app.add_typer(pct_app, name="pct")
+app.add_typer(attest_app, name="attest")
 app.command(name="neo4j-import")(neo4j_import_cmd)
 app.add_typer(compile_command, name="compile")
 app.add_typer(verify_command, name="verify")

--- a/graqle/governance/tamper_evidence/verifier.py
+++ b/graqle/governance/tamper_evidence/verifier.py
@@ -1,0 +1,525 @@
+"""Standalone offline verifier for GraQle-format tamper-evidence proof bundles.
+
+This module is the **canonical verifier** (moat M2) and the engineered form of
+the survive-our-disappearance invariant: given a proof bundle, a trusted-key
+manifest, and nothing else — no network, no GraQle service, no proprietary
+code — it answers whether the proof holds. If GraQle vanished tomorrow, a third
+party with this file (or a re-implementation of it) and the public signing keys
+could still verify every proof we ever emitted.
+
+It is FREE and open forever (Apache-2.0, Community edition) and is NEVER gated.
+
+Isolation contract (the moat invariant)
+----------------------------------------
+``verify_bundle`` composes only four already-shipped primitives —
+:func:`~graqle.governance.tamper_evidence.merkle.leaf_hash_for_record`,
+:class:`~graqle.governance.tamper_evidence.merkle.InclusionProof`,
+:func:`~graqle.governance.tamper_evidence.canonicalize.canon`, and
+:class:`~graqle.governance.custody.ed25519_key_manifest.Ed25519KeyManifest` —
+plus the Python standard library and ``cryptography`` (a core dependency).
+
+It imports **nothing** from ``graqle.server``, ``graqle.studio``, or any
+anchoring/network client. Rekor inclusion data, if checked, is passed *in the
+bundle as data* and is never fetched. A runtime import guard (below) fails loudly
+at import time if a server/studio module is already loaded in the process, so a
+regression that smuggles a proprietary or network dependency into the verifier's
+import graph is caught immediately rather than silently breaking the moat. The
+same isolation is enforced statically by the WS-A3 CI AST gate; runtime + CI is
+defense-in-depth (a CI-only check would let a runtime regression pass unseen).
+
+Canonical proof-bundle schema (R25-EU01 §358 "Proof Bundle Schema")
+-------------------------------------------------------------------
+``verify_bundle`` accepts a JSON-style ``dict`` with these fields::
+
+    {
+      "proof_format_version": "1",          # str, must match leaf's version
+      "record": { ... },                    # the governed-trace record; MUST
+                                            #   itself carry proof_format_version
+                                            #   (enforced by canon_leaf)
+      "leaf": {
+        "leaf_index": 3,                    # int, position in the tree
+        "tree_size": 8,                     # int, number of leaves
+        "leaf_hash": "<hex>"                # the record's RFC 6962 leaf hash
+      },
+      "merkle": {
+        "merkle_root": "<hex>",             # the batch root
+        "merkle_path": ["<hex>", ...],      # sibling hashes bottom-up
+        "merkle_path_directions": [0, 1, …] # 0 = sibling-left, 1 = sibling-right
+      },
+      "signature": {
+        "alg": "ed25519",                   # only ed25519 is accepted
+        "kid": "graqle-sdk-signing-2026-Q2",
+        "sig": "<hex>",                     # ed25519 signature over signed_message
+        "signed_at": "2026-05-31T13:00:00Z" # RFC 3339 UTC; the trust instant
+      },
+      "rekor": {                            # OPTIONAL — offline data, never fetched
+        "log_index": 42,
+        "log_id": "...",
+        "signed_tree_head": "...",
+        "inclusion_cert": "...",
+        "integrated_time": 1748000000
+      }
+    }
+
+What the signature covers (SD-001, locked 2026-05-31)
+-----------------------------------------------------
+The ed25519 signature is over ``canon`` of::
+
+    {
+      "proof_format_version": <version>,
+      "merkle_root": <merkle_root hex>,
+      "kid": <kid>,
+      "signed_at": <signed_at>
+    }
+
+The Merkle root already commits to every leaf in the batch (RFC 6962), so
+signing the root transitively authenticates the record without re-signing each
+leaf. The signature is therefore small and shareable across every proof in a
+batch, and it binds the exact bytes Rekor anchors. ``verify_bundle`` reconstructs
+this message byte-for-byte via :func:`canon`, so the literal order of these four
+fields is irrelevant — JCS sorts keys — but the field *set* is frozen interop
+contract.
+
+Verification steps (each failure is typed, never an exception to the caller)
+----------------------------------------------------------------------------
+1. **Shape** — missing/malformed fields → :attr:`VerifyFailure.MALFORMED_BUNDLE`.
+2. **Leaf recompute** — ``leaf_hash_for_record(record)`` must equal the stated
+   ``leaf_hash`` (constant-time) → :attr:`VerifyFailure.TAMPERED_LEAF`.
+3. **Merkle inclusion** — the reconstructed :class:`InclusionProof` must recompute
+   to ``merkle_root`` → :attr:`VerifyFailure.WRONG_ROOT`.
+4. **Signature trust** — ``trusted_keys.verify(kid, signed_message, sig,
+   at=signed_at)`` under the 3-state custody lifecycle → an unknown kid is
+   :attr:`VerifyFailure.UNKNOWN_KID`; a falsey result (revoked, out-of-window, or
+   cryptographically invalid) is :attr:`VerifyFailure.UNTRUSTED_KID`.
+5. **Rekor (optional)** — if a ``rekor`` block is present its ``signed_tree_head``
+   must commit to ``merkle_root`` → :attr:`VerifyFailure.REKOR_MISMATCH`,
+   ``rekor_checked=True``. Absent → ``rekor_checked=False`` and the proof can
+   still be ``ok`` (a locally-anchored proof is valid without a public log).
+
+The whole function is pure: no I/O, no network, no file handles, no clock reads
+beyond parsing ``signed_at`` from the bundle. All hash/identity comparisons use
+:func:`hmac.compare_digest` to resist timing oracles.
+"""
+
+from __future__ import annotations
+
+import hmac
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from graqle.governance.custody.ed25519_key_manifest import (
+    Ed25519KeyManifest,
+    UnknownKidError,
+)
+from graqle.governance.tamper_evidence.canonicalize import canon
+from graqle.governance.tamper_evidence.errors import TamperEvidenceError
+from graqle.governance.tamper_evidence.merkle import (
+    InclusionProof,
+    leaf_hash_for_record,
+)
+
+# ── Runtime import-isolation guard (moat M2, defense-in-depth with WS-A3 CI) ──
+#
+# The verifier's value is that it depends on nothing proprietary and nothing
+# networked. If a server/studio module is already imported in this process when
+# the verifier is imported, *something* has wired the verifier into a surface it
+# must stay free of — fail loudly here rather than let the moat erode silently.
+# We check sys.modules (already-imported), NOT a fresh import, so this never
+# itself pulls server/studio in. The WS-A3 CI AST gate enforces the same
+# invariant statically on the import graph; the two together are belt-and-braces.
+_FORBIDDEN_MODULE_PREFIXES = ("graqle.server", "graqle.studio")
+
+
+def _assert_isolated(loaded_modules: object = None) -> None:
+    """Raise if a forbidden (server/studio) module is present in ``sys.modules``.
+
+    ``loaded_modules`` defaults to ``sys.modules``; it is injectable purely so
+    the isolation guard itself is unit-testable without manipulating the real
+    interpreter module table. A module counts as forbidden if its dotted name
+    equals or is a sub-package of any entry in
+    :data:`_FORBIDDEN_MODULE_PREFIXES`.
+    """
+    modules = sys.modules if loaded_modules is None else loaded_modules
+    offenders = sorted(
+        name
+        for name in modules
+        if any(
+            name == prefix or name.startswith(prefix + ".")
+            for prefix in _FORBIDDEN_MODULE_PREFIXES
+        )
+    )
+    if offenders:
+        raise ImportError(
+            "graqle.governance.tamper_evidence.verifier must stay isolated from "
+            "proprietary/networked surfaces, but these forbidden modules are "
+            f"already loaded: {offenders}. The standalone verifier is moat M2 — "
+            "it may import only merkle, canonicalize, custody.ed25519_key_manifest, "
+            "the standard library, and cryptography. See the WS-A3 CI gate."
+        )
+
+
+_assert_isolated()
+
+
+class VerifierError(TamperEvidenceError):
+    """Base class for verifier-level *misuse* errors (NOT failed verifications).
+
+    ``verify_bundle`` never raises on a *failed* verification — a bad proof yields
+    a :class:`VerifyResult` with ``ok=False`` and a typed :class:`VerifyFailure`.
+    This error type is reserved for misuse of the API itself (e.g. passing
+    something that is not a key manifest), so callers can distinguish "the proof
+    did not verify" from "you called me wrong".
+    """
+
+
+class VerifyFailure(str, Enum):
+    """The single, typed reason a bundle failed to verify (or ``OK``).
+
+    A ``str`` enum so the value is JSON/log friendly and stable across releases:
+    these names are part of the public verifier contract (machine-readable
+    ``--format json`` in WS-A2 emits them verbatim). Each non-OK member maps to
+    exactly one verification step, so a caller can branch on *why* a proof failed
+    without parsing prose.
+    """
+
+    OK = "OK"
+    MALFORMED_BUNDLE = "MALFORMED_BUNDLE"
+    TAMPERED_LEAF = "TAMPERED_LEAF"
+    WRONG_ROOT = "WRONG_ROOT"
+    UNKNOWN_KID = "UNKNOWN_KID"
+    UNTRUSTED_KID = "UNTRUSTED_KID"
+    REKOR_MISMATCH = "REKOR_MISMATCH"
+
+
+# Verification step names, used as keys in VerifyResult.checks. Frozen so the
+# result shape is a stable contract for the CLI / external auditors.
+_CHECK_LEAF = "leaf"
+_CHECK_MERKLE = "merkle"
+_CHECK_SIGNATURE = "signature"
+_CHECK_REKOR = "rekor"
+
+
+@dataclass(frozen=True)
+class VerifyResult:
+    """The outcome of :func:`verify_bundle` — a value object, never an exception.
+
+    Attributes
+    ----------
+    ok:
+        ``True`` iff every *attempted* check passed. The optional Rekor check not
+        being attempted (no ``rekor`` block) does not make ``ok`` False — a
+        locally-anchored proof is valid without a public-log receipt.
+    failure:
+        The single typed reason verification failed, or :attr:`VerifyFailure.OK`
+        when ``ok`` is True. Exactly one failure is reported: checks run in order
+        (leaf → merkle → signature → rekor) and the first failure short-circuits,
+        because a later check is meaningless once an earlier invariant is broken
+        (e.g. an inclusion proof against a tampered leaf is not informative).
+    checks:
+        Per-step booleans for the checks that ran (``leaf``/``merkle``/
+        ``signature`` always when reached; ``rekor`` only when a receipt was
+        present). A step that did not run is absent from the mapping rather than
+        recorded ``False``, so ``checks`` distinguishes "ran and passed", "ran and
+        failed", and "not attempted".
+    rekor_checked:
+        Whether an offline Rekor inclusion check was performed (i.e. a ``rekor``
+        block was present and validated). ``False`` means no receipt was in the
+        bundle, NOT that one was present and failed (that would be ``ok=False``
+        with ``failure=REKOR_MISMATCH``).
+    """
+
+    ok: bool
+    failure: VerifyFailure
+    checks: dict[str, bool] = field(default_factory=dict)
+    rekor_checked: bool = False
+
+
+def _fail(failure: VerifyFailure, checks: dict[str, bool]) -> VerifyResult:
+    """Build a failed :class:`VerifyResult` carrying the checks run so far."""
+    return VerifyResult(
+        ok=False,
+        failure=failure,
+        checks=dict(checks),
+        rekor_checked=checks.get(_CHECK_REKOR, False),
+    )
+
+
+def _require_obj(mapping: object, key: str) -> dict[str, Any]:
+    """Return ``mapping[key]`` requiring both to be dicts, else raise.
+
+    Used inside the shape-validation try/except so a missing key or a non-dict
+    where a dict was expected both surface as MALFORMED_BUNDLE rather than an
+    uncaught exception escaping ``verify_bundle``.
+    """
+    if not isinstance(mapping, dict):
+        raise TypeError(f"expected an object to read {key!r} from")
+    value = mapping[key]
+    if not isinstance(value, dict):
+        raise TypeError(f"{key!r} must be an object")
+    return value
+
+
+def _hex_to_bytes(value: object) -> bytes:
+    """Decode a hex string to bytes, raising on any non-str / malformed hex.
+
+    A bundle field that should be hex but is an int, None, or malformed hex is a
+    shape error (MALFORMED_BUNDLE), so this raises ValueError/TypeError that the
+    caller's shape guard converts into a typed failure.
+    """
+    if not isinstance(value, str):
+        raise TypeError(f"expected a hex string, got {type(value).__name__}")
+    return bytes.fromhex(value)
+
+
+def _require_int(value: object, name: str) -> int:
+    """Return ``value`` as an int, rejecting bool (a bool is not a valid index)."""
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise TypeError(f"{name} must be an int")
+    return value
+
+
+def _parse_signed_at(value: object) -> datetime:
+    """Parse an RFC 3339 ``signed_at`` to a timezone-aware UTC ``datetime``.
+
+    Accepts a trailing ``Z`` (common in proof bundles) as well as explicit
+    offsets. A naive timestamp is treated as UTC. A non-string or unparseable
+    value raises, surfacing as MALFORMED_BUNDLE.
+    """
+    if not isinstance(value, str):
+        raise TypeError(f"signed_at must be a string, got {type(value).__name__}")
+    text = value[:-1] + "+00:00" if value.endswith("Z") else value
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _signed_message(
+    proof_format_version: object, merkle_root_hex: str, kid: str, signed_at: str
+) -> bytes:
+    """Reconstruct the exact bytes the signature covers (SD-001).
+
+    Canonicalizes the frozen four-field set with :func:`canon` (RFC 8785 JCS).
+    JCS sorts object keys, so the literal order here is irrelevant — what is
+    fixed is the field *set*. Building this from the bundle's own values means a
+    verifier recomputes the signer's message rather than trusting any precomputed
+    "signed_message" the bundle might (maliciously) carry.
+    """
+    return canon(
+        {
+            "proof_format_version": proof_format_version,
+            "merkle_root": merkle_root_hex,
+            "kid": kid,
+            "signed_at": signed_at,
+        }
+    )
+
+
+def verify_bundle(
+    proof_bundle: dict[str, Any], trusted_keys: Ed25519KeyManifest
+) -> VerifyResult:
+    """Verify a GraQle-format proof bundle offline against a trusted-key manifest.
+
+    Parameters
+    ----------
+    proof_bundle:
+        A bundle conforming to the schema in the module docstring. Treated as
+        untrusted input: any structural defect yields
+        :attr:`VerifyFailure.MALFORMED_BUNDLE` rather than an exception.
+    trusted_keys:
+        The :class:`Ed25519KeyManifest` holding the public keys (and their
+        validity windows + lifecycle states) the verifier trusts. A verify-only
+        manifest holding only public material is the common case.
+
+    Returns
+    -------
+    VerifyResult
+        ``ok=True`` with ``failure=OK`` iff every attempted check passed; else
+        ``ok=False`` with the single typed :class:`VerifyFailure` for the first
+        failing step. Never raises for a bad *proof*; raises
+        :class:`VerifierError` only for caller misuse (a non-manifest
+        ``trusted_keys``).
+    """
+    if not isinstance(trusted_keys, Ed25519KeyManifest):
+        raise VerifierError(
+            "trusted_keys must be an Ed25519KeyManifest holding the public keys "
+            f"to trust; got {type(trusted_keys).__name__}"
+        )
+
+    checks: dict[str, bool] = {}
+
+    # ── Step 0: shape ────────────────────────────────────────────────────────
+    # Pull every field we need up front; any KeyError/TypeError/ValueError here
+    # means the bundle is structurally malformed. We catch broadly (those three
+    # families only) so a missing key, a wrong type, or bad hex all map to one
+    # typed failure instead of leaking a stack trace to the caller.
+    try:
+        if not isinstance(proof_bundle, dict):
+            raise TypeError("proof_bundle must be an object")
+        proof_format_version = proof_bundle["proof_format_version"]
+
+        record = proof_bundle["record"]
+        if not isinstance(record, dict):
+            raise TypeError("record must be an object")
+
+        leaf = _require_obj(proof_bundle, "leaf")
+        leaf_index = _require_int(leaf["leaf_index"], "leaf_index")
+        tree_size = _require_int(leaf["tree_size"], "tree_size")
+        stated_leaf_hash = _hex_to_bytes(leaf["leaf_hash"])
+
+        merkle = _require_obj(proof_bundle, "merkle")
+        merkle_root_hex = merkle["merkle_root"]
+        merkle_root = _hex_to_bytes(merkle_root_hex)
+        merkle_path_hex = merkle["merkle_path"]
+        directions = merkle["merkle_path_directions"]
+        if not isinstance(merkle_path_hex, list) or not isinstance(directions, list):
+            raise TypeError("merkle_path and merkle_path_directions must be arrays")
+        merkle_path = [_hex_to_bytes(h) for h in merkle_path_hex]
+
+        signature = _require_obj(proof_bundle, "signature")
+        alg = signature["alg"]
+        kid = signature["kid"]
+        sig_bytes = _hex_to_bytes(signature["sig"])
+        signed_at_raw = signature["signed_at"]
+        if not isinstance(kid, str):
+            raise TypeError("signature.kid must be a string")
+        signed_at = _parse_signed_at(signed_at_raw)
+    except (KeyError, TypeError, ValueError):
+        return _fail(VerifyFailure.MALFORMED_BUNDLE, checks)
+
+    # Only ed25519 is accepted; an unexpected alg is a malformed/unsupported
+    # bundle, not a trust failure (we never reached a key).
+    if alg != "ed25519":
+        return _fail(VerifyFailure.MALFORMED_BUNDLE, checks)
+
+    # ── Step 1: leaf recompute ───────────────────────────────────────────────
+    # Recompute the leaf hash from the record itself and compare (constant-time)
+    # to the stated leaf hash. canon_leaf (inside leaf_hash_for_record) requires
+    # proof_format_version inside the record; a record lacking it raises, which
+    # we treat as a tampered/invalid leaf rather than a malformed wrapper.
+    try:
+        recomputed_leaf = leaf_hash_for_record(record)
+    except (TamperEvidenceError, ValueError, TypeError):
+        return _fail(VerifyFailure.TAMPERED_LEAF, checks)
+    if not hmac.compare_digest(recomputed_leaf, stated_leaf_hash):
+        return _fail(VerifyFailure.TAMPERED_LEAF, checks)
+    checks[_CHECK_LEAF] = True
+
+    # ── Step 2: Merkle inclusion ─────────────────────────────────────────────
+    # Reconstruct the inclusion proof from the RECOMPUTED leaf hash (not the
+    # stated one — using the recomputed hash means the inclusion proof is checked
+    # against the bytes we actually trust). InclusionProof's constructor enforces
+    # path/direction length + value integrity; a structural defect there is a
+    # malformed proof, surfaced as WRONG_ROOT (the merkle step did not pass).
+    try:
+        inclusion = InclusionProof(
+            leaf_index=leaf_index,
+            tree_size=tree_size,
+            leaf_hash=recomputed_leaf,
+            merkle_path=merkle_path,
+            merkle_path_directions=list(directions),
+        )
+        merkle_ok = inclusion.verify(merkle_root)
+    except (TamperEvidenceError, ValueError, TypeError):
+        return _fail(VerifyFailure.WRONG_ROOT, checks)
+    if not merkle_ok:
+        return _fail(VerifyFailure.WRONG_ROOT, checks)
+    checks[_CHECK_MERKLE] = True
+
+    # ── Step 3: signature trust ──────────────────────────────────────────────
+    # Verify the ed25519 signature over the reconstructed signed_message at the
+    # proof's recorded time. An unknown kid is a distinct, caller-relevant
+    # condition (the signer is not in the manifest at all) vs. a known-but-
+    # untrusted key (revoked / out-of-window) or a bad signature — the latter two
+    # are indistinguishable by design (manifest.verify returns False) and both
+    # collapse to UNTRUSTED_KID.
+    signed_message = _signed_message(
+        proof_format_version, merkle_root_hex, kid, signed_at_raw
+    )
+    try:
+        signature_ok = trusted_keys.verify(kid, signed_message, sig_bytes, at=signed_at)
+    except UnknownKidError:
+        return _fail(VerifyFailure.UNKNOWN_KID, checks)
+    if not signature_ok:
+        return _fail(VerifyFailure.UNTRUSTED_KID, checks)
+    checks[_CHECK_SIGNATURE] = True
+
+    # ── Step 4: optional offline Rekor inclusion ─────────────────────────────
+    # A rekor block is OPTIONAL. When present, it must commit to the same root we
+    # just verified the record into. We do NOT contact the network: the receipt's
+    # signed_tree_head is treated as data and checked for consistency with
+    # merkle_root. A present-but-inconsistent receipt fails closed.
+    rekor = proof_bundle.get("rekor")
+    if rekor is not None:
+        if not _verify_rekor_offline(rekor, merkle_root_hex):
+            checks[_CHECK_REKOR] = False
+            return _fail(VerifyFailure.REKOR_MISMATCH, checks)
+        checks[_CHECK_REKOR] = True
+
+    return VerifyResult(
+        ok=True,
+        failure=VerifyFailure.OK,
+        checks=dict(checks),
+        rekor_checked=checks.get(_CHECK_REKOR, False),
+    )
+
+
+def _verify_rekor_offline(rekor: object, merkle_root_hex: str) -> bool:
+    """Offline consistency check of a Rekor receipt against the Merkle root.
+
+    This is a *data* check, never a network call (the verifier's isolation
+    contract). A well-formed receipt must (a) be an object carrying the required
+    fields and (b) bind the same ``merkle_root`` the inclusion proof verified
+    into — the receipt's ``signed_tree_head`` must reference that exact root hex.
+
+    Full cryptographic validation of Rekor's signed tree head against the Rekor
+    public key (Sigstore key material) is performed by an external auditor /
+    ``rekor-cli`` and is intentionally out of scope for the offline SDK verifier,
+    which holds no Rekor key material and makes no network calls. What we
+    guarantee here is that the binding the bundle asserts is internally
+    consistent: the receipt in the bundle is *about this root*, so a receipt
+    copied from a different anchor cannot be passed off as this proof's anchor.
+    Returns ``True`` iff the receipt is well-formed and references
+    ``merkle_root_hex``; ``False`` (fail closed) for any structural defect or a
+    root mismatch.
+    """
+    if not isinstance(rekor, dict):
+        return False
+    required = ("log_index", "log_id", "signed_tree_head", "inclusion_cert")
+    if any(key_name not in rekor for key_name in required):
+        return False
+    signed_tree_head = rekor["signed_tree_head"]
+    if not isinstance(signed_tree_head, str):
+        return False
+    # The receipt must reference the exact root hex we verified into. We compare
+    # constant-time on the encoded bytes; the root hex carried in the STH is the
+    # binding between this receipt and this proof.
+    return hmac.compare_digest(
+        merkle_root_hex.encode("utf-8"),
+        _extract_anchored_root_hex(signed_tree_head).encode("utf-8"),
+    )
+
+
+def _extract_anchored_root_hex(signed_tree_head: str) -> str:
+    """Extract the anchored root hex a Rekor STH commits to.
+
+    Bundles produced by GraQle's own committer record the anchored root hex
+    directly as the ``signed_tree_head`` value (the STH's root_hash field,
+    lower-hex). External Rekor STHs carry the root inside a signed JSON blob;
+    parsing/validating those against the Rekor public key is the external
+    auditor's job (see :func:`_verify_rekor_offline`). Here we return the value
+    as-is so the offline binding check compares like-for-like; a mismatch with
+    ``merkle_root_hex`` fails closed upstream.
+    """
+    return signed_tree_head
+
+
+__all__ = [
+    "VerifyFailure",
+    "VerifyResult",
+    "VerifierError",
+    "verify_bundle",
+]

--- a/graqle/verify/__init__.py
+++ b/graqle/verify/__init__.py
@@ -1,0 +1,305 @@
+"""Offline proof-bundle verification surface (WS-A2) — CLI + ``python -m`` core.
+
+This package is the *user-facing* skin over
+:func:`graqle.governance.tamper_evidence.verifier.verify_bundle` (WS-A1, moat M2).
+It ships in **Community** (Apache-2.0) and is NEVER gated: anyone with
+``pip install graqle``, a proof bundle, and the signer's public key(s) can verify
+a proof offline, with no network and no proprietary code.
+
+Two entrypoints share the one core here:
+
+* ``python -m graqle.verify <bundle.json> --key <pub.pem>`` (this package's
+  :mod:`graqle.verify.__main__`), and
+* ``graq attest verify <bundle.json> --key <pub.pem>`` (the Typer sub-app in
+  :mod:`graqle.cli.commands.attest`).
+
+Both call :func:`run_verify`, so the verification logic, exit codes, and JSON
+output are identical regardless of which surface is used.
+
+Isolation contract
+-------------------
+This module imports only the standard library, ``cryptography``, and the two
+isolated tamper-evidence modules (the verifier + the ed25519 key manifest). It
+imports **nothing** from ``graqle.server``/``graqle.studio``/anchoring/network,
+so ``python -m graqle.verify`` runs in a studio-free interpreter (WS-A3
+subprocess invariant). The WS-A3 CI AST gate enforces this statically.
+
+Key material formats
+--------------------
+``run_verify`` accepts the trusted keys two ways:
+
+* ``--key <pub.pem>`` — a single ed25519 public-key PEM. The bundle's own
+  ``signature.kid`` is registered under a wide-open trust window, so a single
+  PEM "just works" for the common case (you trust this one key for this proof).
+  The bundle's lifecycle/window security still comes from the *signing* side;
+  with a bare PEM the verifier trusts the key for any time.
+* ``--keys <keyring.json>`` — a JSON keyring giving explicit per-kid windows and
+  lifecycle states, so an auditor can verify a proof under the *exact* trust
+  state that applied when it was produced (e.g. a since-revoked key)::
+
+      {
+        "keys": [
+          {
+            "kid": "graqle-sdk-signing-2026-Q2",
+            "public_key_pem": "-----BEGIN PUBLIC KEY-----\\n...",
+            "valid_from": "2026-04-01T00:00:00Z",
+            "valid_until": "2026-12-31T23:59:59Z",
+            "state": "ACTIVE"        # ACTIVE | RETIRED | REVOKED
+          }
+        ]
+      }
+
+Exit codes (shared by both surfaces)
+------------------------------------
+* ``0`` — the bundle verified (``VerifyResult.ok``).
+* ``1`` — the bundle did not verify (a typed failure).
+* ``2`` — bad CLI input / unreadable or malformed key/bundle file (a usage
+  error, distinct from a proof that simply failed to verify).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from graqle.governance.custody.ed25519_key_manifest import (
+    Ed25519KeyManifest,
+    KeyState,
+)
+from graqle.governance.tamper_evidence.verifier import (
+    VerifyResult,
+    verify_bundle,
+)
+
+# Exit codes — a module-level contract shared by both surfaces.
+EXIT_OK = 0
+EXIT_FAILED = 1
+EXIT_USAGE = 2
+
+# A bare --key PEM is trusted across this wide window (the bundle's own
+# signing-time lifecycle is the real control; a single PEM means "I trust this
+# key for this proof" without the caller having to state a window).
+_WIDE_OPEN_FROM = datetime(1970, 1, 1, tzinfo=timezone.utc)
+_WIDE_OPEN_UNTIL = datetime(9999, 12, 31, tzinfo=timezone.utc)
+
+
+class VerifyUsageError(Exception):
+    """A usage error (bad/unreadable input) — maps to exit code 2.
+
+    Distinct from a proof that fails to verify (exit 1): this means the caller
+    gave us something we could not even attempt to verify (missing file, bad
+    PEM, malformed keyring JSON).
+    """
+
+
+def _load_public_key(pem_bytes: bytes):
+    """Load an ed25519 public key from PEM bytes, raising VerifyUsageError on failure."""
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PublicKey,
+    )
+
+    try:
+        key = serialization.load_pem_public_key(pem_bytes)
+    except Exception as exc:  # cryptography raises a variety of types
+        raise VerifyUsageError(f"could not parse public-key PEM: {exc}") from exc
+    if not isinstance(key, Ed25519PublicKey):
+        raise VerifyUsageError(
+            "public key is not an ed25519 key; the GraQle verifier only trusts "
+            "ed25519 signing keys"
+        )
+    return key
+
+
+def _parse_state(raw: object, kid: str) -> KeyState:
+    """Parse a keyring entry's lifecycle state string to a KeyState."""
+    if raw is None:
+        return KeyState.ACTIVE
+    if not isinstance(raw, str):
+        raise VerifyUsageError(f"keyring entry {kid!r}: state must be a string")
+    try:
+        return KeyState[raw.strip().upper()]
+    except KeyError as exc:
+        raise VerifyUsageError(
+            f"keyring entry {kid!r}: unknown state {raw!r}; expected one of "
+            "ACTIVE, RETIRED, REVOKED"
+        ) from exc
+
+
+def _parse_ts(raw: object, kid: str, field_name: str, default: datetime) -> datetime:
+    """Parse an RFC 3339 timestamp from a keyring entry, or use ``default``."""
+    if raw is None:
+        return default
+    if not isinstance(raw, str):
+        raise VerifyUsageError(
+            f"keyring entry {kid!r}: {field_name} must be an RFC 3339 string"
+        )
+    text = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise VerifyUsageError(
+            f"keyring entry {kid!r}: {field_name} is not a valid RFC 3339 "
+            f"timestamp: {raw!r}"
+        ) from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def manifest_from_single_key(pem_bytes: bytes, kid: str) -> Ed25519KeyManifest:
+    """Build a one-key manifest trusting ``kid`` across a wide-open window.
+
+    Used for the ``--key <pub.pem>`` convenience path: the single PEM is
+    registered under the bundle's own ``kid`` so ``verify_bundle`` finds it.
+    """
+    manifest = Ed25519KeyManifest()
+    manifest.register(
+        kid=kid,
+        public_key=_load_public_key(pem_bytes),
+        valid_from=_WIDE_OPEN_FROM,
+        valid_until=_WIDE_OPEN_UNTIL,
+    )
+    return manifest
+
+
+def manifest_from_keyring(keyring: dict[str, Any]) -> Ed25519KeyManifest:
+    """Build a manifest from a parsed keyring dict (explicit windows + states).
+
+    Raises :class:`VerifyUsageError` on any malformed entry — a keyring is
+    operator-supplied trust configuration, so a defect must be loud, not
+    silently dropped (mirrors the pct keyring-loader discipline).
+    """
+    if not isinstance(keyring, dict) or not isinstance(keyring.get("keys"), list):
+        raise VerifyUsageError(
+            "keyring must be a JSON object with a 'keys' array"
+        )
+    manifest = Ed25519KeyManifest()
+    seen = 0
+    for entry in keyring["keys"]:
+        if not isinstance(entry, dict):
+            raise VerifyUsageError("each keyring entry must be a JSON object")
+        kid = entry.get("kid")
+        pem = entry.get("public_key_pem")
+        if not isinstance(kid, str) or not kid:
+            raise VerifyUsageError("keyring entry missing a non-empty 'kid'")
+        if not isinstance(pem, str) or not pem:
+            raise VerifyUsageError(
+                f"keyring entry {kid!r} missing a non-empty 'public_key_pem'"
+            )
+        state = _parse_state(entry.get("state"), kid)
+        valid_from = _parse_ts(entry.get("valid_from"), kid, "valid_from", _WIDE_OPEN_FROM)
+        valid_until = _parse_ts(
+            entry.get("valid_until"), kid, "valid_until", _WIDE_OPEN_UNTIL
+        )
+        manifest.register(
+            kid=kid,
+            public_key=_load_public_key(pem.encode("ascii")),
+            valid_from=valid_from,
+            valid_until=valid_until,
+            state=state,
+        )
+        seen += 1
+    if seen == 0:
+        raise VerifyUsageError("keyring 'keys' array is empty — no keys to trust")
+    return manifest
+
+
+def _read_json_file(path: Path, what: str) -> Any:
+    """Read + parse a JSON file, raising VerifyUsageError on any I/O or parse error."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise VerifyUsageError(f"cannot read {what} file {path}: {exc}") from exc
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise VerifyUsageError(f"{what} file is not valid JSON: {exc}") from exc
+
+
+def load_manifest(
+    *, key_path: Path | None, keys_path: Path | None, bundle: dict[str, Any]
+) -> Ed25519KeyManifest:
+    """Build the trusted-key manifest from --key or --keys.
+
+    Exactly one of ``key_path`` / ``keys_path`` must be given. With ``--key``,
+    the single PEM is registered under the bundle's own ``signature.kid``.
+    """
+    if (key_path is None) == (keys_path is None):
+        raise VerifyUsageError(
+            "provide exactly one of --key <pub.pem> or --keys <keyring.json>"
+        )
+    if key_path is not None:
+        try:
+            pem_bytes = key_path.read_bytes()
+        except OSError as exc:
+            raise VerifyUsageError(f"cannot read key file {key_path}: {exc}") from exc
+        sig = bundle.get("signature")
+        kid = sig.get("kid") if isinstance(sig, dict) else None
+        if not isinstance(kid, str) or not kid:
+            raise VerifyUsageError(
+                "bundle has no signature.kid to register the --key under; "
+                "use --keys with an explicit kid instead"
+            )
+        return manifest_from_single_key(pem_bytes, kid)
+    keyring = _read_json_file(keys_path, "keyring")
+    return manifest_from_keyring(keyring)
+
+
+def result_to_dict(result: VerifyResult) -> dict[str, Any]:
+    """Render a VerifyResult as a JSON-serializable dict (the --format json shape)."""
+    return {
+        "ok": result.ok,
+        "failure": result.failure.value,
+        "checks": dict(result.checks),
+        "rekor_checked": result.rekor_checked,
+    }
+
+
+def run_verify(
+    *,
+    bundle_path: Path,
+    key_path: Path | None = None,
+    keys_path: Path | None = None,
+    rekor_sth_path: Path | None = None,
+) -> tuple[int, dict[str, Any]]:
+    """Verify a bundle file and return ``(exit_code, result_dict)``.
+
+    The single core both surfaces (CLI + ``python -m``) call. Reads the bundle
+    JSON, builds the trusted-key manifest, optionally injects an external Rekor
+    STH file into the bundle's ``rekor`` block, runs :func:`verify_bundle`, and
+    maps the outcome to an exit code. Raises :class:`VerifyUsageError` (exit 2)
+    for input problems; returns exit 0/1 for a verified/failed proof.
+    """
+    bundle = _read_json_file(bundle_path, "bundle")
+    if not isinstance(bundle, dict):
+        raise VerifyUsageError("bundle file must contain a JSON object")
+
+    # Optional external Rekor STH file: injected as DATA into the bundle's rekor
+    # block (never fetched). If the bundle already carries a rekor block, an
+    # explicit --rekor-sth file overrides it so an auditor can supply their own.
+    if rekor_sth_path is not None:
+        sth = _read_json_file(rekor_sth_path, "rekor STH")
+        if not isinstance(sth, dict):
+            raise VerifyUsageError("rekor STH file must contain a JSON object")
+        bundle = {**bundle, "rekor": sth}
+
+    manifest = load_manifest(key_path=key_path, keys_path=keys_path, bundle=bundle)
+    result = verify_bundle(bundle, manifest)
+    exit_code = EXIT_OK if result.ok else EXIT_FAILED
+    return exit_code, result_to_dict(result)
+
+
+__all__ = [
+    "EXIT_OK",
+    "EXIT_FAILED",
+    "EXIT_USAGE",
+    "VerifyUsageError",
+    "manifest_from_single_key",
+    "manifest_from_keyring",
+    "load_manifest",
+    "result_to_dict",
+    "run_verify",
+]

--- a/graqle/verify/__main__.py
+++ b/graqle/verify/__main__.py
@@ -1,0 +1,107 @@
+"""``python -m graqle.verify`` — offline proof-bundle verification entrypoint.
+
+A stdlib-only (argparse) entrypoint over :func:`graqle.verify.run_verify`, kept
+deliberately dependency-light so it runs in a studio-free interpreter with only
+``graqle`` installed (no extras, no Typer) — this is the surface the WS-A3
+subprocess invariant exercises.
+
+Usage::
+
+    python -m graqle.verify <bundle.json> --key <pub.pem>
+    python -m graqle.verify <bundle.json> --keys <keyring.json> --format json
+    python -m graqle.verify <bundle.json> --key <pub.pem> --rekor-sth <sth.json>
+
+Exit codes: 0 verified · 1 not verified · 2 usage/input error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from graqle.verify import EXIT_USAGE, VerifyUsageError, run_verify
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m graqle.verify",
+        description=(
+            "Verify a GraQle-format tamper-evidence proof bundle offline. "
+            "No network; no proprietary code. Exit 0 = verified, 1 = not "
+            "verified, 2 = usage error."
+        ),
+    )
+    parser.add_argument(
+        "bundle",
+        help="Path to the proof-bundle JSON file to verify.",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--key",
+        metavar="PUB.PEM",
+        help="Path to a single ed25519 public-key PEM trusted for this proof.",
+    )
+    group.add_argument(
+        "--keys",
+        metavar="KEYRING.JSON",
+        help=(
+            "Path to a JSON keyring with explicit per-kid windows + lifecycle "
+            "states (for auditing a proof under its historical trust state)."
+        ),
+    )
+    parser.add_argument(
+        "--rekor-sth",
+        metavar="STH.JSON",
+        default=None,
+        help=(
+            "Optional Rekor signed-tree-head JSON to check the proof against "
+            "(offline; treated as data, never fetched)."
+        ),
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format (default: text).",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Parse args, run verification, print the result, return the exit code."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        exit_code, result = run_verify(
+            bundle_path=Path(args.bundle),
+            key_path=Path(args.key) if args.key else None,
+            keys_path=Path(args.keys) if args.keys else None,
+            rekor_sth_path=Path(args.rekor_sth) if args.rekor_sth else None,
+        )
+    except VerifyUsageError as exc:
+        # Usage/input error -> exit 2, message to stderr (machine-readable too
+        # when --format json so a caller never has to parse prose).
+        if args.format == "json":
+            print(json.dumps({"ok": False, "error": str(exc)}), file=sys.stderr)
+        else:
+            print(f"error: {exc}", file=sys.stderr)
+        return EXIT_USAGE
+
+    if args.format == "json":
+        print(json.dumps(result))
+    else:
+        status = "VERIFIED" if result["ok"] else "FAILED"
+        print(f"{status}: {result['failure']}")
+        for step, passed in result["checks"].items():
+            print(f"  {step}: {'pass' if passed else 'FAIL'}")
+        if not result["rekor_checked"]:
+            print("  rekor: not checked (no receipt in bundle)")
+    return exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via subprocess
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.63.1"
+version = "0.64.0"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Proprietary — see LICENSE"}

--- a/tests/test_tamper_evidence/test_verifier.py
+++ b/tests/test_tamper_evidence/test_verifier.py
@@ -486,14 +486,30 @@ def test_isolation_guard_allows_lookalike_prefixes():
 
 
 def test_module_import_did_not_load_server_or_studio():
-    # The verifier import (top of this file) must not have pulled server/studio in.
-    assert not any(
-        name == "graqle.server"
-        or name.startswith("graqle.server.")
-        or name == "graqle.studio"
-        or name.startswith("graqle.studio.")
-        for name in sys.modules
+    # Importing the verifier must NOT pull graqle.server/graqle.studio into
+    # sys.modules. This is checked in a CLEAN subprocess (not the current
+    # interpreter): sys.modules is process-global, so other tests in the full
+    # suite that legitimately import server/studio would pollute a same-process
+    # check and make it spuriously fail (local-isolated-green != CI-full-suite).
+    # A fresh interpreter that imports only the verifier isolates the question to
+    # "does importing the verifier load server/studio" — which is what we mean.
+    script = (
+        "import sys;"
+        "import graqle.governance.tamper_evidence.verifier;"
+        "bad = [n for n in sys.modules if n == 'graqle.server' "
+        "or n.startswith('graqle.server.') or n == 'graqle.studio' "
+        "or n.startswith('graqle.studio.')];"
+        "assert not bad, bad;"
+        "print('CLEAN')"
     )
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        shell=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "CLEAN" in proc.stdout
 
 
 # ── Subprocess invariant: verify in a studio-free interpreter (AC-1/AC-3) ─────

--- a/tests/test_tamper_evidence/test_verifier.py
+++ b/tests/test_tamper_evidence/test_verifier.py
@@ -1,0 +1,540 @@
+"""Tests for the standalone offline proof-bundle verifier (WS-A1, moat M2).
+
+These tests build a REAL signed + Merkle-anchored bundle end-to-end from the
+shipped primitives (no mocks for the crypto): a genuine ``MerkleTree`` over real
+records and a genuine ``Ed25519KeyManifest`` signing key. Each failure mode is
+then exercised by fault-injecting a single field into a valid bundle, so the
+typed failures are proven against real cryptographic rejection rather than
+stubbed behaviour. Coverage is realistic (fault injection reaches every
+defensive branch), per the 100%-realistic-coverage standing directive.
+
+The bundle the fixtures build is exactly the canonical WS-A1 schema, so these
+tests also pin the moat-M2 wire format.
+"""
+
+from __future__ import annotations
+
+import copy
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from graqle.governance.custody.ed25519_key_manifest import (
+    Ed25519KeyManifest,
+    KeyState,
+)
+from graqle.governance.tamper_evidence.merkle import MerkleTree
+from graqle.governance.tamper_evidence.verifier import (
+    VerifyFailure,
+    VerifyResult,
+    VerifierError,
+    _assert_isolated,
+    _extract_anchored_root_hex,
+    _parse_signed_at,
+    _require_obj,
+    _verify_rekor_offline,
+    verify_bundle,
+)
+
+# ── Fixture constants ────────────────────────────────────────────────────────
+KID = "graqle-sdk-signing-2026-Q2"
+SIGNED_AT = "2026-05-31T13:00:00Z"
+SIGNED_AT_DT = datetime(2026, 5, 31, 13, 0, 0, tzinfo=timezone.utc)
+PROOF_FORMAT_VERSION = "1"
+
+
+def _record(record_id: str = "rec-A") -> dict:
+    """A valid governed-trace record carrying the required leaf fields."""
+    return {
+        "proof_format_version": PROOF_FORMAT_VERSION,
+        "record_id": record_id,
+        "content_hash": "a" * 64,
+        "timestamp_unix": 1748000000,
+        "governance_metadata": {"gate": "CLEAR"},
+        # a wrapper field outside LEAF_HASH_FIELDS — must NOT affect the leaf:
+        "ignored_wrapper_field": "noise",
+    }
+
+
+def _manifest_with_key(
+    *,
+    state: KeyState = KeyState.ACTIVE,
+    valid_from: datetime | None = None,
+    valid_until: datetime | None = None,
+) -> tuple[Ed25519KeyManifest, Ed25519PrivateKey]:
+    """A manifest holding one signing key (ACTIVE by default), plus its private key."""
+    manifest = Ed25519KeyManifest()
+    private_key = Ed25519PrivateKey.generate()
+    manifest.register(
+        kid=KID,
+        public_key=private_key.public_key(),
+        valid_from=valid_from or (SIGNED_AT_DT - timedelta(days=1)),
+        valid_until=valid_until or (SIGNED_AT_DT + timedelta(days=365)),
+        state=KeyState.ACTIVE,  # register active so we can sign, then transition
+        private_key=private_key,
+    )
+    if state is KeyState.RETIRED:
+        manifest.retire(KID)
+    elif state is KeyState.REVOKED:
+        manifest.revoke(KID)
+    return manifest, private_key
+
+
+def _build_valid_bundle(
+    *,
+    records: list[dict] | None = None,
+    index: int = 0,
+    manifest: Ed25519KeyManifest | None = None,
+    include_rekor: bool = False,
+) -> dict:
+    """Build a fully valid, signed, Merkle-anchored proof bundle.
+
+    Signs with an ACTIVE key (signing requires ACTIVE), then the caller may swap
+    in a manifest whose key has since been retired/revoked to test verify-time
+    trust transitions independently of sign-time.
+    """
+    records = records or [_record("rec-A"), _record("rec-B"), _record("rec-C")]
+    tree = MerkleTree.from_records(records)
+    proof = tree.inclusion_proof(index)
+    root_hex = tree.root_hex
+
+    signing_manifest = Ed25519KeyManifest()
+    signing_priv = Ed25519PrivateKey.generate()
+    signing_manifest.register(
+        kid=KID,
+        public_key=signing_priv.public_key(),
+        valid_from=SIGNED_AT_DT - timedelta(days=1),
+        valid_until=SIGNED_AT_DT + timedelta(days=365),
+        private_key=signing_priv,
+    )
+    # Reconstruct the exact signed message the verifier will rebuild (SD-001).
+    from graqle.governance.tamper_evidence.verifier import _signed_message
+
+    message = _signed_message(PROOF_FORMAT_VERSION, root_hex, KID, SIGNED_AT)
+    sig_hex = signing_manifest.sign(KID, message, at=SIGNED_AT_DT).hex()
+
+    bundle = {
+        "proof_format_version": PROOF_FORMAT_VERSION,
+        "record": records[index],
+        "leaf": {
+            "leaf_index": index,
+            "tree_size": tree.size,
+            "leaf_hash": proof.leaf_hash.hex(),
+        },
+        "merkle": {
+            "merkle_root": root_hex,
+            "merkle_path": [h.hex() for h in proof.merkle_path],
+            "merkle_path_directions": list(proof.merkle_path_directions),
+        },
+        "signature": {
+            "alg": "ed25519",
+            "kid": KID,
+            "sig": sig_hex,
+            "signed_at": SIGNED_AT,
+        },
+    }
+    if include_rekor:
+        bundle["rekor"] = {
+            "log_index": 42,
+            "log_id": "rekor.sigstore.dev",
+            "signed_tree_head": root_hex,  # GraQle committer records root hex here
+            "inclusion_cert": "deadbeef",
+            "integrated_time": 1748000100,
+        }
+
+    # The verifying manifest trusts the SAME public key the signer used.
+    if manifest is None:
+        manifest = Ed25519KeyManifest()
+        manifest.register(
+            kid=KID,
+            public_key=signing_priv.public_key(),
+            valid_from=SIGNED_AT_DT - timedelta(days=1),
+            valid_until=SIGNED_AT_DT + timedelta(days=365),
+        )
+    bundle["_test_manifest"] = manifest  # stashed for the test; popped before verify
+    bundle["_test_signing_pub"] = signing_priv.public_key()
+    return bundle
+
+
+def _split(bundle: dict) -> tuple[dict, Ed25519KeyManifest]:
+    """Pop the stashed test manifest out of a fixture bundle."""
+    b = copy.deepcopy(
+        {k: v for k, v in bundle.items() if not k.startswith("_test_")}
+    )
+    return b, bundle["_test_manifest"]
+
+
+# ── Happy path ───────────────────────────────────────────────────────────────
+def test_valid_bundle_verifies():
+    bundle, manifest = _split(_build_valid_bundle())
+    result = verify_bundle(bundle, manifest)
+    assert isinstance(result, VerifyResult)
+    assert result.ok is True
+    assert result.failure is VerifyFailure.OK
+    assert result.checks == {"leaf": True, "merkle": True, "signature": True}
+    assert result.rekor_checked is False
+
+
+def test_valid_bundle_with_rekor_verifies():
+    bundle, manifest = _split(_build_valid_bundle(include_rekor=True))
+    result = verify_bundle(bundle, manifest)
+    assert result.ok is True
+    assert result.rekor_checked is True
+    assert result.checks["rekor"] is True
+
+
+@pytest.mark.parametrize("index", [0, 1, 2])
+def test_every_leaf_index_verifies(index):
+    bundle, manifest = _split(_build_valid_bundle(index=index))
+    assert verify_bundle(bundle, manifest).ok is True
+
+
+def test_wrapper_field_does_not_affect_leaf():
+    """A field outside LEAF_HASH_FIELDS can change without breaking the proof."""
+    bundle, manifest = _split(_build_valid_bundle())
+    bundle["record"]["ignored_wrapper_field"] = "totally-different"
+    assert verify_bundle(bundle, manifest).ok is True
+
+
+# ── Failure modes (fault injection) ──────────────────────────────────────────
+def test_tampered_leaf_hash_fails():
+    bundle, manifest = _split(_build_valid_bundle())
+    bundle["leaf"]["leaf_hash"] = "f" * 64
+    result = verify_bundle(bundle, manifest)
+    assert result.ok is False
+    assert result.failure is VerifyFailure.TAMPERED_LEAF
+
+
+def test_tampered_record_fails_as_tampered_leaf():
+    bundle, manifest = _split(_build_valid_bundle())
+    bundle["record"]["content_hash"] = "b" * 64  # a leaf field -> changes the hash
+    result = verify_bundle(bundle, manifest)
+    assert result.ok is False
+    assert result.failure is VerifyFailure.TAMPERED_LEAF
+
+
+def test_record_missing_proof_format_version_fails_as_tampered_leaf():
+    bundle, manifest = _split(_build_valid_bundle())
+    del bundle["record"]["proof_format_version"]
+    result = verify_bundle(bundle, manifest)
+    assert result.ok is False
+    assert result.failure is VerifyFailure.TAMPERED_LEAF
+
+
+def test_wrong_root_fails():
+    bundle, manifest = _split(_build_valid_bundle())
+    bundle["merkle"]["merkle_root"] = "0" * 64
+    result = verify_bundle(bundle, manifest)
+    assert result.ok is False
+    assert result.failure is VerifyFailure.WRONG_ROOT
+    assert result.checks == {"leaf": True}
+
+
+def test_tampered_merkle_path_fails_wrong_root():
+    bundle, manifest = _split(_build_valid_bundle())
+    # flip one sibling hash in the path
+    path = bundle["merkle"]["merkle_path"]
+    path[0] = "c" * 64
+    result = verify_bundle(bundle, manifest)
+    assert result.ok is False
+    assert result.failure is VerifyFailure.WRONG_ROOT
+
+
+def test_inconsistent_path_lengths_fail_wrong_root():
+    bundle, manifest = _split(_build_valid_bundle())
+    # break the InclusionProof __post_init__ invariant
+    bundle["merkle"]["merkle_path_directions"] = [0]
+    bundle["merkle"]["merkle_path"] = ["a" * 64, "b" * 64]
+    result = verify_bundle(bundle, manifest)
+    assert result.ok is False
+    assert result.failure is VerifyFailure.WRONG_ROOT
+
+
+def test_unknown_kid_fails():
+    bundle, _ = _split(_build_valid_bundle())
+    empty_manifest = Ed25519KeyManifest()  # no keys registered
+    result = verify_bundle(bundle, empty_manifest)
+    assert result.ok is False
+    assert result.failure is VerifyFailure.UNKNOWN_KID
+
+
+def test_revoked_kid_fails_untrusted():
+    # Sign valid, then verify against a manifest where the key is REVOKED.
+    revoked_manifest, _ = _manifest_with_key(state=KeyState.REVOKED)
+    bundle, _ = _split(_build_valid_bundle())
+    # point the manifest's key at the SAME public key the bundle was signed with
+    bundle_full = _build_valid_bundle()
+    signing_pub = bundle_full["_test_signing_pub"]
+    revoked_manifest2 = Ed25519KeyManifest()
+    revoked_manifest2.register(
+        kid=KID,
+        public_key=signing_pub,
+        valid_from=SIGNED_AT_DT - timedelta(days=1),
+        valid_until=SIGNED_AT_DT + timedelta(days=365),
+    )
+    revoked_manifest2.revoke(KID)
+    clean_bundle, _ = _split(bundle_full)
+    result = verify_bundle(clean_bundle, revoked_manifest2)
+    assert result.ok is False
+    assert result.failure is VerifyFailure.UNTRUSTED_KID
+
+
+def test_out_of_window_kid_fails_untrusted():
+    bundle_full = _build_valid_bundle()
+    signing_pub = bundle_full["_test_signing_pub"]
+    # window that does NOT include SIGNED_AT
+    manifest = Ed25519KeyManifest()
+    manifest.register(
+        kid=KID,
+        public_key=signing_pub,
+        valid_from=SIGNED_AT_DT + timedelta(days=10),
+        valid_until=SIGNED_AT_DT + timedelta(days=20),
+    )
+    clean_bundle, _ = _split(bundle_full)
+    result = verify_bundle(clean_bundle, manifest)
+    assert result.ok is False
+    assert result.failure is VerifyFailure.UNTRUSTED_KID
+
+
+def test_retired_kid_still_verifies():
+    """A RETIRED key still verifies historical proofs (within window)."""
+    bundle_full = _build_valid_bundle()
+    signing_pub = bundle_full["_test_signing_pub"]
+    manifest = Ed25519KeyManifest()
+    manifest.register(
+        kid=KID,
+        public_key=signing_pub,
+        valid_from=SIGNED_AT_DT - timedelta(days=1),
+        valid_until=SIGNED_AT_DT + timedelta(days=365),
+    )
+    manifest.retire(KID)
+    clean_bundle, _ = _split(bundle_full)
+    assert verify_bundle(clean_bundle, manifest).ok is True
+
+
+def test_wrong_key_signature_fails_untrusted():
+    """A signature from a different key than the manifest trusts is rejected."""
+    bundle, _ = _split(_build_valid_bundle())
+    other_priv = Ed25519PrivateKey.generate()
+    manifest = Ed25519KeyManifest()
+    manifest.register(
+        kid=KID,
+        public_key=other_priv.public_key(),  # different key
+        valid_from=SIGNED_AT_DT - timedelta(days=1),
+        valid_until=SIGNED_AT_DT + timedelta(days=365),
+    )
+    result = verify_bundle(bundle, manifest)
+    assert result.ok is False
+    assert result.failure is VerifyFailure.UNTRUSTED_KID
+
+
+def test_tampered_signed_at_fails_untrusted():
+    """Changing signed_at changes the signed message -> signature no longer valid."""
+    bundle, manifest = _split(_build_valid_bundle())
+    bundle["signature"]["signed_at"] = "2026-06-01T00:00:00Z"
+    result = verify_bundle(bundle, manifest)
+    assert result.ok is False
+    # still within window, but message differs -> crypto invalid -> UNTRUSTED_KID
+    assert result.failure is VerifyFailure.UNTRUSTED_KID
+
+
+# ── Rekor ────────────────────────────────────────────────────────────────────
+def test_rekor_mismatch_fails():
+    bundle, manifest = _split(_build_valid_bundle(include_rekor=True))
+    bundle["rekor"]["signed_tree_head"] = "d" * 64  # references a different root
+    result = verify_bundle(bundle, manifest)
+    assert result.ok is False
+    assert result.failure is VerifyFailure.REKOR_MISMATCH
+    assert result.checks["rekor"] is False
+    assert result.rekor_checked is False
+
+
+def test_rekor_missing_required_field_fails():
+    bundle, manifest = _split(_build_valid_bundle(include_rekor=True))
+    del bundle["rekor"]["log_id"]
+    result = verify_bundle(bundle, manifest)
+    assert result.ok is False
+    assert result.failure is VerifyFailure.REKOR_MISMATCH
+
+
+def test_rekor_non_dict_fails():
+    assert _verify_rekor_offline("not-a-dict", "a" * 64) is False
+
+
+def test_rekor_non_string_sth_fails():
+    rekor = {
+        "log_index": 1,
+        "log_id": "x",
+        "signed_tree_head": 12345,  # not a string
+        "inclusion_cert": "y",
+    }
+    assert _verify_rekor_offline(rekor, "a" * 64) is False
+
+
+def test_extract_anchored_root_hex_identity():
+    assert _extract_anchored_root_hex("abc123") == "abc123"
+
+
+# ── Malformed bundles ────────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda b: b.pop("proof_format_version"),
+        lambda b: b.pop("record"),
+        lambda b: b.pop("leaf"),
+        lambda b: b.pop("merkle"),
+        lambda b: b.pop("signature"),
+        lambda b: b.__setitem__("record", "not-a-dict"),
+        lambda b: b.__setitem__("leaf", "not-a-dict"),
+        lambda b: b["leaf"].__setitem__("leaf_index", "not-an-int"),
+        lambda b: b["leaf"].__setitem__("leaf_index", True),  # bool is not an int
+        lambda b: b["leaf"].__setitem__("tree_size", None),
+        lambda b: b["leaf"].__setitem__("leaf_hash", 123),  # not a hex string
+        lambda b: b["leaf"].__setitem__("leaf_hash", "zz"),  # invalid hex
+        lambda b: b["merkle"].__setitem__("merkle_path", "not-a-list"),
+        lambda b: b["merkle"].__setitem__("merkle_path_directions", "not-a-list"),
+        lambda b: b["merkle"].__setitem__("merkle_path", [123]),  # non-str in list
+        lambda b: b["signature"].__setitem__("kid", 999),  # not a string
+        lambda b: b["signature"].__setitem__("sig", "zz"),  # invalid hex
+        lambda b: b["signature"].__setitem__("signed_at", 12345),  # not a string
+        lambda b: b["signature"].__setitem__("signed_at", "not-a-date"),
+        lambda b: b["signature"].__setitem__("alg", "rsa"),  # unsupported alg
+    ],
+)
+def test_malformed_bundle_variants(mutate):
+    bundle, manifest = _split(_build_valid_bundle())
+    mutate(bundle)
+    result = verify_bundle(bundle, manifest)
+    assert result.ok is False
+    assert result.failure is VerifyFailure.MALFORMED_BUNDLE
+
+
+def test_non_dict_bundle_is_malformed():
+    _, manifest = _split(_build_valid_bundle())
+    result = verify_bundle("not-a-bundle", manifest)
+    assert result.ok is False
+    assert result.failure is VerifyFailure.MALFORMED_BUNDLE
+
+
+# ── Caller misuse ────────────────────────────────────────────────────────────
+def test_non_manifest_trusted_keys_raises_verifier_error():
+    bundle, _ = _split(_build_valid_bundle())
+    with pytest.raises(VerifierError):
+        verify_bundle(bundle, trusted_keys={"not": "a manifest"})
+
+
+# ── _require_obj helper (defensive non-dict guard) ───────────────────────────
+def test_require_obj_rejects_non_dict_mapping():
+    # The verify_bundle entry guard already ensures proof_bundle is a dict, so
+    # this defensive branch is exercised directly via the helper (fault
+    # injection, not pragma-hiding).
+    with pytest.raises(TypeError):
+        _require_obj("not-a-dict", "leaf")
+
+
+def test_require_obj_rejects_non_dict_value():
+    with pytest.raises(TypeError):
+        _require_obj({"leaf": "not-a-dict"}, "leaf")
+
+
+def test_require_obj_returns_dict():
+    assert _require_obj({"leaf": {"a": 1}}, "leaf") == {"a": 1}
+
+
+# ── signed_at parsing ────────────────────────────────────────────────────────
+def test_parse_signed_at_z_suffix():
+    assert _parse_signed_at("2026-05-31T13:00:00Z") == SIGNED_AT_DT
+
+
+def test_parse_signed_at_explicit_offset():
+    parsed = _parse_signed_at("2026-05-31T15:00:00+02:00")
+    assert parsed == SIGNED_AT_DT
+
+
+def test_parse_signed_at_naive_treated_as_utc():
+    parsed = _parse_signed_at("2026-05-31T13:00:00")
+    assert parsed == SIGNED_AT_DT
+
+
+def test_parse_signed_at_non_string_raises():
+    with pytest.raises(TypeError):
+        _parse_signed_at(12345)
+
+
+# ── Import-isolation guard ───────────────────────────────────────────────────
+def test_isolation_guard_passes_when_clean():
+    # No graqle.server / graqle.studio module -> no raise.
+    _assert_isolated({"graqle.core.graph": object(), "os": object()})
+
+
+@pytest.mark.parametrize(
+    "forbidden",
+    ["graqle.server", "graqle.server.lambda_handler", "graqle.studio", "graqle.studio.app"],
+)
+def test_isolation_guard_raises_on_forbidden_module(forbidden):
+    with pytest.raises(ImportError) as exc:
+        _assert_isolated({forbidden: object(), "graqle.core": object()})
+    assert "isolated" in str(exc.value)
+
+
+def test_isolation_guard_allows_lookalike_prefixes():
+    # 'graqle.serverless' is NOT 'graqle.server' (prefix must be a dotted boundary)
+    _assert_isolated({"graqle.serverless_helper": object()})
+
+
+def test_module_import_did_not_load_server_or_studio():
+    # The verifier import (top of this file) must not have pulled server/studio in.
+    assert not any(
+        name == "graqle.server"
+        or name.startswith("graqle.server.")
+        or name == "graqle.studio"
+        or name.startswith("graqle.studio.")
+        for name in sys.modules
+    )
+
+
+# ── Subprocess invariant: verify in a studio-free interpreter (AC-1/AC-3) ─────
+def test_verify_in_subprocess_without_studio():
+    """verify_bundle works in a fresh interpreter that never imports studio.
+
+    Uses shell=False with a fixed argv (no shell injection surface). Proves the
+    verifier is genuinely standalone: a fresh process imports only the verifier
+    and its allowed deps and verifies a real bundle, exiting 0.
+    """
+    script = (
+        "import sys;"
+        "from datetime import datetime, timedelta, timezone;"
+        "from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey;"
+        "from graqle.governance.custody.ed25519_key_manifest import Ed25519KeyManifest;"
+        "from graqle.governance.tamper_evidence.merkle import MerkleTree;"
+        "from graqle.governance.tamper_evidence.verifier import verify_bundle, _signed_message;"
+        "recs=[{'proof_format_version':'1','record_id':'r','content_hash':'a'*64,"
+        "'timestamp_unix':1,'governance_metadata':{}}];"
+        "t=MerkleTree.from_records(recs);p=t.inclusion_proof(0);"
+        "at=datetime(2026,5,31,13,tzinfo=timezone.utc);"
+        "priv=Ed25519PrivateKey.generate();m=Ed25519KeyManifest();"
+        "m.register(kid='k',public_key=priv.public_key(),"
+        "valid_from=at-timedelta(days=1),valid_until=at+timedelta(days=1),private_key=priv);"
+        "msg=_signed_message('1',t.root_hex,'k','2026-05-31T13:00:00Z');"
+        "sig=m.sign('k',msg,at=at).hex();"
+        "b={'proof_format_version':'1','record':recs[0],"
+        "'leaf':{'leaf_index':0,'tree_size':t.size,'leaf_hash':p.leaf_hash.hex()},"
+        "'merkle':{'merkle_root':t.root_hex,'merkle_path':[h.hex() for h in p.merkle_path],"
+        "'merkle_path_directions':list(p.merkle_path_directions)},"
+        "'signature':{'alg':'ed25519','kid':'k','sig':sig,'signed_at':'2026-05-31T13:00:00Z'}};"
+        "r=verify_bundle(b,m);"
+        "assert r.ok, r.failure;"
+        "assert 'graqle.server' not in sys.modules and 'graqle.studio' not in sys.modules;"
+        "print('SUBPROC_OK')"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        shell=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "SUBPROC_OK" in proc.stdout

--- a/tests/test_tamper_evidence/test_verifier_isolation.py
+++ b/tests/test_tamper_evidence/test_verifier_isolation.py
@@ -1,0 +1,176 @@
+"""WS-A3 — import-isolation CI gate for the standalone verifier (moat M2).
+
+This is the *static* half of the moat-M2 isolation invariant (the runtime
+``_assert_isolated`` guard in verifier.py is the dynamic half — defense in depth).
+It performs an AST import-graph audit and **fails the build** if the verifier or
+its user-facing surface imports anything OUTSIDE a frozen allowlist:
+
+    {merkle, canonicalize, custody.ed25519_key_manifest, errors} (the four
+    tamper-evidence primitives the verifier composes) + the standard library +
+    ``cryptography``.
+
+An allowlist (not a denylist) is used deliberately: a denylist only catches the
+forbidden imports we thought to name, whereas an allowlist catches ANY new
+dependency — including a future ``graqle.server``/``graqle.studio``/network
+import that a denylist would miss. A regression that smuggles a proprietary or
+networked dependency into the verifier breaks the "survive-our-disappearance"
+guarantee silently; this gate makes CI red instead.
+
+The companion subprocess-invariant tests (verify in a studio-free interpreter)
+live in test_verifier.py (AC-1/AC-3) and test_verify_surface.py.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+_GRAQLE_ROOT = Path(__file__).parent.parent.parent / "graqle"
+_VERIFIER = _GRAQLE_ROOT / "governance" / "tamper_evidence" / "verifier.py"
+_VERIFY_PKG = _GRAQLE_ROOT / "verify"
+
+# The four tamper-evidence primitives the verifier is allowed to compose.
+_ALLOWED_GRAQLE_MODULES = {
+    "graqle.governance.tamper_evidence.merkle",
+    "graqle.governance.tamper_evidence.canonicalize",
+    "graqle.governance.tamper_evidence.errors",
+    "graqle.governance.custody.ed25519_key_manifest",
+}
+
+# The verify surface (CLI + module entrypoint) additionally composes the verifier
+# itself + the verify core; these stay inside the isolation domain.
+_ALLOWED_SURFACE_MODULES = _ALLOWED_GRAQLE_MODULES | {
+    "graqle.governance.tamper_evidence.verifier",
+    "graqle.verify",
+    "graqle.cli.console",  # console helper is stdlib+rich only (UI shell)
+}
+
+# Third-party packages the verifier may use. cryptography is a core dependency;
+# typer/rich are the CLI shell (surface only, not the verifier core).
+_ALLOWED_THIRD_PARTY = {"cryptography"}
+_ALLOWED_SURFACE_THIRD_PARTY = _ALLOWED_THIRD_PARTY | {"typer", "rich", "click"}
+
+# Anything matching these is an immediate, explicit FAIL regardless of allowlist
+# (a belt-and-braces check that names the exact moat breakers).
+_FORBIDDEN_PREFIXES = ("graqle.server", "graqle.studio")
+
+
+def _stdlib_module_names() -> set[str]:
+    """Top-level standard-library module names available on this interpreter."""
+    names = set(sys.stdlib_module_names)
+    names.add("__future__")
+    return names
+
+
+def _top(module: str) -> str:
+    return module.split(".", 1)[0]
+
+
+def _collect_import_modules(path: Path) -> set[str]:
+    """Return the set of fully-dotted module sources imported by ``path``."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    out: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                out.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            # Only absolute imports matter for isolation; relative imports
+            # (level>0) stay inside the package and carry no module string.
+            if node.level == 0 and node.module:
+                out.add(node.module)
+    return out
+
+
+def _check_isolation(
+    path: Path,
+    *,
+    allowed_graqle: set[str],
+    allowed_third_party: set[str],
+) -> None:
+    stdlib = _stdlib_module_names()
+    imports = _collect_import_modules(path)
+    offenders: list[str] = []
+    for module in sorted(imports):
+        top = _top(module)
+        # Explicit moat-breaker check first.
+        if any(module == p or module.startswith(p + ".") for p in _FORBIDDEN_PREFIXES):
+            offenders.append(f"{module} (FORBIDDEN proprietary/server surface)")
+            continue
+        if top == "graqle":
+            if module not in allowed_graqle:
+                offenders.append(f"{module} (graqle module not in isolation allowlist)")
+            continue
+        if top in stdlib:
+            continue
+        if top in allowed_third_party:
+            continue
+        offenders.append(f"{module} (third-party not in allowlist)")
+    assert not offenders, (
+        f"{path.name} imports outside the isolation allowlist: {offenders}. "
+        f"The standalone verifier (moat M2) may import only the four "
+        f"tamper-evidence primitives, the standard library, and cryptography. "
+        f"Adding any other dependency breaks the survive-our-disappearance "
+        f"invariant — see WS-A1 verifier.py module docstring."
+    )
+
+
+def test_verifier_imports_are_isolated():
+    """verifier.py imports only {merkle, canonicalize, errors, manifest} + stdlib + cryptography."""
+    _check_isolation(
+        _VERIFIER,
+        allowed_graqle=_ALLOWED_GRAQLE_MODULES,
+        allowed_third_party=_ALLOWED_THIRD_PARTY,
+    )
+
+
+@pytest.mark.parametrize(
+    "surface_file",
+    [p for p in _VERIFY_PKG.rglob("*.py") if "__pycache__" not in p.parts],
+    ids=lambda p: p.name,
+)
+def test_verify_surface_imports_are_isolated(surface_file):
+    """The python -m graqle.verify surface stays inside the isolation domain."""
+    _check_isolation(
+        surface_file,
+        allowed_graqle=_ALLOWED_SURFACE_MODULES,
+        allowed_third_party=_ALLOWED_SURFACE_THIRD_PARTY,
+    )
+
+
+def test_attest_cli_does_not_import_server_or_studio():
+    """The graq attest sub-app must not pull server/studio into the import graph."""
+    attest = _GRAQLE_ROOT / "cli" / "commands" / "attest.py"
+    imports = _collect_import_modules(attest)
+    for module in imports:
+        assert not any(
+            module == p or module.startswith(p + ".") for p in _FORBIDDEN_PREFIXES
+        ), f"attest.py imports forbidden module {module!r} (moat M2 breaker)"
+
+
+def test_allowlist_actually_constrains():
+    """Meta-test: a hypothetical forbidden import would be caught.
+
+    Guards against the gate silently passing everything (e.g. if the allowlist
+    accidentally became all-encompassing). We synthesize a tiny module that
+    imports graqle.server and assert the checker flags it.
+    """
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".py", delete=False, encoding="utf-8"
+    ) as fh:
+        fh.write("import graqle.server.lambda_handler\n")
+        bad_path = Path(fh.name)
+    try:
+        with pytest.raises(AssertionError):
+            _check_isolation(
+                bad_path,
+                allowed_graqle=_ALLOWED_GRAQLE_MODULES,
+                allowed_third_party=_ALLOWED_THIRD_PARTY,
+            )
+    finally:
+        bad_path.unlink()

--- a/tests/test_verify/test_verify_surface.py
+++ b/tests/test_verify/test_verify_surface.py
@@ -1,0 +1,541 @@
+"""Tests for the WS-A2 offline verification surface (core + CLI + module entrypoint).
+
+Covers:
+- graqle.verify core: run_verify, manifest loaders, usage errors, json shape.
+- graqle.cli.commands.attest: `graq attest verify` via Typer CliRunner.
+- graqle.verify.__main__: argparse entrypoint + exit codes (in-process via main()).
+- python -m graqle.verify in a studio-free subprocess (true isolation, AC-1/AC-3).
+
+All fixtures build a REAL signed + Merkle-anchored bundle from the shipped
+primitives and write it to temp files, so the surface is exercised end-to-end
+(no mocks). Realistic 100% coverage via fault injection of each input path.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from typer.testing import CliRunner
+
+from graqle.cli.main import app
+from graqle.governance.tamper_evidence.merkle import MerkleTree
+from graqle.verify import (
+    EXIT_FAILED,
+    EXIT_OK,
+    EXIT_USAGE,
+    VerifyUsageError,
+    load_manifest,
+    manifest_from_keyring,
+    manifest_from_single_key,
+    result_to_dict,
+    run_verify,
+)
+from graqle.verify.__main__ import main as module_main
+
+runner = CliRunner()
+
+KID = "graqle-sdk-signing-2026-Q2"
+SIGNED_AT = "2026-05-31T13:00:00Z"
+SIGNED_AT_DT = datetime(2026, 5, 31, 13, 0, 0, tzinfo=timezone.utc)
+
+
+def _record(rid="r1"):
+    return {
+        "proof_format_version": "1",
+        "record_id": rid,
+        "content_hash": "a" * 64,
+        "timestamp_unix": 1748000000,
+        "governance_metadata": {"gate": "CLEAR"},
+    }
+
+
+def _make_bundle_and_key(tmp_path: Path, *, include_rekor=False):
+    """Write a valid signed bundle + the signer's public-key PEM to temp files.
+
+    Returns (bundle_path, key_pem_path, priv, root_hex).
+    """
+    from graqle.verify import _WIDE_OPEN_FROM  # noqa: F401 (ensure import path valid)
+    from graqle.governance.tamper_evidence.verifier import _signed_message
+
+    records = [_record("r1"), _record("r2")]
+    tree = MerkleTree.from_records(records)
+    proof = tree.inclusion_proof(0)
+    root_hex = tree.root_hex
+
+    priv = Ed25519PrivateKey.generate()
+    from graqle.governance.custody.ed25519_key_manifest import Ed25519KeyManifest
+
+    signer = Ed25519KeyManifest()
+    signer.register(
+        kid=KID,
+        public_key=priv.public_key(),
+        valid_from=SIGNED_AT_DT - timedelta(days=1),
+        valid_until=SIGNED_AT_DT + timedelta(days=365),
+        private_key=priv,
+    )
+    msg = _signed_message("1", root_hex, KID, SIGNED_AT)
+    sig_hex = signer.sign(KID, msg, at=SIGNED_AT_DT).hex()
+
+    bundle = {
+        "proof_format_version": "1",
+        "record": records[0],
+        "leaf": {
+            "leaf_index": 0,
+            "tree_size": tree.size,
+            "leaf_hash": proof.leaf_hash.hex(),
+        },
+        "merkle": {
+            "merkle_root": root_hex,
+            "merkle_path": [h.hex() for h in proof.merkle_path],
+            "merkle_path_directions": list(proof.merkle_path_directions),
+        },
+        "signature": {
+            "alg": "ed25519",
+            "kid": KID,
+            "sig": sig_hex,
+            "signed_at": SIGNED_AT,
+        },
+    }
+    if include_rekor:
+        bundle["rekor"] = {
+            "log_index": 1,
+            "log_id": "rekor",
+            "signed_tree_head": root_hex,
+            "inclusion_cert": "abcd",
+            "integrated_time": 1748000100,
+        }
+
+    bundle_path = tmp_path / "bundle.json"
+    bundle_path.write_text(json.dumps(bundle), encoding="utf-8")
+
+    pub_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    key_path = tmp_path / "pub.pem"
+    key_path.write_bytes(pub_pem)
+
+    return bundle_path, key_path, priv, root_hex
+
+
+def _keyring_path(tmp_path: Path, priv: Ed25519PrivateKey, *, state="ACTIVE"):
+    pub_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("ascii")
+    keyring = {
+        "keys": [
+            {
+                "kid": KID,
+                "public_key_pem": pub_pem,
+                "valid_from": "2026-04-01T00:00:00Z",
+                "valid_until": "2026-12-31T23:59:59Z",
+                "state": state,
+            }
+        ]
+    }
+    p = tmp_path / "keyring.json"
+    p.write_text(json.dumps(keyring), encoding="utf-8")
+    return p
+
+
+# ── core: run_verify ─────────────────────────────────────────────────────────
+def test_run_verify_ok_with_single_key(tmp_path):
+    bundle_path, key_path, _, _ = _make_bundle_and_key(tmp_path)
+    code, result = run_verify(bundle_path=bundle_path, key_path=key_path)
+    assert code == EXIT_OK
+    assert result["ok"] is True
+    assert result["failure"] == "OK"
+
+
+def test_run_verify_ok_with_keyring(tmp_path):
+    bundle_path, _, priv, _ = _make_bundle_and_key(tmp_path)
+    keys_path = _keyring_path(tmp_path, priv)
+    code, result = run_verify(bundle_path=bundle_path, keys_path=keys_path)
+    assert code == EXIT_OK
+    assert result["ok"] is True
+
+
+def test_run_verify_revoked_keyring_fails(tmp_path):
+    bundle_path, _, priv, _ = _make_bundle_and_key(tmp_path)
+    keys_path = _keyring_path(tmp_path, priv, state="REVOKED")
+    code, result = run_verify(bundle_path=bundle_path, keys_path=keys_path)
+    assert code == EXIT_FAILED
+    assert result["ok"] is False
+    assert result["failure"] == "UNTRUSTED_KID"
+
+
+def test_run_verify_tampered_bundle_fails(tmp_path):
+    bundle_path, key_path, _, _ = _make_bundle_and_key(tmp_path)
+    data = json.loads(bundle_path.read_text())
+    data["leaf"]["leaf_hash"] = "f" * 64
+    bundle_path.write_text(json.dumps(data))
+    code, result = run_verify(bundle_path=bundle_path, key_path=key_path)
+    assert code == EXIT_FAILED
+    assert result["failure"] == "TAMPERED_LEAF"
+
+
+def test_run_verify_rekor_in_bundle(tmp_path):
+    bundle_path, key_path, _, _ = _make_bundle_and_key(tmp_path, include_rekor=True)
+    code, result = run_verify(bundle_path=bundle_path, key_path=key_path)
+    assert code == EXIT_OK
+    assert result["rekor_checked"] is True
+
+
+def test_run_verify_external_rekor_sth_file(tmp_path):
+    bundle_path, key_path, _, root_hex = _make_bundle_and_key(tmp_path)
+    sth_path = tmp_path / "sth.json"
+    sth_path.write_text(json.dumps({
+        "log_index": 1, "log_id": "r", "signed_tree_head": root_hex,
+        "inclusion_cert": "x",
+    }))
+    code, result = run_verify(
+        bundle_path=bundle_path, key_path=key_path, rekor_sth_path=sth_path
+    )
+    assert code == EXIT_OK
+    assert result["rekor_checked"] is True
+
+
+def test_run_verify_external_rekor_sth_mismatch(tmp_path):
+    bundle_path, key_path, _, _ = _make_bundle_and_key(tmp_path)
+    sth_path = tmp_path / "sth.json"
+    sth_path.write_text(json.dumps({
+        "log_index": 1, "log_id": "r", "signed_tree_head": "d" * 64,
+        "inclusion_cert": "x",
+    }))
+    code, result = run_verify(
+        bundle_path=bundle_path, key_path=key_path, rekor_sth_path=sth_path
+    )
+    assert code == EXIT_FAILED
+    assert result["failure"] == "REKOR_MISMATCH"
+
+
+# ── core: usage errors (exit 2) ──────────────────────────────────────────────
+def test_run_verify_missing_bundle_file(tmp_path):
+    with pytest.raises(VerifyUsageError):
+        run_verify(bundle_path=tmp_path / "nope.json", key_path=tmp_path / "k.pem")
+
+
+def test_run_verify_bundle_not_json(tmp_path):
+    p = tmp_path / "b.json"
+    p.write_text("not json{")
+    kp = tmp_path / "k.pem"
+    kp.write_bytes(b"x")
+    with pytest.raises(VerifyUsageError):
+        run_verify(bundle_path=p, key_path=kp)
+
+
+def test_run_verify_bundle_not_object(tmp_path):
+    p = tmp_path / "b.json"
+    p.write_text("[1,2,3]")
+    kp = tmp_path / "k.pem"
+    kp.write_bytes(b"x")
+    with pytest.raises(VerifyUsageError):
+        run_verify(bundle_path=p, key_path=kp)
+
+
+def test_run_verify_no_key_or_keys(tmp_path):
+    bundle_path, _, _, _ = _make_bundle_and_key(tmp_path)
+    with pytest.raises(VerifyUsageError):
+        run_verify(bundle_path=bundle_path)
+
+
+def test_run_verify_both_key_and_keys(tmp_path):
+    bundle_path, key_path, priv, _ = _make_bundle_and_key(tmp_path)
+    keys_path = _keyring_path(tmp_path, priv)
+    with pytest.raises(VerifyUsageError):
+        run_verify(bundle_path=bundle_path, key_path=key_path, keys_path=keys_path)
+
+
+def test_run_verify_rekor_sth_not_object(tmp_path):
+    bundle_path, key_path, _, _ = _make_bundle_and_key(tmp_path)
+    sth = tmp_path / "sth.json"
+    sth.write_text("[1,2]")
+    with pytest.raises(VerifyUsageError):
+        run_verify(bundle_path=bundle_path, key_path=key_path, rekor_sth_path=sth)
+
+
+def test_run_verify_missing_key_file(tmp_path):
+    bundle_path, _, _, _ = _make_bundle_and_key(tmp_path)
+    with pytest.raises(VerifyUsageError):
+        run_verify(bundle_path=bundle_path, key_path=tmp_path / "nope.pem")
+
+
+def test_run_verify_key_but_no_kid_in_bundle(tmp_path):
+    bundle_path, key_path, _, _ = _make_bundle_and_key(tmp_path)
+    data = json.loads(bundle_path.read_text())
+    del data["signature"]["kid"]
+    bundle_path.write_text(json.dumps(data))
+    with pytest.raises(VerifyUsageError):
+        run_verify(bundle_path=bundle_path, key_path=key_path)
+
+
+# ── core: manifest loaders ───────────────────────────────────────────────────
+def test_manifest_from_single_key_bad_pem():
+    with pytest.raises(VerifyUsageError):
+        manifest_from_single_key(b"not a pem", KID)
+
+
+def test_manifest_from_single_key_non_ed25519(tmp_path):
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    rsa_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = rsa_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    with pytest.raises(VerifyUsageError):
+        manifest_from_single_key(pem, KID)
+
+
+def test_manifest_from_keyring_not_object():
+    with pytest.raises(VerifyUsageError):
+        manifest_from_keyring(["not", "a", "dict"])
+
+
+def test_manifest_from_keyring_empty_keys():
+    with pytest.raises(VerifyUsageError):
+        manifest_from_keyring({"keys": []})
+
+
+def test_manifest_from_keyring_entry_not_object():
+    with pytest.raises(VerifyUsageError):
+        manifest_from_keyring({"keys": ["nope"]})
+
+
+def test_manifest_from_keyring_missing_kid(tmp_path):
+    pub = Ed25519PrivateKey.generate().public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    with pytest.raises(VerifyUsageError):
+        manifest_from_keyring({"keys": [{"public_key_pem": pub}]})
+
+
+def test_manifest_from_keyring_missing_pem():
+    with pytest.raises(VerifyUsageError):
+        manifest_from_keyring({"keys": [{"kid": "k"}]})
+
+
+def test_manifest_from_keyring_bad_state():
+    pub = Ed25519PrivateKey.generate().public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    with pytest.raises(VerifyUsageError):
+        manifest_from_keyring({"keys": [{"kid": "k", "public_key_pem": pub, "state": "BOGUS"}]})
+
+
+def test_manifest_from_keyring_non_string_state():
+    pub = Ed25519PrivateKey.generate().public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    with pytest.raises(VerifyUsageError):
+        manifest_from_keyring({"keys": [{"kid": "k", "public_key_pem": pub, "state": 5}]})
+
+
+def test_manifest_from_keyring_bad_timestamp():
+    pub = Ed25519PrivateKey.generate().public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    with pytest.raises(VerifyUsageError):
+        manifest_from_keyring(
+            {"keys": [{"kid": "k", "public_key_pem": pub, "valid_from": "not-a-date"}]}
+        )
+
+
+def test_manifest_from_keyring_non_string_timestamp():
+    pub = Ed25519PrivateKey.generate().public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    with pytest.raises(VerifyUsageError):
+        manifest_from_keyring(
+            {"keys": [{"kid": "k", "public_key_pem": pub, "valid_from": 12345}]}
+        )
+
+
+def test_manifest_from_keyring_defaults_state_active(tmp_path):
+    bundle_path, _, priv, _ = _make_bundle_and_key(tmp_path)
+    pub = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    # no state/window fields -> defaults (ACTIVE, wide-open) -> verifies
+    m = manifest_from_keyring({"keys": [{"kid": KID, "public_key_pem": pub}]})
+    entry = m.get(KID)
+    from graqle.governance.custody.ed25519_key_manifest import KeyState
+
+    assert entry.state is KeyState.ACTIVE
+
+
+def test_load_manifest_keyring_not_dict(tmp_path):
+    p = tmp_path / "k.json"
+    p.write_text('"a string"')
+    with pytest.raises(VerifyUsageError):
+        load_manifest(key_path=None, keys_path=p, bundle={})
+
+
+def test_manifest_from_keyring_naive_timestamp(tmp_path):
+    # A keyring window timestamp WITHOUT a timezone -> treated as UTC (line 148).
+    bundle_path, _, priv, _ = _make_bundle_and_key(tmp_path)
+    pub = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    m = manifest_from_keyring(
+        {
+            "keys": [
+                {
+                    "kid": KID,
+                    "public_key_pem": pub,
+                    "valid_from": "2026-04-01T00:00:00",  # naive — no Z, no offset
+                    "valid_until": "2026-12-31T23:59:59",
+                }
+            ]
+        }
+    )
+    entry = m.get(KID)
+    assert entry.valid_from.tzinfo is not None  # normalised to UTC
+
+
+# ── core: result_to_dict shape ───────────────────────────────────────────────
+def test_result_to_dict_shape(tmp_path):
+    bundle_path, key_path, _, _ = _make_bundle_and_key(tmp_path)
+    _, result = run_verify(bundle_path=bundle_path, key_path=key_path)
+    assert set(result.keys()) == {"ok", "failure", "checks", "rekor_checked"}
+
+
+# ── CLI: graq attest verify ──────────────────────────────────────────────────
+def test_cli_verify_ok_text(tmp_path):
+    bundle_path, key_path, _, _ = _make_bundle_and_key(tmp_path)
+    res = runner.invoke(app, ["attest", "verify", str(bundle_path), "--key", str(key_path)])
+    assert res.exit_code == 0
+    assert "VERIFIED" in res.stdout
+
+
+def test_cli_verify_ok_json(tmp_path):
+    bundle_path, key_path, _, _ = _make_bundle_and_key(tmp_path)
+    res = runner.invoke(
+        app, ["attest", "verify", str(bundle_path), "--key", str(key_path), "--format", "json"]
+    )
+    assert res.exit_code == 0
+    payload = json.loads(res.stdout)
+    assert payload["ok"] is True
+
+
+def test_cli_verify_failed(tmp_path):
+    bundle_path, key_path, _, _ = _make_bundle_and_key(tmp_path)
+    data = json.loads(bundle_path.read_text())
+    data["merkle"]["merkle_root"] = "0" * 64
+    bundle_path.write_text(json.dumps(data))
+    res = runner.invoke(app, ["attest", "verify", str(bundle_path), "--key", str(key_path)])
+    assert res.exit_code == 1
+    assert "FAILED" in res.stdout
+
+
+def test_cli_verify_usage_error(tmp_path):
+    res = runner.invoke(
+        app, ["attest", "verify", str(tmp_path / "nope.json"), "--key", str(tmp_path / "k.pem")]
+    )
+    assert res.exit_code == 2
+
+
+def test_cli_verify_usage_error_json(tmp_path):
+    res = runner.invoke(
+        app,
+        ["attest", "verify", str(tmp_path / "nope.json"), "--key", str(tmp_path / "k.pem"), "--format", "json"],
+    )
+    assert res.exit_code == 2
+
+
+def test_cli_verify_bad_format(tmp_path):
+    bundle_path, key_path, _, _ = _make_bundle_and_key(tmp_path)
+    res = runner.invoke(
+        app, ["attest", "verify", str(bundle_path), "--key", str(key_path), "--format", "xml"]
+    )
+    assert res.exit_code == 2
+
+
+def test_cli_verify_keyring_and_rekor(tmp_path):
+    bundle_path, _, priv, _ = _make_bundle_and_key(tmp_path, include_rekor=True)
+    keys_path = _keyring_path(tmp_path, priv)
+    res = runner.invoke(app, ["attest", "verify", str(bundle_path), "--keys", str(keys_path)])
+    assert res.exit_code == 0
+    assert "rekor" not in res.stdout.lower() or "pass" in res.stdout.lower()
+
+
+# ── module entrypoint: graqle.verify.main() in-process ───────────────────────
+def test_module_main_ok(tmp_path):
+    bundle_path, key_path, _, _ = _make_bundle_and_key(tmp_path)
+    code = module_main([str(bundle_path), "--key", str(key_path)])
+    assert code == EXIT_OK
+
+
+def test_module_main_json(tmp_path, capsys):
+    bundle_path, key_path, _, _ = _make_bundle_and_key(tmp_path)
+    code = module_main([str(bundle_path), "--key", str(key_path), "--format", "json"])
+    assert code == EXIT_OK
+    out = capsys.readouterr().out
+    assert json.loads(out)["ok"] is True
+
+
+def test_module_main_failed(tmp_path):
+    bundle_path, key_path, _, _ = _make_bundle_and_key(tmp_path)
+    data = json.loads(bundle_path.read_text())
+    data["leaf"]["leaf_hash"] = "f" * 64
+    bundle_path.write_text(json.dumps(data))
+    code = module_main([str(bundle_path), "--key", str(key_path)])
+    assert code == EXIT_FAILED
+
+
+def test_module_main_usage_error(tmp_path):
+    code = module_main([str(tmp_path / "nope.json"), "--key", str(tmp_path / "k.pem")])
+    assert code == EXIT_USAGE
+
+
+def test_module_main_usage_error_json(tmp_path, capsys):
+    code = module_main(
+        [str(tmp_path / "nope.json"), "--key", str(tmp_path / "k.pem"), "--format", "json"]
+    )
+    assert code == EXIT_USAGE
+    err = capsys.readouterr().err
+    assert json.loads(err)["ok"] is False
+
+
+def test_module_main_text_no_rekor_note(tmp_path, capsys):
+    bundle_path, key_path, _, _ = _make_bundle_and_key(tmp_path)
+    module_main([str(bundle_path), "--key", str(key_path)])
+    out = capsys.readouterr().out
+    assert "rekor: not checked" in out
+
+
+def test_module_main_text_with_rekor_no_note(tmp_path, capsys):
+    # rekor_checked True -> the "not checked" note is skipped (branch 101->103).
+    bundle_path, key_path, _, _ = _make_bundle_and_key(tmp_path, include_rekor=True)
+    code = module_main([str(bundle_path), "--key", str(key_path)])
+    out = capsys.readouterr().out
+    assert code == EXIT_OK
+    assert "rekor: not checked" not in out
+
+
+# ── subprocess invariant: studio-free interpreter (AC-1/AC-3) ────────────────
+def test_module_entrypoint_in_studio_free_subprocess(tmp_path):
+    bundle_path, key_path, _, _ = _make_bundle_and_key(tmp_path)
+    proc = subprocess.run(
+        [sys.executable, "-m", "graqle.verify", str(bundle_path), "--key", str(key_path)],
+        shell=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "VERIFIED" in proc.stdout


### PR DESCRIPTION
## WS-A — Standalone offline proof-bundle verifier (moat M2) + `graq attest verify` CLI + import-isolation gate

**CR:** BizQ open-core build, Session-1 (Community/SDK lane) · **Branch:** `bau/cr-bizq-001-community` off `private/master` `9a448a1b` · **Lane:** community

This PR lands **WS-A** of ADR-BIZ-001: the free, open-forever verifier that is both the product's integrity guarantee and **moat M2** (the canonical GraQle-format proof). It engineers the "survive-our-disappearance" invariant — anyone with the verifier and the public keys can verify every proof offline, forever, with no network and no proprietary code.

### What ships

| WS | Deliverable |
|----|-------------|
| **A1** | `graqle/governance/tamper_evidence/verifier.py` — `verify_bundle(proof_bundle, trusted_keys: Ed25519KeyManifest) -> VerifyResult`. Composes the four shipped primitives (leaf recompute · Merkle inclusion · ed25519 windowed 3-state trust · optional **offline** Rekor binding) into one verifier. Pure stdlib + `cryptography`; **zero** `graqle.server`/`graqle.studio`/network imports. Runtime import-isolation guard. Typed failures (`MALFORMED_BUNDLE`/`TAMPERED_LEAF`/`WRONG_ROOT`/`UNKNOWN_KID`/`UNTRUSTED_KID`/`REKOR_MISMATCH`), never raises on a bad proof. |
| **A2** | `graqle/verify/` core + `python -m graqle.verify` (argparse, stdlib-only) + `graq attest verify <bundle> --key/--keys/--rekor-sth/--format` (Typer sub-app). Shared `run_verify` → identical exit codes (0 verified / 1 not verified / 2 usage) and JSON across both surfaces. |
| **A3** | `tests/test_tamper_evidence/test_verifier_isolation.py` — AST **allowlist** import-isolation gate: the build fails if the verifier or its surface imports anything outside `{merkle, canonicalize, errors, custody.ed25519_key_manifest}` + stdlib + `cryptography`. Includes a meta-test proving the allowlist actually constrains. |

### Key design decision (SD-001)
The ed25519 signature covers `canon({proof_format_version, merkle_root, kid, signed_at})`. The Merkle root transitively authenticates every leaf in the batch (RFC 6962), so signing the root authenticates the record without per-leaf re-signing — small, batch-shareable, and binds the exact bytes Rekor anchors.

### CLI naming
`graq verify` is already taken by the dev-intelligence "verify staged changes" command. This PR uses **`graq attest verify`** (new `attest` group, matches the runtime attestation domain) to avoid a collision. `python -m graqle.verify` is the dependency-light equivalent.

### Tests & quality
- **110 tests, 100% statement + branch coverage (realistic)** — real signed + Merkle-anchored fixtures, fault injection for every failure mode, the runtime isolation guard, and a **studio-free subprocess invariant** (`shell=False`, fixed argv) proving the verifier runs standalone.
- Phase-7 sentinel (ADR-209): preflight + adversarial `graq_predict` + manual structured security review. **0 BLOCKERs, 0 MAJORs open.** One MAJOR caught-and-fixed by the tests: `--format json` now emits plain `json.dumps` (was Rich `print_json` injecting ANSI codes that broke `| jq`).

### Isolation (moat M2) — defense in depth
Enforced **both** at runtime (the import guard in `verifier.py`) **and** statically (the WS-A3 AST CI gate). A CI-only check would let a runtime regression pass unseen; a runtime-only check wouldn't fail the build.

### Notes for review
- 3 atomic commits: WS-A1 verifier · WS-A2 verify core · WS-A2 CLI + WS-A3 gate.
- New files under the worktree were created via native Write (S-010: `graq_write`/`graq_generate` can't create new files outside the MCP serve-CWD — logged `V-CR-BIZQ-001-NATIVE-001` in `.gcc/OPEN-TRACKER-CAPABILITY-GAPS.md` CG-MKT-11). All edits to existing files + all reads/tests/commits went through `graq_*`.
- IP: only SAFE-TO-EXPOSE elements (signatures, field names, status enums, RFC names). No Q-weights / J̄ formula / STG rules / θ_fold.
- **Unblocks Session-2:** the `verify_bundle()` / `run_verify()` signatures are now stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
