### PR TITLE
v0.65.0: metering layer (billable unit) — dual count point + exactly-once dedupe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## 0.65.0 (2026-05-31) — [Metering layer: the billable unit for hosted proof anchoring]
+
+> The open-core meter. A billable event (`unit="proof_anchored"`) is recorded
+> only when a proof becomes *hosted* (anchored) — local work stays free — and is
+> deduped to exactly-once on the proof's Merkle `leaf_hash` across both
+> proof-production paths. Composition-only: no governed/anchoring internals are
+> modified beyond one additive, never-raise observer seam.
+
+**Added**
+
+- New `graqle.metering` package (Apache-2.0, Community):
+  - `MeterEvent` — the billable unit (`unit="proof_anchored"`, frozen, validated).
+  - `MeterSink` Protocol — the one-method sink interface (the seam hosted
+    backends implement); `LocalNullMeter` is the Community no-op (local = free).
+  - `MeteredAttestationSink` — count point 1: wraps any runtime `AttestationSink`,
+    meters the attested proof, then always delegates the durable write.
+  - `make_meter_observer()` — count point 2: a never-raise callback for the
+    Layer-5 `Committer`, fired once per leaf on the *anchored* transition.
+  - `MeterDedupeStore` — WAL-backed exactly-once gate keyed on `leaf_hash`
+    (atomic temp→fsync→replace→dir-fsync writes, integrity-checksum + content
+    validation on recovery, DoS size cap). Exactly-once under retry, dual-path,
+    and crash-mid-write.
+
+**Changed**
+
+- `Committer` gains an optional `meter_observer` parameter (additive, defaults
+  to `None` = no metering). Fired only on the anchored transition, guarded so a
+  metering fault can never break the anchoring path. No behavioural change when
+  unset.
+
 ## 0.64.0 (2026-05-31) — [Standalone offline proof verifier + `graq attest verify`]
 
 > The canonical, free-forever offline verifier for GraQle-format tamper-evidence

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.64.0"
+__version__ = "0.65.0"

--- a/graqle/governance/tamper_evidence/committer.py
+++ b/graqle/governance/tamper_evidence/committer.py
@@ -119,12 +119,20 @@ class Committer:
         anchor: RekorAnchor | None = None,
         replay_queue: LocalReplayQueue | None = None,
         kg_persist: KgPersistFn | None = None,
+        meter_observer: Callable[[str, dict[str, Any]], None] | None = None,
     ) -> None:
         self._config = config
         self._batcher = batcher
         self._anchor = anchor
         self._replay_queue = replay_queue
         self._kg_persist = kg_persist
+        # WS-B count point 2: a best-effort, never-raise callback invoked once per
+        # anchored leaf (the billable proof_anchored unit). Additive + optional;
+        # default None = no metering (Community local work is free). The callback
+        # itself must not raise (graqle.metering.make_meter_observer guarantees
+        # this); we still guard the call site so a misbehaving observer can never
+        # break the anchoring path — the proof is durable in Rekor regardless.
+        self._meter_observer = meter_observer
         self._lock = threading.RLock()
         # Commit records keyed by content-address (the batcher's idempotency key),
         # so a record submitted twice maps to one CommitRecord (mirrors the
@@ -269,6 +277,28 @@ class Committer:
                     for cr in batch_records:
                         cr.mark_anchored(receipt.log_index, receipt.log_id)
                     anchored = True
+                    # WS-B count point 2: each anchored leaf is one billable
+                    # proof. Fire the meter observer per leaf, keyed on the leaf
+                    # hash (cr.record_hash) — the SAME idempotency key as the
+                    # runtime path, so a proof reaching both paths bills once.
+                    # Guarded: a metering fault must never undo a durable anchor.
+                    if self._meter_observer is not None:
+                        for cr in batch_records:
+                            try:
+                                self._meter_observer(
+                                    cr.record_hash,
+                                    {
+                                        "batch_id": batch_id,
+                                        "merkle_root_hex": root_hex,
+                                        "rekor_log_index": receipt.log_index,
+                                        "rekor_log_id": receipt.log_id,
+                                    },
+                                )
+                            except Exception:  # never break the anchoring path
+                                logger.warning(
+                                    "meter observer raised on anchored leaf "
+                                    "(non-fatal); anchor is durable", exc_info=True
+                                )
                 except AnchorError as exc:
                     self._handle_anchor_failure(batch_id, root_hex, batch_records, exc)
 

--- a/graqle/metering/__init__.py
+++ b/graqle/metering/__init__.py
@@ -1,0 +1,40 @@
+"""GraQle metering (WS-B): the billable-unit meter for hosted proof anchoring.
+
+Open-core boundary
+------------------
+This package ships in the Apache-2.0 ``graqle`` **Community** build. It defines:
+
+* the billable unit — :class:`MeterEvent` (``unit="proof_anchored"``);
+* the sink interface — :class:`MeterSink` (the seam the proprietary
+  Studio-backend's ``StudioMeter`` binds to in Session-2);
+* the Community sink — :class:`LocalNullMeter` (a no-op: **local work is free**);
+* the exactly-once dedupe store — :class:`MeterDedupeStore` (WAL-backed,
+  keyed on the proof ``leaf_hash``);
+* the two count points that record *intent to bill* without modifying any
+  governed/anchoring internals (composition, never modification):
+    - :class:`MeteredAttestationSink` — wraps the runtime ``AttestationSink``;
+    - :func:`make_meter_observer` — a never-raise callback for the Layer-5
+      ``Committer`` anchor path.
+
+The free/paid line (ADR §3.3): **local = free, hosted = metered.** A billable
+event is recorded only at the moment a proof becomes hosted/anchored, deduped to
+exactly-once across both paths and retries on the proof's ``leaf_hash``.
+"""
+
+from __future__ import annotations
+
+from graqle.metering.committer_hook import make_meter_observer
+from graqle.metering.dedupe import MeterDedupeError, MeterDedupeStore
+from graqle.metering.events import PROOF_ANCHORED, MeterEvent, MeterSink
+from graqle.metering.sinks import LocalNullMeter, MeteredAttestationSink
+
+__all__ = [
+    "PROOF_ANCHORED",
+    "MeterEvent",
+    "MeterSink",
+    "LocalNullMeter",
+    "MeteredAttestationSink",
+    "MeterDedupeStore",
+    "MeterDedupeError",
+    "make_meter_observer",
+]

