### PR TITLE
v0.66.0: edition detector (graqle.edition) — open-core edition axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## 0.66.0 (2026-06-01) — [Edition detection (`graqle.edition`)]
+
+> The open-core **edition detector** — the install/feature-set axis (Community /
+> Studio / Enterprise), distinct from the licence tier. Additive and reversible:
+> nothing gates on it yet; it composes with the existing licensing module and
+> defaults to Community.
+
+**Added**
+
+- New `graqle/edition.py`:
+  - `Edition` enum — `COMMUNITY` / `STUDIO` / `ENTERPRISE`.
+  - `detect_edition()` — resolves the active edition: a `GRAQLE_EDITION` env
+    override (exact-match only) → otherwise mapped from `LicenseManager`'s tier →
+    otherwise `COMMUNITY`. `lru_cache`d, with `reset_edition_cache()`.
+  - `is_community()` / `is_studio_or_higher()` / `is_enterprise()` helpers.
+- Fail-closed by design: every failure or malformed-input path resolves to
+  `COMMUNITY` — no input yields a paid edition without a valid licence or an
+  exact valid override. The detector only *reports* the edition; it grants no
+  entitlement (feature gating verifies the licence itself).
+- Composes with the existing `graqle.licensing` (no parallel edition stack).
+
 ## 0.65.0 (2026-05-31) — [Metering layer: the billable unit for hosted proof anchoring]
 
 > The open-core meter. A billable event (`unit="proof_anchored"`) is recorded

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.65.0"
+__version__ = "0.66.0"