--- a/graqle/metering/committer_hook.py
+++ b/graqle/metering/committer_hook.py
@@ -1,0 +1,86 @@
+"""Count point 2 (Layer-5 batch path): meter each anchored leaf (WS-B B1).
+
+The Layer-5 ``Committer`` anchors a *batch* of governed records to Rekor in one
+call; each leaf in that batch is one hosted proof and therefore one billable
+``proof_anchored`` event. This path bypasses the runtime ``AttestationSink``
+entirely, so metering only count point 1 would silently under-bill every
+batch-anchored proof (the spec's revenue-leak finding).
+
+This module provides :func:`make_meter_observer` — a factory that returns a
+**best-effort, never-raise** callback matching the ``Committer``'s additive
+``meter_observer`` seam (mirroring the shipped ``as_trace_observer`` discipline:
+a metering fault must never break the anchoring/governed path). The ``Committer``
+invokes it **only on the ANCHORED transition**, once per anchored leaf, passing
+that leaf's ``record_hash`` (the Merkle ``leaf_hash`` hex — the SAME idempotency
+key used on count point 1, so a proof that somehow flows through both paths bills
+exactly once when the two paths share a :class:`MeterDedupeStore`).
+
+The free/paid line is honoured structurally: the observer fires on
+``anchored=True`` only. A purely-local commit (no anchor configured, or anchor
+failed → REPLAY_QUEUED/FAILED) never reaches this callback, so local work emits
+zero billable events.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+from graqle.metering.dedupe import MeterDedupeStore
+from graqle.metering.events import MeterEvent, MeterSink
+from graqle.metering.sinks import LocalNullMeter
+
+__all__ = ["make_meter_observer"]
+
+logger = logging.getLogger(__name__)
+
+# The observer is called once per anchored leaf with (record_hash, context).
+MeterObserver = Callable[[str, dict[str, Any]], None]
+
+
+def make_meter_observer(
+    meter: MeterSink | None = None,
+    dedupe: MeterDedupeStore | None = None,
+    *,
+    edition: str = "community",
+) -> MeterObserver:
+    """Build a never-raise ``meter_observer`` for the ``Committer`` anchor path.
+
+    Parameters
+    ----------
+    meter:
+        Where billable events go (defaults to :class:`LocalNullMeter` — Community
+        meters nothing). The Studio-backend passes its ``StudioMeter``.
+    dedupe:
+        The exactly-once gate. Pass the SAME :class:`MeterDedupeStore` instance as
+        count point 1 to get cross-path exactly-once; omit for per-call emission
+        without dedupe.
+    edition:
+        Edition stamped onto emitted events. Defaults to ``"community"``.
+
+    Returns
+    -------
+    A callable ``observer(record_hash, context)`` that the ``Committer`` invokes
+    once per anchored leaf. It NEVER raises: any metering fault is swallowed and
+    logged so the anchoring path's success/failure semantics are unchanged.
+    ``context`` carries non-billing batch metadata (e.g. ``batch_id``,
+    ``rekor_log_index``) for the meter API's audit trail.
+    """
+    sink: MeterSink = meter if meter is not None else LocalNullMeter()
+
+    def _observe(record_hash: str, context: dict[str, Any] | None = None) -> None:
+        try:
+            if not isinstance(record_hash, str) or not record_hash:
+                return  # nothing to bill without a leaf hash
+            if dedupe is not None and not dedupe.mark_if_new(record_hash):
+                return  # already billed (other path / retry) — exactly-once
+            event = MeterEvent(
+                idempotency_key=record_hash,
+                edition=edition,
+                metadata=dict(context) if isinstance(context, dict) else {},
+            )
+            sink.record(event)
+        except Exception:  # never break the anchoring path
+            logger.warning("metering failed on committer anchor path (non-fatal)", exc_info=True)
+
+    return _observe

--- a/graqle/metering/dedupe.py
+++ b/graqle/metering/dedupe.py
@@ -1,0 +1,323 @@
+"""Exactly-once billing dedupe store, WAL-backed (WS-B B3).
+
+The dedupe store is the **single authoritative source of billable events**: a
+:class:`MeterEvent` is recorded to the downstream :class:`~graqle.metering.events.MeterSink`
+**iff** its ``idempotency_key`` (the proof's Merkle ``leaf_hash`` hex) has not
+been seen before. Because that key is identical at both count points (the
+runtime ``AttestationSink`` path and the Layer-5 ``Committer`` batch path) and
+stable across retries, this gives exactly-once billing under:
+
+* **retry** — the same anchor re-emitted after a transient downstream failure;
+* **dual-path** — a proof that flows through *both* count points;
+* **crash-mid-write** — durability via the same WAL discipline the Layer-5
+  batcher uses (temp → ``fsync`` → atomic ``os.replace`` → directory ``fsync`` →
+  post-write zero-length check), with on-recovery content validation.
+
+This module deliberately mirrors ``graqle.governance.tamper_evidence.batcher``'s
+WAL implementation rather than inventing a new one: the key is already a 64-char
+SHA-256 hex (a ``leaf_hash``), so the same path-traversal guard, DoS size cap,
+and corruption-skip recovery apply unchanged. Pure stdlib — no proprietary or
+network dependency, ships in Community.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+import threading
+from pathlib import Path
+from typing import Any
+
+__all__ = ["MeterDedupeError", "MeterDedupeStore"]
+
+logger = logging.getLogger(__name__)
+
+# A ledger entry filename is ``<idempotency-key>.meter.json``. A distinct suffix
+# from the batcher's ``.wal.json`` so the two stores can never collide even if an
+# operator points them at the same directory by mistake.
+_LEDGER_SUFFIX = ".meter.json"
+
+# An idempotency key is the hex of a SHA-256 digest (a leaf_hash): exactly 64
+# lowercase hex chars. Enforced on EVERY key that becomes a path segment — even
+# one reconstructed from an on-disk filename during recovery, which must never be
+# trusted to be well-formed (path-traversal defence-in-depth, mirrors batcher).
+_KEY_LEN = 64
+_HEX_DIGITS = frozenset("0123456789abcdef")
+
+# Hard cap on a single on-disk ledger entry's size, read during crash recovery.
+# A meter ledger entry is tiny (key + edition + a few metadata fields), so 1 MiB
+# is generous headroom while still refusing a maliciously oversized or corrupt
+# entry that could exhaust memory on read (DoS guard).
+_MAX_LEDGER_ENTRY_BYTES = 1 * 1024 * 1024
+
+
+class MeterDedupeError(Exception):
+    """Raised for dedupe-store operations that cannot proceed safely."""
+
+
+def _is_valid_key(key: str) -> bool:
+    """True iff ``key`` is a well-formed SHA-256 hex idempotency key.
+
+    Rejects anything that could escape the ledger directory as a path segment
+    (``..``, ``/``, ``\\``, absolute prefixes) since none of those are lowercase
+    hex of length 64. This is the structural half of the path-traversal guard.
+    """
+    return len(key) == _KEY_LEN and not (set(key) - _HEX_DIGITS)
+
+
+def _safe_dir_fsync(dir_path: Path) -> None:
+    """Best-effort durable-rename guarantee: fsync the directory on POSIX.
+
+    After ``os.replace`` the file's *data* is durable (it was fsync'd before the
+    rename), but on POSIX the *rename* itself is only durable once the containing
+    directory's metadata is fsync'd. On Windows there is no portable
+    directory-fsync, and file-level fsync already provides adequate durability
+    for the rename, so this is a no-op there. A failed dir-fsync must never turn
+    a successful, already-recorded dedupe entry into a raised exception.
+    """
+    if os.name != "posix":
+        return
+    fd = None
+    try:
+        fd = os.open(str(dir_path), os.O_RDONLY)
+        os.fsync(fd)
+    except OSError as exc:
+        logger.warning("meter-dedupe directory fsync failed for %s: %s", dir_path, exc)
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+class MeterDedupeStore:
+    """Durable, thread-safe, exactly-once gate keyed on the proof ``leaf_hash``.
+
+    Usage::
+
+        store = MeterDedupeStore(directory)
+        if store.mark_if_new(event.idempotency_key):
+            sink.record(event)   # first time only
+
+    :meth:`mark_if_new` returns ``True`` exactly once per key (the caller then
+    bills), ``False`` on every subsequent call for the same key (no-op). The
+    durable WAL entry is written *before* ``True`` is returned, so a crash after
+    billing can never re-bill, and a crash before the entry is durable simply
+    re-bills on retry — never silently drops a billable event.
+
+    Parameters
+    ----------
+    directory:
+        Where ledger entries live. Created if absent. One file per recorded key.
+    digest:
+        Optional integrity checksum carried inside each entry (sentinel MAJOR:
+        "WAL carries integrity checksums + corruption recovery"). On recovery the
+        stored digest is recomputed from the entry's own fields; a mismatch marks
+        the entry corrupt and it is skipped (left on disk for inspection), never
+        trusted as a recorded key.
+    """
+
+    def __init__(self, directory: str | Path) -> None:
+        self._dir = Path(directory)
+        self._lock = threading.RLock()
+        # In-memory mirror of recorded keys for O(1) hot-path checks. Rebuilt from
+        # disk on construction so exactly-once survives a process restart.
+        self._seen: set[str] = set()
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._recover()
+
+    # ---- public API -----------------------------------------------------------
+
+    def mark_if_new(self, key: str) -> bool:
+        """Atomically record ``key`` and report whether it was new.
+
+        Returns ``True`` the first time a well-formed ``key`` is presented (the
+        caller should bill), ``False`` if it was already recorded (no-op). A
+        malformed key is rejected with :class:`MeterDedupeError` rather than
+        silently treated as new — a key that is not a valid leaf_hash hex is a
+        programming error upstream, not a billable event.
+        """
+        if not _is_valid_key(key):
+            raise MeterDedupeError(
+                f"refusing to dedupe on a malformed idempotency key "
+                f"(expected {_KEY_LEN}-char lowercase hex leaf_hash)"
+            )
+        with self._lock:
+            if key in self._seen:
+                return False
+            # Durably record BEFORE acknowledging "new". Ordering rationale
+            # (sentinel adversarial pass):
+            #   * A crash AFTER _write_entry but BEFORE self._seen.add does NOT
+            #     double-bill on restart: __init__ -> _recover() reads every
+            #     on-disk entry back into _seen, so the key is remembered and the
+            #     next mark_if_new returns False. (proven by
+            #     test_recovery_remembers_across_restart.)
+            #   * If the caller's sink.record() raises AFTER this returns True,
+            #     the key is already persisted, so that one proof is billed-once
+            #     -> recorded-as-seen but the emit was lost (a single under-bill).
+            #     This is the deliberate, customer-favourable trade-off: the
+            #     alternative (persist AFTER a successful emit) would re-bill on
+            #     every retry — over-charging is worse than a rare single
+            #     under-emit, and the sink (StudioMeter, S2) owns its own durable
+            #     delivery queue downstream of this gate.
+            self._write_entry(key)
+            self._seen.add(key)
+            return True
+
+    def has(self, key: str) -> bool:
+        """True iff ``key`` has already been recorded (read-only, no write)."""
+        with self._lock:
+            return key in self._seen
+
+    @property
+    def count(self) -> int:
+        """Number of distinct billable keys recorded (observability)."""
+        with self._lock:
+            return len(self._seen)
+
+    # ---- durable persistence --------------------------------------------------
+
+    def _ledger_path(self, key: str) -> Path:
+        """Path of the ledger entry for ``key`` — the single key→path choke point.
+
+        ``key`` must be well-formed hex (the only way a path segment could carry
+        ``..`` or a separator is a malformed key), so the format guard lives here.
+        """
+        if not _is_valid_key(key):
+            raise MeterDedupeError(
+                f"refusing to build a ledger path from a malformed idempotency key "
+                f"(expected {_KEY_LEN}-char lowercase hex)"
+            )
+        return self._dir / f"{key}{_LEDGER_SUFFIX}"
+
+    @staticmethod
+    def _entry_digest(key: str) -> str:
+        """Integrity checksum bound into each entry: SHA-256 of the key itself.
+
+        The entry is content-addressed by its key (the filename), so the digest
+        is over the key — on recovery we recompute it and reject any entry whose
+        stored digest disagrees (corruption / tamper guard).
+        """
+        return hashlib.sha256(key.encode("utf-8")).hexdigest()
+
+    def _write_entry(self, key: str) -> None:
+        """Atomically + durably write one ledger entry (temp → fsync → replace).
+
+        Mirrors ``batcher._write_wal_entry``:
+
+        1. write to a NamedTemporaryFile in the SAME directory (so os.replace is
+           an atomic intra-filesystem rename, never a cross-device copy);
+        2. flush + os.fsync the fd (data hits stable storage);
+        3. os.replace into the final path (atomic: a reader sees old-or-new);
+        4. fsync the directory on POSIX so the rename itself is durable;
+        5. verify the final file's size is non-zero (a zero-byte entry would be a
+           silent truncation we must not treat as recorded).
+        """
+        final_path = self._ledger_path(key)
+        # The exists() short-circuit is an optimisation, NOT the correctness
+        # mechanism: callers reach _write_entry under self._lock (RLock held
+        # across the whole mark_if_new check-write-add), so there is no in-process
+        # TOCTOU window. Even out-of-process, the entry is content-addressed
+        # (filename == key, body derived from key), so two writers of the same key
+        # write byte-identical content and the atomic os.replace below is
+        # last-writer-wins with identical bytes — never a partial/corrupt entry.
+        if final_path.exists():
+            return  # idempotent on disk too (defends against an in-flight retry)
+
+        payload = json.dumps(
+            {"idempotency_key": key, "digest": self._entry_digest(key)},
+            ensure_ascii=False,
+            sort_keys=True,
+        ).encode("utf-8")
+
+        tmp_name: str | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="wb",
+                dir=str(self._dir),
+                prefix=f".{key}.",
+                suffix=".tmp",
+                delete=False,
+            ) as tmp:
+                tmp_name = tmp.name
+                tmp.write(payload)
+                tmp.flush()
+                os.fsync(tmp.fileno())
+            os.replace(tmp_name, str(final_path))
+            tmp_name = None  # ownership transferred to final_path
+            _safe_dir_fsync(self._dir)
+            try:
+                if final_path.stat().st_size == 0:
+                    raise MeterDedupeError(
+                        f"meter ledger entry {final_path.name} is zero-length after "
+                        f"write; refusing to acknowledge a corrupt billable record"
+                    )
+            except OSError as exc:
+                raise MeterDedupeError(
+                    f"meter ledger entry {final_path.name} could not be stat'd "
+                    f"after write: {exc}"
+                ) from exc
+        finally:
+            if tmp_name is not None:
+                try:
+                    os.unlink(tmp_name)
+                except OSError:
+                    pass
+
+    # ---- crash recovery -------------------------------------------------------
+
+    def _recover(self) -> None:
+        """Rebuild the in-memory seen-set from on-disk ledger entries.
+
+        Called once from ``__init__``. A corrupt or mismatched entry is skipped
+        (and left on disk for operator inspection) rather than aborting recovery —
+        one bad entry must not make the store forget every other billed key (which
+        would re-bill them).
+        """
+        try:
+            entries = [
+                p for p in self._dir.iterdir()
+                if p.is_file() and p.name.endswith(_LEDGER_SUFFIX)
+            ]
+        except OSError:
+            return  # no readable ledger dir => nothing to recover
+        for path in entries:
+            key = self._read_entry(path)
+            if key is not None:
+                self._seen.add(key)
+
+    def _read_entry(self, path: Path) -> str | None:
+        """Parse + validate one ledger entry. Returns the key, or None if invalid.
+
+        Validation (mirrors ``batcher._read_wal_entry``): the stored
+        ``idempotency_key`` must (a) be well-formed hex, (b) equal the filename
+        stem, and (c) carry a ``digest`` equal to the recomputed checksum. Any
+        mismatch means corruption/tamper — the entry is rejected (returns None)
+        rather than trusted as a recorded key. The on-disk entry is size-capped
+        before being read into memory (DoS guard).
+        """
+        try:
+            if path.stat().st_size > _MAX_LEDGER_ENTRY_BYTES:
+                return None  # oversized entry: skip without loading (DoS guard)
+            raw = path.read_bytes()
+            data = json.loads(raw.decode("utf-8"))
+        except (OSError, ValueError, UnicodeDecodeError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        key = data.get("idempotency_key")
+        digest = data.get("digest")
+        if not isinstance(key, str) or not isinstance(digest, str):
+            return None
+        if not _is_valid_key(key):
+            return None  # malformed key => reject (path-traversal / corruption)
+        expected_stem = path.name[: -len(_LEDGER_SUFFIX)]
+        if key != expected_stem:
+            return None  # filename/content disagree => corrupt
+        if digest != self._entry_digest(key):
+            return None  # integrity checksum mismatch => corrupt / tampered
+        return key

--- a/graqle/metering/events.py
+++ b/graqle/metering/events.py
@@ -1,0 +1,154 @@
+"""The metering data model: the billable unit and the sink interface (WS-B).
+
+This module defines *what* a billable event is and *where* it goes, with zero
+proprietary or network dependencies — it ships in the Apache-2.0 ``graqle``
+Community package. The Studio-backend (Session-2) implements :class:`MeterSink`
+as ``StudioMeter`` (emit to the metering API + enforce allowance/overage); the
+Community build ships only :class:`LocalNullMeter` (a no-op — local work is
+free).
+
+Design rules (mirror the Layer-5 / runtime composition discipline):
+
+* **The unit is the *anchored* proof.** ADR §3.2/§3.3: the free/paid line is
+  ``local = free, hosted = metered``. A :class:`MeterEvent` is therefore only
+  ever recorded at the moment a proof becomes hosted/anchored — never for a
+  purely-local self-commit. ``unit`` is fixed to ``"proof_anchored"`` (Q3
+  locked: per-anchor only; hosted verify-at-scale ships free).
+* **The idempotency key is the leaf hash.** ``idempotency_key`` is the
+  governed record's Merkle ``leaf_hash`` (hex). It is globally unique per proof
+  and *identical* at both count points (the runtime ``AttestationSink`` path and
+  the Layer-5 ``Committer`` batch path), so the same proof reached via both
+  paths — or retried — dedupes to exactly one billable event (see
+  :mod:`graqle.metering.dedupe`).
+* **A count point only records intent.** Emitting a :class:`MeterEvent` must
+  never alter or block the governed/anchoring path; the sink decides what to do
+  with it. Best-effort, never-raise wiring is the contract (see
+  :mod:`graqle.metering.sinks` and :mod:`graqle.metering.committer_hook`).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Protocol, runtime_checkable
+
+__all__ = [
+    "PROOF_ANCHORED",
+    "MeterEvent",
+    "MeterSink",
+]
+
+# The single billable unit (Q3 locked). A constant rather than a free string so
+# every count point and every sink agrees on the exact token, and a typo becomes
+# an import error rather than a silently-unbilled event.
+PROOF_ANCHORED = "proof_anchored"
+
+
+def _utc_now_iso() -> str:
+    """UTC ISO-8601 timestamp (timezone-aware), to seconds — the event clock."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass(frozen=True)
+class MeterEvent:
+    """One record of *intent to bill* for a hosted/anchored proof.
+
+    Immutable by construction (``frozen=True``): a count point produces it and
+    hands it to a :class:`MeterSink`; nothing downstream may mutate the billable
+    facts. The authoritative dedupe (exactly-once) lives in
+    :class:`graqle.metering.dedupe.MeterDedupeStore`, keyed on
+    :attr:`idempotency_key`.
+
+    Attributes
+    ----------
+    idempotency_key:
+        The governed record's Merkle ``leaf_hash`` (lowercase hex). Globally
+        unique per proof, stable across retries, and identical at both count
+        points — this is what makes exactly-once possible. Required, non-empty.
+    edition:
+        The edition that produced the proof (``"community"`` / ``"studio"`` /
+        ``"enterprise"``). Carried so the meter API can attribute usage to a
+        tenant/plan without re-deriving it. Defaults to ``"community"``.
+    unit:
+        The billable unit. Fixed to :data:`PROOF_ANCHORED`; constructing a
+        :class:`MeterEvent` with any other unit is a programming error and is
+        rejected (defence against an un-priced unit silently entering the meter).
+    count:
+        How many billable units this event represents. Always ``1`` for a
+        per-anchor event; the field exists so a future batched-emit optimisation
+        can coalesce without changing the schema. Must be a positive int.
+    ts:
+        UTC ISO-8601 timestamp of the anchoring moment. Auto-set if omitted.
+    metadata:
+        Optional non-billing context (e.g. ``batch_id``, ``rekor_log_index``)
+        for the meter API's audit trail. Never affects dedupe or pricing. Copied
+        defensively so the frozen event truly owns its data.
+    """
+
+    idempotency_key: str
+    edition: str = "community"
+    unit: str = PROOF_ANCHORED
+    count: int = 1
+    ts: str = field(default_factory=_utc_now_iso)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        # Validate at the boundary: a malformed billable event must fail loudly
+        # where it is created, not produce a mis-billed or un-billed record
+        # downstream. frozen=True means we must go through object.__setattr__ to
+        # normalise the defensively-copied metadata.
+        if not isinstance(self.idempotency_key, str) or not self.idempotency_key:
+            raise ValueError("idempotency_key must be a non-empty string (the leaf_hash hex)")
+        if self.unit != PROOF_ANCHORED:
+            raise ValueError(
+                f"unit must be {PROOF_ANCHORED!r} (the only billable unit; "
+                f"hosted verify-at-scale ships free), got {self.unit!r}"
+            )
+        if not isinstance(self.edition, str) or not self.edition:
+            raise ValueError("edition must be a non-empty string")
+        if not isinstance(self.count, int) or isinstance(self.count, bool) or self.count < 1:
+            raise ValueError("count must be a positive int")
+        if not isinstance(self.ts, str) or not self.ts:
+            raise ValueError("ts must be a non-empty ISO-8601 string")
+        if not isinstance(self.metadata, dict):
+            raise ValueError("metadata must be a dict")
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a plain dict for the meter API / audit store."""
+        return {
+            "idempotency_key": self.idempotency_key,
+            "edition": self.edition,
+            "unit": self.unit,
+            "count": self.count,
+            "ts": self.ts,
+            "metadata": dict(self.metadata),
+        }
+
+
+@runtime_checkable
+class MeterSink(Protocol):
+    """Where a billable :class:`MeterEvent` is recorded (one-method interface).
+
+    Mirrors the shape of ``graqle.governance.runtime.AttestationSink`` (one
+    method, takes the unit of work, side-effects only): the Community build ships
+    :class:`graqle.metering.sinks.LocalNullMeter` (no-op); the proprietary
+    Studio-backend (Session-2) ships ``StudioMeter`` that emits to the metering
+    API and enforces the free monthly hosted-anchor allowance → tiered overage.
+
+    Contract for implementers:
+
+    * ``record`` is called at most once per *unique* billable event — the
+      exactly-once dedupe (keyed on :attr:`MeterEvent.idempotency_key`) is
+      enforced *before* the sink by :class:`graqle.metering.dedupe.MeterDedupeStore`,
+      so a sink may assume it never sees the same key twice for billing
+      purposes. (A sink is still free to be internally idempotent.)
+    * ``record`` is invoked on the governed/anchoring path. It MUST be fast and
+      MUST NOT raise in a way that can break that path — the wiring wraps it
+      best-effort, but a well-behaved sink defers slow/remote work (HTTP, DB)
+      off the critical path itself.
+    """
+
+    def record(self, event: MeterEvent) -> None:
+        """Record one billable event. Side-effects only; returns nothing."""
+        ...

--- a/graqle/metering/sinks.py
+++ b/graqle/metering/sinks.py
@@ -1,0 +1,125 @@
+"""Community meter sinks + the runtime-path count point (WS-B B1).
+
+Two pieces ship in Community:
+
+* :class:`LocalNullMeter` — the default :class:`~graqle.metering.events.MeterSink`.
+  A no-op: local work is free (ADR §3.3). It exists so the wiring is always
+  present and identical in shape to the hosted build — the Studio-backend swaps
+  in ``StudioMeter`` (Session-2) with no call-site change.
+* :class:`MeteredAttestationSink` — **count point 1** (the runtime path). A thin
+  decorator that wraps *any* ``graqle.governance.runtime.AttestationSink``,
+  reads the proof's ``leaf_hash_hex`` off the record, runs the exactly-once
+  dedupe gate, and (on a genuinely-new proof) records one :class:`MeterEvent` —
+  *then* delegates the actual durable write to the wrapped sink. Composition,
+  not modification: ``GovernedRuntime.attest`` is untouched; you opt in by
+  constructing the runtime with ``GovernedRuntime(sink=MeteredAttestationSink(...))``.
+
+Count point 2 (the Layer-5 batch path) lives in
+:mod:`graqle.metering.committer_hook`.
+
+The billable moment on this path is the attested write itself, which only
+carries a ``leaf_hash_hex`` when it represents a real governed decision; a record
+without one is passed straight through unmetered (defensive — never bill a
+malformed/partial record).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from graqle.metering.dedupe import MeterDedupeStore
+from graqle.metering.events import MeterEvent, MeterSink
+
+__all__ = ["LocalNullMeter", "MeteredAttestationSink"]
+
+logger = logging.getLogger(__name__)
+
+
+class LocalNullMeter:
+    """The Community no-op meter sink: local work is free, so it bills nothing.
+
+    Implements :class:`~graqle.metering.events.MeterSink`. Kept as a real class
+    (not ``None``) so every count point always has a sink to call and the wiring
+    is identical between Community and the hosted build.
+    """
+
+    def record(self, event: MeterEvent) -> None:  # noqa: D401 - protocol impl
+        """No-op. Community does not meter local work."""
+        return None
+
+
+class MeteredAttestationSink:
+    """Count point 1 (runtime path): meter an attested write, then delegate it.
+
+    Wraps any ``AttestationSink`` (``DurableJsonlSink``, ``InMemorySink``, or the
+    R2 hosted anchoring sink). On each :meth:`write`:
+
+    1. extract the proof's ``leaf_hash_hex`` from the record (the idempotency
+       key — computed by ``GovernedRuntime.attest`` before it calls the sink);
+    2. **meter best-effort** — run the exactly-once dedupe gate and, only on a
+       genuinely-new proof, hand one :class:`MeterEvent` to the configured
+       :class:`MeterSink`. Any metering error is swallowed and logged: metering
+       must never break or block the durable attestation path;
+    3. **always** delegate the write to the wrapped sink (the system of record).
+
+    Parameters
+    ----------
+    inner:
+        The wrapped ``AttestationSink`` whose ``write`` does the durable record.
+    meter:
+        Where billable events go (defaults to :class:`LocalNullMeter`).
+    dedupe:
+        The exactly-once gate. Shared with count point 2 so a proof that flows
+        through both paths bills once. Optional: if omitted, the meter still
+        fires but without cross-call dedupe — pass a shared
+        :class:`MeterDedupeStore` for real exactly-once.
+    edition:
+        Edition stamped onto emitted events. Defaults to ``"community"``.
+    """
+
+    def __init__(
+        self,
+        inner: Any,
+        meter: MeterSink | None = None,
+        dedupe: MeterDedupeStore | None = None,
+        *,
+        edition: str = "community",
+    ) -> None:
+        if inner is None or not hasattr(inner, "write"):
+            raise ValueError("inner must be an AttestationSink (an object with a write method)")
+        self._inner = inner
+        self._meter: MeterSink = meter if meter is not None else LocalNullMeter()
+        self._dedupe = dedupe
+        self._edition = edition
+
+    def write(self, record: dict[str, Any]) -> None:
+        """Meter the attested record (best-effort), then durably write it."""
+        # Step 1+2: meter intent. Wrapped so a metering fault can NEVER stop the
+        # durable write — the attestation is the system of record; billing is
+        # downstream and must not gate it.
+        try:
+            self._meter_record(record)
+        except Exception:  # never break the attestation path
+            logger.warning("metering failed on runtime attest path (non-fatal)", exc_info=True)
+        # Step 3: the durable write always happens.
+        self._inner.write(record)
+
+    def _meter_record(self, record: dict[str, Any]) -> None:
+        """Emit one billable event for ``record`` if it is a new anchored proof."""
+        key = record.get("leaf_hash_hex") if isinstance(record, dict) else None
+        if not isinstance(key, str) or not key:
+            # No leaf hash => not a meterable governed proof. Pass through.
+            return
+        if self._dedupe is not None and not self._dedupe.mark_if_new(key):
+            return  # already billed (retry / other path) — exactly-once
+        event = MeterEvent(
+            idempotency_key=key,
+            edition=self._edition,
+            metadata={
+                k: record[k]
+                for k in ("record_id", "domain", "policy_id")
+                if isinstance(record, dict) and k in record
+            },
+        )
+        self._meter.record(event)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.64.0"
+version = "0.65.0"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Proprietary — see LICENSE"}

--- a/tests/test_metering/test_committer_hook.py
+++ b/tests/test_metering/test_committer_hook.py
@@ -1,0 +1,94 @@
+"""Tests for count point 2's observer factory (WS-B B1).
+
+100% statement + branch coverage of graqle/metering/committer_hook.py:
+make_meter_observer's emission, dedupe gating, empty-key guard, metadata
+passthrough, and the never-raise guarantee.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from graqle.metering.committer_hook import make_meter_observer
+from graqle.metering.dedupe import MeterDedupeStore
+from graqle.metering.events import PROOF_ANCHORED, MeterEvent
+
+
+def _key(s: str = "p") -> str:
+    return hashlib.sha256(s.encode()).hexdigest()
+
+
+class _CapMeter:
+    def __init__(self):
+        self.events: list[MeterEvent] = []
+
+    def record(self, event):
+        self.events.append(event)
+
+
+def test_observer_bills_each_anchored_leaf(tmp_path):
+    cap = _CapMeter()
+    obs = make_meter_observer(meter=cap, dedupe=MeterDedupeStore(tmp_path), edition="studio")
+    obs(_key("a"), {"batch_id": "b1", "rekor_log_index": 5})
+    obs(_key("b"), {"batch_id": "b1", "rekor_log_index": 5})
+    assert len(cap.events) == 2
+    assert all(e.unit == PROOF_ANCHORED and e.edition == "studio" for e in cap.events)
+    assert cap.events[0].metadata == {"batch_id": "b1", "rekor_log_index": 5}
+
+
+def test_observer_dedupes_within_path(tmp_path):
+    cap = _CapMeter()
+    obs = make_meter_observer(meter=cap, dedupe=MeterDedupeStore(tmp_path))
+    obs(_key("a"), {})
+    obs(_key("a"), {})  # same leaf re-anchored / retry => no-op
+    assert len(cap.events) == 1
+
+
+def test_observer_empty_key_is_noop(tmp_path):
+    cap = _CapMeter()
+    obs = make_meter_observer(meter=cap, dedupe=MeterDedupeStore(tmp_path))
+    obs("", {})
+    obs(None, {})  # type: ignore[arg-type]
+    assert cap.events == []
+
+
+def test_observer_non_dict_context_coerced_to_empty(tmp_path):
+    cap = _CapMeter()
+    obs = make_meter_observer(meter=cap, dedupe=MeterDedupeStore(tmp_path))
+    obs(_key("a"), None)
+    obs(_key("b"), "not-a-dict")  # type: ignore[arg-type]
+    assert cap.events[0].metadata == {} and cap.events[1].metadata == {}
+
+
+def test_observer_defaults_to_local_null_meter(tmp_path):
+    # No meter configured => LocalNullMeter, bills nothing but does not raise.
+    obs = make_meter_observer(dedupe=MeterDedupeStore(tmp_path))
+    obs(_key("a"), {})  # no exception
+
+
+def test_observer_no_dedupe_bills_each_call():
+    cap = _CapMeter()
+    obs = make_meter_observer(meter=cap)  # dedupe=None
+    obs(_key("a"), {})
+    obs(_key("a"), {})
+    assert len(cap.events) == 2
+
+
+def test_observer_never_raises_on_meter_fault(tmp_path):
+    class _Boom:
+        def record(self, event):
+            raise RuntimeError("meter down")
+
+    obs = make_meter_observer(meter=_Boom(), dedupe=MeterDedupeStore(tmp_path))
+    obs(_key("a"), {})  # must NOT raise
+
+
+def test_observer_never_raises_on_dedupe_fault():
+    class _BoomStore:
+        def mark_if_new(self, key):
+            raise OSError("disk full")
+
+    cap = _CapMeter()
+    obs = make_meter_observer(meter=cap, dedupe=_BoomStore())
+    obs(_key("a"), {})  # must NOT raise
+    assert cap.events == []

--- a/tests/test_metering/test_committer_seam.py
+++ b/tests/test_metering/test_committer_seam.py
@@ -1,0 +1,181 @@
+"""Integration tests for the Committer meter_observer seam (WS-B count point 2).
+
+Exercises the additive seam in graqle/governance/tamper_evidence/committer.py
+against a REAL WalBatcher + Committer with a fake anchor, covering:
+* the per-leaf observer fire on the ANCHORED transition,
+* the per-leaf guard's except branch (a raising observer never breaks the anchor),
+* local-only (no anchor) emitting zero billable events (free/paid line),
+* anchor-failure path (REPLAY_QUEUED) emitting zero,
+* cross-path exactly-once when count point 1 and 2 share a MeterDedupeStore.
+
+Offline + deterministic (no network, no Neo4j): the anchor/transport are fakes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from graqle.config.attestation_config import AttestationConfig, RekorConfig, ReplayQueueConfig
+from graqle.governance.tamper_evidence.anchors.sigstore_rekor import RekorAnchor, RekorReceipt
+from graqle.governance.tamper_evidence.audit_log_v3 import CommitStatus
+from graqle.governance.tamper_evidence.batcher import WalBatcher
+from graqle.governance.tamper_evidence.committer import Committer
+from graqle.governance.tamper_evidence.local_replay_queue import LocalReplayQueue
+from graqle.metering import MeterDedupeStore, MeteredAttestationSink, make_meter_observer
+from graqle.metering.events import MeterEvent
+
+
+# ---- fakes / helpers (mirror tests/test_tamper_evidence/test_committer.py) ----
+
+
+def _record(i: int) -> dict:
+    return {
+        "proof_format_version": "1.0.0",
+        "record_id": f"tr_{i:06d}",
+        "content_hash": hashlib.sha256(f"payload-{i}".encode()).hexdigest(),
+        "timestamp_unix": 1_700_000_000 + i,
+        "governance_metadata": {"decision": "ALLOW", "seq": i},
+    }
+
+
+def _receipt(i: int = 1) -> RekorReceipt:
+    return RekorReceipt(i, "logid", "sth", "cert", 1_700_000_000 + i)
+
+
+class _OkTransport:
+    def __init__(self):
+        self.calls = 0
+
+    def submit(self, root_bytes):
+        self.calls += 1
+        return _receipt(self.calls)
+
+
+class _FailTransport:
+    def submit(self, root_bytes):
+        raise RuntimeError("rekor down")
+
+
+def _ok_anchor() -> RekorAnchor:
+    return RekorAnchor(transport=_OkTransport(), sleep=lambda _s: None)
+
+
+def _fail_anchor() -> RekorAnchor:
+    return RekorAnchor(
+        config=RekorConfig(retry_max_attempts=1),
+        transport=_FailTransport(),
+        sleep=lambda _s: None,
+    )
+
+
+def _config() -> AttestationConfig:
+    return AttestationConfig(batch_max_records=1000, batch_max_seconds=5)
+
+
+def _batcher(tmp_path) -> WalBatcher:
+    return WalBatcher(_config(), wal_root=tmp_path)
+
+
+class _CapMeter:
+    def __init__(self):
+        self.events: list[MeterEvent] = []
+
+    def record(self, event):
+        self.events.append(event)
+
+
+# ---- the seam ----------------------------------------------------------------
+
+
+def test_anchored_batch_bills_each_leaf(tmp_path):
+    cap = _CapMeter()
+    obs = make_meter_observer(meter=cap, dedupe=MeterDedupeStore(tmp_path / "dd"), edition="studio")
+    committer = Committer(_config(), _batcher(tmp_path / "wal"), anchor=_ok_anchor(), meter_observer=obs)
+    committer.submit(_record(1))
+    committer.submit(_record(2))
+    committer.submit(_record(3))
+    n = committer.flush()
+    assert n == 3
+    assert len(cap.events) == 3
+    assert all(e.unit == "proof_anchored" and e.edition == "studio" for e in cap.events)
+    # carries the batch context for the meter API audit trail
+    assert cap.events[0].metadata.get("rekor_log_index") == 1
+    assert "batch_id" in cap.events[0].metadata and "merkle_root_hex" in cap.events[0].metadata
+
+
+def test_no_observer_means_no_billing_machinery(tmp_path):
+    # meter_observer=None (the Community default) — anchoring still works, no calls.
+    committer = Committer(_config(), _batcher(tmp_path / "wal"), anchor=_ok_anchor())
+    committer.submit(_record(1))
+    assert committer.flush() == 1  # anchors fine without a meter
+
+
+def test_local_only_no_anchor_bills_zero(tmp_path):
+    cap = _CapMeter()
+    obs = make_meter_observer(meter=cap, dedupe=MeterDedupeStore(tmp_path / "dd"))
+    committer = Committer(_config(), _batcher(tmp_path / "wal"), anchor=None, meter_observer=obs)
+    committer.submit(_record(1))
+    committer.flush()
+    # local commit (COMMITTED, never ANCHORED) => free/paid line => zero events
+    assert cap.events == []
+    cr = committer.commit_record_for(_record(1))
+    assert cr.commit_status == CommitStatus.COMMITTED
+
+
+def test_anchor_failure_replay_queued_bills_zero(tmp_path):
+    cap = _CapMeter()
+    obs = make_meter_observer(meter=cap, dedupe=MeterDedupeStore(tmp_path / "dd"))
+    rq = LocalReplayQueue(ReplayQueueConfig(), queue_root=tmp_path / "rq")
+    committer = Committer(
+        _config(), _batcher(tmp_path / "wal"),
+        anchor=_fail_anchor(), replay_queue=rq, meter_observer=obs,
+    )
+    committer.submit(_record(1))
+    committer.flush()
+    # anchor failed => REPLAY_QUEUED, never ANCHORED => not billable yet
+    assert cap.events == []
+    assert committer.commit_record_for(_record(1)).commit_status == CommitStatus.REPLAY_QUEUED
+
+
+def test_raising_observer_never_breaks_anchor(tmp_path):
+    # The per-leaf guard inside committer.py must swallow an observer exception:
+    # the proof is durable in Rekor regardless.
+    def _boom(record_hash, context):
+        raise RuntimeError("observer blew up")
+
+    committer = Committer(_config(), _batcher(tmp_path / "wal"), anchor=_ok_anchor(), meter_observer=_boom)
+    committer.submit(_record(1))
+    n = committer.flush()  # must NOT raise
+    assert n == 1
+    assert committer.commit_record_for(_record(1)).commit_status == CommitStatus.ANCHORED
+
+
+def test_cross_path_exactly_once(tmp_path):
+    # The SAME proof reaches count point 1 (runtime sink) and count point 2
+    # (committer anchor). With a shared dedupe store, it bills exactly once.
+    cap = _CapMeter()
+    shared = MeterDedupeStore(tmp_path / "dd")
+
+    class _Inner:
+        def __init__(self):
+            self.written = []
+
+        def write(self, r):
+            self.written.append(r)
+
+    # Path 1: a runtime attest record carrying the leaf hash for record #1.
+    leaf1 = hashlib.sha256(b"the-one-proof").hexdigest()
+    runtime_sink = MeteredAttestationSink(_Inner(), meter=cap, dedupe=shared, edition="studio")
+    runtime_sink.write({"leaf_hash_hex": leaf1, "record_id": "tr_000001"})
+    assert len(cap.events) == 1  # billed via path 1
+
+    # Path 2: the committer anchors a leaf with the SAME hash.
+    obs = make_meter_observer(meter=cap, dedupe=shared, edition="studio")
+    obs(leaf1, {"batch_id": "b1"})
+    assert len(cap.events) == 1  # NOT re-billed — cross-path exactly-once
+
+    # A different proof on path 2 does bill.
+    obs(hashlib.sha256(b"another-proof").hexdigest(), {"batch_id": "b1"})
+    assert len(cap.events) == 2

--- a/tests/test_metering/test_dedupe.py
+++ b/tests/test_metering/test_dedupe.py
@@ -1,0 +1,292 @@
+"""Tests for the WAL-backed exactly-once dedupe store (WS-B B3).
+
+100% statement + branch coverage of graqle/metering/dedupe.py. Defensive paths
+(corruption, zero-length, oversized, path-traversal, fsync failure, Windows vs
+POSIX dir-fsync) are reached by real fault injection — never hidden behind
+pragma:no-cover.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from graqle.metering import dedupe as dedupe_mod
+from graqle.metering.dedupe import (
+    _LEDGER_SUFFIX,
+    MeterDedupeError,
+    MeterDedupeStore,
+    _is_valid_key,
+    _safe_dir_fsync,
+)
+
+
+def _key(s: str = "p") -> str:
+    return hashlib.sha256(s.encode()).hexdigest()
+
+
+# ---- key validation -----------------------------------------------------------
+
+
+def test_is_valid_key():
+    assert _is_valid_key(_key())
+    assert not _is_valid_key("")
+    assert not _is_valid_key("x" * 64)  # not hex
+    assert not _is_valid_key(_key()[:-1])  # 63 chars
+    assert not _is_valid_key(_key() + "a")  # 65 chars
+    assert not _is_valid_key("../" + "a" * 61)  # path-traversal attempt
+
+
+# ---- exactly-once core --------------------------------------------------------
+
+
+def test_mark_if_new_first_true_then_false(tmp_path):
+    store = MeterDedupeStore(tmp_path)
+    k = _key()
+    assert store.mark_if_new(k) is True
+    assert store.mark_if_new(k) is False  # second time = no-op
+    assert store.mark_if_new(k) is False
+    assert store.has(k)
+    assert store.count == 1
+
+
+def test_distinct_keys_each_new(tmp_path):
+    store = MeterDedupeStore(tmp_path)
+    assert store.mark_if_new(_key("a")) is True
+    assert store.mark_if_new(_key("b")) is True
+    assert store.count == 2
+
+
+def test_has_is_read_only(tmp_path):
+    store = MeterDedupeStore(tmp_path)
+    k = _key()
+    assert store.has(k) is False
+    assert store.count == 0  # has() did not record
+
+
+def test_mark_if_new_rejects_malformed_key(tmp_path):
+    store = MeterDedupeStore(tmp_path)
+    with pytest.raises(MeterDedupeError, match="malformed idempotency key"):
+        store.mark_if_new("not-a-leaf-hash")
+
+
+def test_ledger_path_rejects_malformed_key(tmp_path):
+    store = MeterDedupeStore(tmp_path)
+    with pytest.raises(MeterDedupeError, match="malformed idempotency key"):
+        store._ledger_path("../escape")
+
+
+# ---- durability + crash recovery ---------------------------------------------
+
+
+def test_recovery_remembers_across_restart(tmp_path):
+    s1 = MeterDedupeStore(tmp_path)
+    s1.mark_if_new(_key("a"))
+    s1.mark_if_new(_key("b"))
+    # fresh store over the same dir = simulated process restart
+    s2 = MeterDedupeStore(tmp_path)
+    assert s2.has(_key("a")) and s2.has(_key("b"))
+    assert s2.count == 2
+    # a recovered key still dedupes (no re-bill)
+    assert s2.mark_if_new(_key("a")) is False
+
+
+def test_on_disk_entry_written_with_digest(tmp_path):
+    store = MeterDedupeStore(tmp_path)
+    k = _key()
+    store.mark_if_new(k)
+    entry = tmp_path / f"{k}{_LEDGER_SUFFIX}"
+    assert entry.exists()
+    data = json.loads(entry.read_text())
+    assert data["idempotency_key"] == k
+    assert data["digest"] == hashlib.sha256(k.encode()).hexdigest()
+
+
+def test_write_entry_idempotent_on_disk(tmp_path):
+    store = MeterDedupeStore(tmp_path)
+    k = _key()
+    store.mark_if_new(k)
+    # calling _write_entry again returns early (file exists) — no crash, no dup
+    store._write_entry(k)
+    assert (tmp_path / f"{k}{_LEDGER_SUFFIX}").exists()
+
+
+# ---- corruption / tamper rejection on recovery -------------------------------
+
+
+def test_recovery_skips_corrupt_json(tmp_path):
+    (tmp_path / f"{_key('a')}{_LEDGER_SUFFIX}").write_text("{ not json")
+    store = MeterDedupeStore(tmp_path)
+    assert store.count == 0  # corrupt entry skipped, not trusted
+
+
+def test_recovery_skips_non_dict_json(tmp_path):
+    (tmp_path / f"{_key('a')}{_LEDGER_SUFFIX}").write_text("[1, 2, 3]")
+    assert MeterDedupeStore(tmp_path).count == 0
+
+
+def test_recovery_skips_missing_fields(tmp_path):
+    (tmp_path / f"{_key('a')}{_LEDGER_SUFFIX}").write_text(json.dumps({"idempotency_key": _key("a")}))
+    assert MeterDedupeStore(tmp_path).count == 0  # no digest
+
+
+def test_recovery_skips_malformed_key_field(tmp_path):
+    p = tmp_path / f"{_key('a')}{_LEDGER_SUFFIX}"
+    p.write_text(json.dumps({"idempotency_key": "short", "digest": "x"}))
+    assert MeterDedupeStore(tmp_path).count == 0
+
+
+def test_recovery_skips_filename_content_mismatch(tmp_path):
+    # filename says key 'a' but content carries key 'b' => corrupt
+    other = _key("b")
+    p = tmp_path / f"{_key('a')}{_LEDGER_SUFFIX}"
+    p.write_text(json.dumps({"idempotency_key": other, "digest": hashlib.sha256(other.encode()).hexdigest()}))
+    assert MeterDedupeStore(tmp_path).count == 0
+
+
+def test_recovery_skips_digest_mismatch(tmp_path):
+    k = _key("a")
+    p = tmp_path / f"{k}{_LEDGER_SUFFIX}"
+    p.write_text(json.dumps({"idempotency_key": k, "digest": "deadbeef"}))  # wrong digest
+    assert MeterDedupeStore(tmp_path).count == 0
+
+
+def test_recovery_skips_oversized_entry(tmp_path, monkeypatch):
+    k = _key("a")
+    p = tmp_path / f"{k}{_LEDGER_SUFFIX}"
+    p.write_text(json.dumps({"idempotency_key": k, "digest": hashlib.sha256(k.encode()).hexdigest()}))
+    monkeypatch.setattr(dedupe_mod, "_MAX_LEDGER_ENTRY_BYTES", 1)  # force oversize
+    assert MeterDedupeStore(tmp_path).count == 0
+
+
+def test_recovery_ignores_non_ledger_files(tmp_path):
+    (tmp_path / "README.txt").write_text("not a ledger entry")
+    (tmp_path / "sub").mkdir()  # a directory, not a file
+    store = MeterDedupeStore(tmp_path)
+    store.mark_if_new(_key("a"))
+    assert store.count == 1
+
+
+def test_recovery_one_bad_entry_does_not_drop_good_ones(tmp_path):
+    good = _key("good")
+    (tmp_path / f"{good}{_LEDGER_SUFFIX}").write_text(
+        json.dumps({"idempotency_key": good, "digest": hashlib.sha256(good.encode()).hexdigest()})
+    )
+    (tmp_path / f"{_key('bad')}{_LEDGER_SUFFIX}").write_text("corrupt")
+    store = MeterDedupeStore(tmp_path)
+    assert store.has(good) and store.count == 1
+
+
+def test_read_entry_handles_unreadable_dir(tmp_path, monkeypatch):
+    # _recover swallows an OSError from iterdir (no readable ledger dir)
+    store = MeterDedupeStore(tmp_path)
+
+    def boom(self):
+        raise OSError("no perms")
+
+    monkeypatch.setattr(Path, "iterdir", boom)
+    store._recover()  # must not raise
+    assert store.count == 0
+
+
+# ---- write-path fault injection ----------------------------------------------
+
+
+def test_write_entry_zero_length_after_write_raises(tmp_path, monkeypatch):
+    # Inject the fault ONLY at the post-write size check. The function calls
+    # final_path.stat() exactly once more after the entry exists; key the fault
+    # on the str(path) (no recursion: we call real_stat, never .exists()).
+    store = MeterDedupeStore(tmp_path)
+    k = _key("z")
+    final_str = str(store._ledger_path(k))
+
+    class _Zero:
+        st_size = 0
+
+    real_stat = Path.stat
+
+    def fake_stat(self, *a, **kw):
+        st = real_stat(self, *a, **kw)
+        if str(self) == final_str and st.st_size > 0:
+            return _Zero()  # report the written entry as zero-length
+        return st
+
+    monkeypatch.setattr(Path, "stat", fake_stat)
+    with pytest.raises(MeterDedupeError, match="zero-length"):
+        store._write_entry(k)
+
+
+def test_write_entry_stat_oserror_raises(tmp_path, monkeypatch):
+    store = MeterDedupeStore(tmp_path)
+    k = _key("z")
+    final_str = str(store._ledger_path(k))
+    real_stat = Path.stat
+    seen = {"n": 0}
+
+    def fake_stat(self, *a, **kw):
+        st = real_stat(self, *a, **kw)  # never recurses (no .exists())
+        if str(self) == final_str and st.st_size > 0:
+            # The first post-existence stat of the final file is the post-write
+            # verification; fail it. (exists() precheck ran before the file
+            # existed, so st_size>0 isolates the post-write call.)
+            seen["n"] += 1
+            raise OSError("stat failed")
+        return st
+
+    monkeypatch.setattr(Path, "stat", fake_stat)
+    with pytest.raises(MeterDedupeError, match="could not be stat'd"):
+        store._write_entry(k)
+    assert seen["n"] == 1
+
+
+def test_write_entry_cleans_tmp_on_replace_failure(tmp_path, monkeypatch):
+    store = MeterDedupeStore(tmp_path)
+    monkeypatch.setattr(dedupe_mod.os, "replace", lambda a, b: (_ for _ in ()).throw(OSError("replace failed")))
+    with pytest.raises(OSError):
+        store._write_entry(_key("z"))
+    # no leftover .tmp files
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_write_entry_unlink_failure_is_swallowed(tmp_path, monkeypatch):
+    store = MeterDedupeStore(tmp_path)
+    monkeypatch.setattr(dedupe_mod.os, "replace", lambda a, b: (_ for _ in ()).throw(OSError("replace failed")))
+    monkeypatch.setattr(dedupe_mod.os, "unlink", lambda p: (_ for _ in ()).throw(OSError("unlink failed")))
+    with pytest.raises(OSError, match="replace failed"):  # original error surfaces, unlink error swallowed
+        store._write_entry(_key("z"))
+
+
+# ---- _safe_dir_fsync branches -------------------------------------------------
+
+
+def test_safe_dir_fsync_noop_on_non_posix(tmp_path, monkeypatch):
+    monkeypatch.setattr(dedupe_mod.os, "name", "nt")
+    _safe_dir_fsync(tmp_path)  # returns immediately, no fd opened
+
+
+def test_safe_dir_fsync_posix_success(tmp_path, monkeypatch):
+    monkeypatch.setattr(dedupe_mod.os, "name", "posix")
+    calls = {"fsync": 0, "close": 0}
+    monkeypatch.setattr(dedupe_mod.os, "open", lambda p, f: 7)
+    monkeypatch.setattr(dedupe_mod.os, "fsync", lambda fd: calls.__setitem__("fsync", calls["fsync"] + 1))
+    monkeypatch.setattr(dedupe_mod.os, "close", lambda fd: calls.__setitem__("close", calls["close"] + 1))
+    _safe_dir_fsync(tmp_path)
+    assert calls == {"fsync": 1, "close": 1}
+
+
+def test_safe_dir_fsync_posix_open_error_logged(tmp_path, monkeypatch):
+    monkeypatch.setattr(dedupe_mod.os, "name", "posix")
+    monkeypatch.setattr(dedupe_mod.os, "open", lambda p, f: (_ for _ in ()).throw(OSError("no dir fd")))
+    _safe_dir_fsync(tmp_path)  # error swallowed (fd never opened, finally skips close)
+
+
+def test_safe_dir_fsync_posix_close_error_swallowed(tmp_path, monkeypatch):
+    monkeypatch.setattr(dedupe_mod.os, "name", "posix")
+    monkeypatch.setattr(dedupe_mod.os, "open", lambda p, f: 7)
+    monkeypatch.setattr(dedupe_mod.os, "fsync", lambda fd: None)
+    monkeypatch.setattr(dedupe_mod.os, "close", lambda fd: (_ for _ in ()).throw(OSError("close failed")))
+    _safe_dir_fsync(tmp_path)  # close error swallowed in finally

--- a/tests/test_metering/test_events.py
+++ b/tests/test_metering/test_events.py
@@ -1,0 +1,117 @@
+"""Tests for the metering data model (WS-B): MeterEvent + MeterSink Protocol.
+
+100% statement + branch coverage of graqle/metering/events.py, including every
+validation branch in MeterEvent.__post_init__ (fault-injected, not hidden).
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from graqle.metering.events import PROOF_ANCHORED, MeterEvent, MeterSink
+
+
+def _key(s: str = "p") -> str:
+    return hashlib.sha256(s.encode()).hexdigest()
+
+
+# ---- happy path ---------------------------------------------------------------
+
+
+def test_minimal_event_defaults():
+    ev = MeterEvent(idempotency_key=_key())
+    assert ev.idempotency_key == _key()
+    assert ev.edition == "community"
+    assert ev.unit == PROOF_ANCHORED
+    assert ev.count == 1
+    assert isinstance(ev.ts, str) and ev.ts  # auto-set ISO timestamp
+    assert ev.metadata == {}
+
+
+def test_event_is_frozen():
+    ev = MeterEvent(idempotency_key=_key())
+    with pytest.raises(Exception):  # FrozenInstanceError
+        ev.edition = "studio"  # type: ignore[misc]
+
+
+def test_metadata_is_defensively_copied():
+    md = {"batch_id": "b1"}
+    ev = MeterEvent(idempotency_key=_key(), metadata=md)
+    md["batch_id"] = "MUTATED"
+    assert ev.metadata == {"batch_id": "b1"}  # event owns its own copy
+
+
+def test_to_dict_roundtrip_shape():
+    ev = MeterEvent(idempotency_key=_key(), edition="studio", metadata={"x": 1})
+    d = ev.to_dict()
+    assert d == {
+        "idempotency_key": _key(),
+        "edition": "studio",
+        "unit": PROOF_ANCHORED,
+        "count": 1,
+        "ts": ev.ts,
+        "metadata": {"x": 1},
+    }
+    # to_dict copies metadata too (mutating the returned dict must not touch event)
+    d["metadata"]["x"] = 99
+    assert ev.metadata == {"x": 1}
+
+
+def test_explicit_count_and_ts():
+    ev = MeterEvent(idempotency_key=_key(), count=3, ts="2026-05-31T00:00:00+00:00")
+    assert ev.count == 3
+    assert ev.ts == "2026-05-31T00:00:00+00:00"
+
+
+# ---- validation branches (each one fault-injected) ---------------------------
+
+
+@pytest.mark.parametrize("bad", ["", None, 123, b"x"])
+def test_rejects_bad_idempotency_key(bad):
+    with pytest.raises(ValueError, match="idempotency_key"):
+        MeterEvent(idempotency_key=bad)  # type: ignore[arg-type]
+
+
+def test_rejects_non_billable_unit():
+    with pytest.raises(ValueError, match="unit must be"):
+        MeterEvent(idempotency_key=_key(), unit="verify_at_scale")
+
+
+@pytest.mark.parametrize("bad", ["", None, 5])
+def test_rejects_bad_edition(bad):
+    with pytest.raises(ValueError, match="edition"):
+        MeterEvent(idempotency_key=_key(), edition=bad)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("bad", [0, -1, "1", 1.0, True])
+def test_rejects_bad_count(bad):
+    # bool is explicitly excluded even though isinstance(True, int) is True.
+    with pytest.raises(ValueError, match="count"):
+        MeterEvent(idempotency_key=_key(), count=bad)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("bad", ["", None, 0])
+def test_rejects_bad_ts(bad):
+    with pytest.raises(ValueError, match="ts"):
+        MeterEvent(idempotency_key=_key(), ts=bad)  # type: ignore[arg-type]
+
+
+def test_rejects_non_dict_metadata():
+    with pytest.raises(ValueError, match="metadata"):
+        MeterEvent(idempotency_key=_key(), metadata=["not", "a", "dict"])  # type: ignore[arg-type]
+
+
+# ---- MeterSink Protocol -------------------------------------------------------
+
+
+def test_metersink_is_runtime_checkable():
+    class Good:
+        def record(self, event): ...
+
+    class Bad:
+        def nope(self): ...
+
+    assert isinstance(Good(), MeterSink)
+    assert not isinstance(Bad(), MeterSink)

--- a/tests/test_metering/test_sinks.py
+++ b/tests/test_metering/test_sinks.py
@@ -1,0 +1,164 @@
+"""Tests for the Community meter sinks + count point 1 (WS-B B1).
+
+100% statement + branch coverage of graqle/metering/sinks.py:
+LocalNullMeter (no-op) and MeteredAttestationSink (runtime-path decorator),
+including the never-raise guard, leaf-hash extraction, dedupe gating, metadata
+projection, and constructor validation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from graqle.metering.events import PROOF_ANCHORED, MeterEvent, MeterSink
+from graqle.metering.dedupe import MeterDedupeStore
+from graqle.metering.sinks import LocalNullMeter, MeteredAttestationSink
+
+
+def _key(s: str = "p") -> str:
+    return hashlib.sha256(s.encode()).hexdigest()
+
+
+class _CapMeter:
+    def __init__(self):
+        self.events: list[MeterEvent] = []
+
+    def record(self, event):
+        self.events.append(event)
+
+
+class _InnerSink:
+    def __init__(self):
+        self.written: list[dict] = []
+
+    def write(self, record):
+        self.written.append(record)
+
+
+# ---- LocalNullMeter -----------------------------------------------------------
+
+
+def test_local_null_meter_is_a_metersink():
+    assert isinstance(LocalNullMeter(), MeterSink)
+
+
+def test_local_null_meter_records_nothing():
+    # No exception, returns None — and there is nowhere for an event to go.
+    assert LocalNullMeter().record(MeterEvent(idempotency_key=_key())) is None
+
+
+# ---- MeteredAttestationSink: construction ------------------------------------
+
+
+def test_requires_inner_with_write():
+    with pytest.raises(ValueError, match="AttestationSink"):
+        MeteredAttestationSink(None)
+    with pytest.raises(ValueError, match="AttestationSink"):
+        MeteredAttestationSink(object())  # no .write
+
+
+def test_defaults_to_local_null_meter():
+    inner = _InnerSink()
+    sink = MeteredAttestationSink(inner)
+    # a meterable record: no configured meter => LocalNullMeter, write still happens
+    sink.write({"leaf_hash_hex": _key()})
+    assert inner.written == [{"leaf_hash_hex": _key()}]
+
+
+# ---- count point 1: write delegation + metering ------------------------------
+
+
+def test_bills_once_and_delegates(tmp_path):
+    inner, cap = _InnerSink(), _CapMeter()
+    store = MeterDedupeStore(tmp_path)
+    sink = MeteredAttestationSink(inner, meter=cap, dedupe=store, edition="studio")
+    rec = {"leaf_hash_hex": _key(), "record_id": "r1", "domain": "d", "policy_id": "p1"}
+    sink.write(rec)
+    assert inner.written == [rec]  # always delegates
+    assert len(cap.events) == 1
+    ev = cap.events[0]
+    assert ev.idempotency_key == _key()
+    assert ev.unit == PROOF_ANCHORED and ev.edition == "studio"
+    # metadata projected from the record (only the whitelisted keys)
+    assert ev.metadata == {"record_id": "r1", "domain": "d", "policy_id": "p1"}
+
+
+def test_retry_does_not_double_bill(tmp_path):
+    inner, cap = _InnerSink(), _CapMeter()
+    store = MeterDedupeStore(tmp_path)
+    sink = MeteredAttestationSink(inner, meter=cap, dedupe=store)
+    rec = {"leaf_hash_hex": _key()}
+    sink.write(rec)
+    sink.write(rec)  # retry
+    assert len(inner.written) == 2  # both writes delegated
+    assert len(cap.events) == 1  # billed once (exactly-once)
+
+
+def test_record_without_leaf_hash_passthrough(tmp_path):
+    inner, cap = _InnerSink(), _CapMeter()
+    sink = MeteredAttestationSink(inner, meter=cap, dedupe=MeterDedupeStore(tmp_path))
+    sink.write({"no_leaf": "x"})  # not a meterable proof
+    assert inner.written == [{"no_leaf": "x"}]
+    assert cap.events == []
+
+
+def test_non_string_leaf_hash_passthrough(tmp_path):
+    inner, cap = _InnerSink(), _CapMeter()
+    sink = MeteredAttestationSink(inner, meter=cap, dedupe=MeterDedupeStore(tmp_path))
+    sink.write({"leaf_hash_hex": 12345})  # wrong type
+    assert inner.written and cap.events == []
+
+
+def test_non_dict_record_passthrough_to_inner():
+    # A non-dict record can't carry a leaf hash; it must still be delegated.
+    inner = _InnerSink()
+    sink = MeteredAttestationSink(inner)
+    sink.write("not-a-dict")  # type: ignore[arg-type]
+    assert inner.written == ["not-a-dict"]
+
+
+def test_metadata_projection_skips_absent_keys(tmp_path):
+    inner, cap = _InnerSink(), _CapMeter()
+    sink = MeteredAttestationSink(inner, meter=cap, dedupe=MeterDedupeStore(tmp_path))
+    sink.write({"leaf_hash_hex": _key()})  # no record_id/domain/policy_id
+    assert cap.events[0].metadata == {}
+
+
+def test_no_dedupe_store_still_bills_each_call():
+    inner, cap = _InnerSink(), _CapMeter()
+    sink = MeteredAttestationSink(inner, meter=cap)  # dedupe=None
+    rec = {"leaf_hash_hex": _key()}
+    sink.write(rec)
+    sink.write(rec)
+    assert len(cap.events) == 2  # without a store, no cross-call dedupe
+
+
+# ---- never-raise guard --------------------------------------------------------
+
+
+def test_meter_fault_never_breaks_write(tmp_path):
+    class _BoomMeter:
+        def record(self, event):
+            raise RuntimeError("meter down")
+
+    inner = _InnerSink()
+    sink = MeteredAttestationSink(inner, meter=_BoomMeter(), dedupe=MeterDedupeStore(tmp_path))
+    rec = {"leaf_hash_hex": _key()}
+    sink.write(rec)  # must NOT raise
+    assert inner.written == [rec]  # durable write still happened
+
+
+def test_dedupe_fault_never_breaks_write(tmp_path):
+    # A dedupe-store failure (e.g. disk error) must also not break the write.
+    class _BoomStore:
+        def mark_if_new(self, key):
+            raise OSError("disk full")
+
+    inner, cap = _InnerSink(), _CapMeter()
+    sink = MeteredAttestationSink(inner, meter=cap, dedupe=_BoomStore())
+    rec = {"leaf_hash_hex": _key()}
+    sink.write(rec)  # must NOT raise
+    assert inner.written == [rec]
+    assert cap.events == []  # dedupe failed before billing


### PR DESCRIPTION
## v0.65.0 — Metering layer (the billable unit for hosted proof anchoring)

Public release of the WS-B metering layer (merged on private as #165). Adds the `graqle.metering` package (Apache-2.0, Community) — the billable unit for hosted proof anchoring — on top of the v0.64.0 verifier.

**Composition only**: no governed/anchoring internals are modified beyond one additive, never-raise observer parameter on the `Committer`.

### What's in it
| Piece | What |
|---|---|
| `MeterEvent` | The billable unit. `unit="proof_anchored"` (per-anchor only). Frozen + validated. |
| `MeterSink` (Protocol) | One-method sink interface (the seam hosted backends implement). |
| `LocalNullMeter` | Community no-op — **local work is free**. |
| `MeteredAttestationSink` | Count point 1: wraps any runtime `AttestationSink`, meters then always delegates the durable write. |
| `make_meter_observer()` | Count point 2: a never-raise callback for the Layer-5 `Committer`, fired once per leaf on the *anchored* transition. |
| `MeterDedupeStore` | WAL-backed exactly-once gate keyed on the proof `leaf_hash` (atomic temp→fsync→replace→dir-fsync; integrity-checksum + content validation on recovery; DoS size cap). Exactly-once under retry, dual-path, and crash-mid-write. |

### Why two count points
A proof can be produced via the runtime `AttestationSink` path **or** the Layer-5 batch-anchor path. Metering only one under-counts the other. Both share one dedupe store keyed on `leaf_hash`, so a proof reaching both — or retried — bills exactly once.

### Free/paid line, mechanical
The billable moment is the *anchored* transition only. A purely-local commit (no anchor) emits **zero** billable events. Metering wiring never raises, so it can't affect the governed/anchoring path.

### Tests
- **77 tests, 100% statement + branch coverage** on all metering modules (fault-injected defensive paths).
- **0 regression** on the existing committer tests (`Committer.meter_observer` defaults to `None` = no behavioural change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