--- a/graqle/edition.py
+++ b/graqle/edition.py
@@ -1,0 +1,175 @@
+"""Edition detection for the open-core build (WS-C C2).
+
+GraQle ships in three **editions** — the install/feature-set axis:
+
+* ``Edition.COMMUNITY`` — Apache-2.0, free forever (the default).
+* ``Edition.STUDIO`` — proprietary hosted backend.
+* ``Edition.ENTERPRISE`` — proprietary federation.
+
+This is **distinct from the licence tier** (``graqle.licensing.LicenseTier`` =
+FREE < PRO < TEAM < ENTERPRISE). :func:`detect_edition` folds the 4 tiers onto
+the 3 editions per **ADR-214** (the single source of truth for this mapping):
+
+    FREE → COMMUNITY · PRO → STUDIO · TEAM → STUDIO · ENTERPRISE → ENTERPRISE
+
+Resolution order (feature-flagged, defaults Community):
+
+1. ``GRAQLE_EDITION`` env override — validated against the enum; an invalid
+   value is ignored (logged WARNING) and resolution falls through. Never raises,
+   never silently upgrades.
+2. Licence-derived — map ``LicenseManager().current_tier`` through ADR-214.
+3. Default — ``Edition.COMMUNITY``.
+
+**No-loophole invariant (ADR-214 §"No-loophole guarantees"):** every failure or
+malformed-input path resolves to ``COMMUNITY``. There is NO code path where
+invalid/forged/absent input yields ``STUDIO`` or ``ENTERPRISE`` — the meter and
+gates fail *closed to the cheaper edition*. This module only *reports* the
+edition; it grants no entitlement (feature gating verifies the licence itself —
+WS-D), so the override is a packaging/test switch, not a licence bypass.
+
+Pure stdlib. Safe to import from any Community surface.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from enum import Enum
+from functools import lru_cache
+
+__all__ = [
+    "Edition",
+    "detect_edition",
+    "is_community",
+    "is_studio_or_higher",
+    "is_enterprise",
+    "reset_edition_cache",
+]
+
+logger = logging.getLogger(__name__)
+
+# The env override knob (ADR-214 step 1). A documented operator/packaging switch
+# (C1 Studio/Enterprise wheels set it); NOT a licence — it reports an edition,
+# it does not grant licensed features.
+_EDITION_ENV_VAR = "GRAQLE_EDITION"
+
+
+class Edition(str, Enum):
+    """The install/feature-set axis (distinct from ``LicenseTier``).
+
+    ``str`` mixin so an :class:`Edition` compares/serialises as its plain value
+    (``Edition.COMMUNITY == "community"``) for config files and logs.
+    """
+
+    COMMUNITY = "community"
+    STUDIO = "studio"
+    ENTERPRISE = "enterprise"
+
+    # Ordering helper for "studio or higher" style checks, without making the
+    # enum itself orderable (which str-Enum is not by default).
+    @property
+    def _rank(self) -> int:
+        return _EDITION_RANK[self]
+
+
+# Ascending capability rank. COMMUNITY is the floor; ENTERPRISE the ceiling.
+_EDITION_RANK: dict[Edition, int] = {
+    Edition.COMMUNITY: 0,
+    Edition.STUDIO: 1,
+    Edition.ENTERPRISE: 2,
+}
+
+
+def _edition_from_env() -> Edition | None:
+    """Resolve an explicit ``GRAQLE_EDITION`` override, or ``None`` to fall through.
+
+    Matched case-insensitively against the EXACT enum values. Any other value
+    (typo, injection, empty) is ignored with a WARNING — it never raises and
+    never default-upgrades (ADR-214 guarantee #2).
+    """
+    raw = os.environ.get(_EDITION_ENV_VAR)
+    if raw is None:
+        return None
+    normalised = raw.strip().lower()
+    if not normalised:
+        return None
+    for edition in Edition:
+        if normalised == edition.value:
+            return edition
+    # Truncate the echoed value: GRAQLE_EDITION is a non-secret packaging knob,
+    # but never log unbounded external input (defence-in-depth — log-bloat/noise).
+    shown = raw if len(raw) <= 32 else raw[:32] + "..."
+    logger.warning(
+        "%s=%r is not a valid edition (expected one of %s); ignoring the override "
+        "and falling back to licence-derived detection",
+        _EDITION_ENV_VAR,
+        shown,
+        ", ".join(e.value for e in Edition),
+    )
+    return None
+
+
+def _edition_from_licence() -> Edition:
+    """Map the active licence tier to an edition per ADR-214.
+
+    Fail-closed to ``COMMUNITY`` (ADR-214 guarantee #1): if the licensing module
+    is absent, raises, or yields an unrecognised tier, return COMMUNITY. A bug
+    here can only ever under-privilege, never grant a paid edition.
+    """
+    try:
+        from graqle.licensing.manager import LicenseManager, LicenseTier
+
+        tier = LicenseManager().current_tier
+        # ADR-214 fold (4 tiers → 3 editions). Anything not explicitly mapped
+        # (a tier added later without updating this table) falls to COMMUNITY —
+        # fail-closed-to-cheaper, never default-up.
+        mapping: dict[LicenseTier, Edition] = {
+            LicenseTier.FREE: Edition.COMMUNITY,
+            LicenseTier.PRO: Edition.STUDIO,
+            LicenseTier.TEAM: Edition.STUDIO,
+            LicenseTier.ENTERPRISE: Edition.ENTERPRISE,
+        }
+        return mapping.get(tier, Edition.COMMUNITY)
+    except Exception:  # noqa: BLE001 — fail closed to the cheaper edition (ADR-214 #1)
+        logger.debug(
+            "licence-derived edition detection failed; defaulting to COMMUNITY",
+            exc_info=True,
+        )
+        return Edition.COMMUNITY
+
+
+@lru_cache(maxsize=1)
+def detect_edition() -> Edition:
+    """Return the active :class:`Edition` (ADR-214 resolution order).
+
+    Cached: resolution is pure given (env, licence state). Call
+    :func:`reset_edition_cache` if either changes within a process (e.g. tests,
+    or a runtime licence reload).
+
+    Guarantees (ADR-214): defaults to ``COMMUNITY``; never raises; every
+    failure/malformed path resolves to ``COMMUNITY`` (never a paid edition).
+    """
+    override = _edition_from_env()
+    if override is not None:
+        return override
+    return _edition_from_licence()
+
+
+def reset_edition_cache() -> None:
+    """Clear the cached :func:`detect_edition` result (tests / licence reload)."""
+    detect_edition.cache_clear()
+
+
+def is_community() -> bool:
+    """True iff the active edition is exactly Community (the free core)."""
+    return detect_edition() is Edition.COMMUNITY
+
+
+def is_studio_or_higher() -> bool:
+    """True iff the active edition is Studio or Enterprise (any paid edition)."""
+    return detect_edition()._rank >= Edition.STUDIO._rank
+
+
+def is_enterprise() -> bool:
+    """True iff the active edition is exactly Enterprise."""
+    return detect_edition() is Edition.ENTERPRISE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.65.0"
+version = "0.66.0"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Proprietary — see LICENSE"}

--- a/tests/test_edition/test_edition.py
+++ b/tests/test_edition/test_edition.py
@@ -1,0 +1,263 @@
+"""Tests for edition detection (WS-C C2, ADR-214).
+
+100% statement + branch coverage of graqle/edition.py, with explicit coverage of
+every ADR-214 no-loophole guarantee:
+* default = COMMUNITY (no env, no licence);
+* the full Option-A tier→edition fold (FREE/PRO/TEAM/ENTERPRISE);
+* env override (valid, case-insensitive, whitespace-trimmed);
+* invalid/empty/injection override → ignored, falls through, NEVER raises/upgrades;
+* fail-closed-to-cheaper: licensing absent / raising / unmapped tier → COMMUNITY;
+* there is NO input that yields a paid edition without a valid licence or explicit
+  valid override.
+
+Every test resets the lru_cache and restores os.environ via monkeypatch so the
+process-global cache never leaks across cases (ADR-214 #5).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import graqle.edition as ed
+from graqle.edition import (
+    Edition,
+    detect_edition,
+    is_community,
+    is_enterprise,
+    is_studio_or_higher,
+    reset_edition_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_edition_state(monkeypatch):
+    """Each test starts with no override and a cleared cache; restored after."""
+    monkeypatch.delenv("GRAQLE_EDITION", raising=False)
+    reset_edition_cache()
+    yield
+    reset_edition_cache()
+
+
+def _force_tier(monkeypatch, tier_value):
+    """Patch LicenseManager.current_tier to return a chosen tier (or raise)."""
+    import graqle.licensing.manager as m
+
+    if isinstance(tier_value, Exception):
+        def boom(self):
+            raise tier_value
+        monkeypatch.setattr(m.LicenseManager, "current_tier", property(boom))
+    else:
+        monkeypatch.setattr(m.LicenseManager, "current_tier", property(lambda self: tier_value))
+
+
+# ---- Edition enum -------------------------------------------------------------
+
+
+def test_edition_is_str_enum():
+    assert Edition.COMMUNITY == "community"
+    assert Edition.STUDIO.value == "studio"
+    assert Edition.ENTERPRISE == "enterprise"
+
+
+def test_edition_rank_order():
+    assert Edition.COMMUNITY._rank < Edition.STUDIO._rank < Edition.ENTERPRISE._rank
+
+
+# ---- default (no env, no licence) ---------------------------------------------
+
+
+def test_default_is_community(monkeypatch):
+    # No env override; force the licence to FREE so the test is independent of any
+    # real licence on the machine.
+    _force_tier(monkeypatch, _tier(monkeypatch, "FREE"))
+    reset_edition_cache()
+    assert detect_edition() is Edition.COMMUNITY
+    assert is_community()
+    assert not is_studio_or_higher()
+    assert not is_enterprise()
+
+
+# ---- Option-A tier → edition fold (ADR-214) -----------------------------------
+
+
+def _tier(monkeypatch, name):
+    import graqle.licensing.manager as m
+    return getattr(m.LicenseTier, name)
+
+
+@pytest.mark.parametrize(
+    "tier_name,expected",
+    [
+        ("FREE", Edition.COMMUNITY),
+        ("PRO", Edition.STUDIO),
+        ("TEAM", Edition.STUDIO),
+        ("ENTERPRISE", Edition.ENTERPRISE),
+    ],
+)
+def test_tier_to_edition_mapping(monkeypatch, tier_name, expected):
+    _force_tier(monkeypatch, _tier(monkeypatch, tier_name))
+    reset_edition_cache()
+    assert detect_edition() is expected
+
+
+def test_pro_and_team_both_studio(monkeypatch):
+    # The 4→3 fold: PRO and TEAM are indistinguishable at the edition level.
+    _force_tier(monkeypatch, _tier(monkeypatch, "PRO"))
+    reset_edition_cache()
+    pro = detect_edition()
+    _force_tier(monkeypatch, _tier(monkeypatch, "TEAM"))
+    reset_edition_cache()
+    team = detect_edition()
+    assert pro is team is Edition.STUDIO
+
+
+# ---- env override (valid) -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("community", Edition.COMMUNITY),
+        ("studio", Edition.STUDIO),
+        ("enterprise", Edition.ENTERPRISE),
+        ("STUDIO", Edition.STUDIO),          # case-insensitive
+        ("  Enterprise  ", Edition.ENTERPRISE),  # whitespace-trimmed
+    ],
+)
+def test_valid_override(monkeypatch, raw, expected):
+    monkeypatch.setenv("GRAQLE_EDITION", raw)
+    reset_edition_cache()
+    assert detect_edition() is expected
+
+
+def test_override_beats_licence(monkeypatch):
+    # Override of 'enterprise' wins even though the licence is FREE.
+    _force_tier(monkeypatch, _tier(monkeypatch, "FREE"))
+    monkeypatch.setenv("GRAQLE_EDITION", "enterprise")
+    reset_edition_cache()
+    assert detect_edition() is Edition.ENTERPRISE
+
+
+# ---- env override (invalid) → fail-closed, never raise/upgrade ----------------
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["", "   ", "studioo", "admin", "free-trial", "enterprise; rm -rf", "1", "none"],
+)
+def test_invalid_override_falls_through_to_community(monkeypatch, raw):
+    # No valid licence behind it, so an invalid override must resolve to COMMUNITY
+    # (never raises, never silently upgrades).
+    _force_tier(monkeypatch, _tier(monkeypatch, "FREE"))
+    monkeypatch.setenv("GRAQLE_EDITION", raw)
+    reset_edition_cache()
+    assert detect_edition() is Edition.COMMUNITY
+
+
+def test_long_invalid_override_is_truncated_in_log(monkeypatch, caplog):
+    # A >32-char invalid value exercises the truncation branch; still fails closed.
+    _force_tier(monkeypatch, _tier(monkeypatch, "FREE"))
+    long_val = "x" * 100
+    monkeypatch.setenv("GRAQLE_EDITION", long_val)
+    reset_edition_cache()
+    import logging as _logging
+    with caplog.at_level(_logging.WARNING, logger="graqle.edition"):
+        assert detect_edition() is Edition.COMMUNITY
+    # the full 100-char value must NOT appear verbatim; the truncated form does
+    assert long_val not in caplog.text
+    assert ("x" * 32 + "...") in caplog.text
+
+
+def test_invalid_override_still_honours_real_licence(monkeypatch):
+    # An invalid override falls THROUGH to licence-derived detection (it doesn't
+    # force Community) — so a real ENTERPRISE licence still resolves correctly.
+    _force_tier(monkeypatch, _tier(monkeypatch, "ENTERPRISE"))
+    monkeypatch.setenv("GRAQLE_EDITION", "garbage")
+    reset_edition_cache()
+    assert detect_edition() is Edition.ENTERPRISE
+
+
+# ---- fail-closed-to-cheaper (ADR-214 #1) --------------------------------------
+
+
+def test_licence_exception_fails_closed(monkeypatch):
+    _force_tier(monkeypatch, RuntimeError("licence subsystem exploded"))
+    reset_edition_cache()
+    assert detect_edition() is Edition.COMMUNITY  # never propagates, never upgrades
+
+
+def test_licensing_import_failure_fails_closed(monkeypatch):
+    # Simulate the licensing module being absent (C1 could ship a Community wheel
+    # that still has licensing, but defence-in-depth: import error => COMMUNITY).
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "graqle.licensing.manager":
+            raise ImportError("no licensing in this wheel")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    reset_edition_cache()
+    assert detect_edition() is Edition.COMMUNITY
+
+
+def test_unmapped_tier_fails_closed(monkeypatch):
+    # A tier added later but not in the ADR-214 table must fall to COMMUNITY,
+    # never default-up. Use a stand-in object that .get() won't find.
+    class FutureTier:
+        value = "ultra"
+    _force_tier(monkeypatch, FutureTier())
+    reset_edition_cache()
+    assert detect_edition() is Edition.COMMUNITY
+
+
+def test_no_input_yields_paid_edition_without_licence_or_valid_override(monkeypatch):
+    # The core anti-abuse invariant: with FREE licence and assorted hostile env
+    # values, the result is ALWAYS COMMUNITY.
+    _force_tier(monkeypatch, _tier(monkeypatch, "FREE"))
+    for hostile in ["", "studio ", "ENTERPRISE\n", "studio;enterprise", "Community\t", "stud"]:
+        monkeypatch.setenv("GRAQLE_EDITION", hostile)
+        reset_edition_cache()
+        result = detect_edition()
+        # only an EXACT valid value would upgrade; none of these are exact
+        if hostile.strip().lower() in (e.value for e in Edition):
+            continue
+        assert result is Edition.COMMUNITY, (hostile, result)
+
+
+# ---- caching ------------------------------------------------------------------
+
+
+def test_result_is_cached(monkeypatch):
+    _force_tier(monkeypatch, _tier(monkeypatch, "FREE"))
+    reset_edition_cache()
+    assert detect_edition() is Edition.COMMUNITY
+    # Change the licence WITHOUT resetting the cache → cached COMMUNITY persists.
+    _force_tier(monkeypatch, _tier(monkeypatch, "ENTERPRISE"))
+    assert detect_edition() is Edition.COMMUNITY  # stale-by-design until reset
+    # After reset, the new value is picked up.
+    reset_edition_cache()
+    assert detect_edition() is Edition.ENTERPRISE
+
+
+# ---- helpers ------------------------------------------------------------------
+
+
+def test_helpers_community(monkeypatch):
+    monkeypatch.setenv("GRAQLE_EDITION", "community")
+    reset_edition_cache()
+    assert is_community() and not is_studio_or_higher() and not is_enterprise()
+
+
+def test_helpers_studio(monkeypatch):
+    monkeypatch.setenv("GRAQLE_EDITION", "studio")
+    reset_edition_cache()
+    assert not is_community() and is_studio_or_higher() and not is_enterprise()
+
+
+def test_helpers_enterprise(monkeypatch):
+    monkeypatch.setenv("GRAQLE_EDITION", "enterprise")
+    reset_edition_cache()
+    assert not is_community() and is_studio_or_higher() and is_enterprise()


### PR DESCRIPTION
## v0.66.0 — Edition detection (`graqle.edition`)

Public release of the WS-C C2 edition detector (merged on private as #166). Adds the open-core **edition** axis — the install/feature-set identity (Community / Studio / Enterprise), distinct from the licence tier. **Additive and reversible**: nothing gates on it yet (gating is a later workstream); it composes with the existing `graqle.licensing` module and defaults to Community.

### What's in it
- `graqle/edition.py`:
  - `Edition` enum — `COMMUNITY` / `STUDIO` / `ENTERPRISE`.
  - `detect_edition()` — `GRAQLE_EDITION` env override (exact-match only) → else mapped from the active licence tier → else `COMMUNITY`. `lru_cache`d + `reset_edition_cache()`.
  - `is_community()` / `is_studio_or_higher()` / `is_enterprise()` helpers.

### Fail-closed by design
Every failure / malformed / forged / absent-input path resolves to **COMMUNITY**. There is no input that yields a paid edition without a valid licence or an exact valid override. `detect_edition()` only *reports* the edition — it grants no entitlement (feature gating verifies the licence itself), so the override is a packaging/test switch, not a licence bypass. Composes with the shipped `graqle.licensing` (no parallel edition stack).

### Tests
- **32 tests, 100% statement + branch coverage** on `edition.py` (every fail-closed path fault-injected: licensing-absent, licence-raises, unmapped-tier, hostile env values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
