### PR TITLE
v0.68.0: ed25519 licence hardening + edition gating (patent-leak scan PASS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## 0.68.0 (2026-06-02) — [Ed25519 licence hardening + edition gating]
+
+> The licence layer moves to **ed25519** (asymmetric): the Community wheel
+> verifies licences with a public key it cannot forge with — the private signer
+> stays server-side. Adds offline grace, revocation (CRL + kid), replay
+> protection, and edition/feature entitlement gating. Existing HMAC licences keep
+> working during a deprecation window (see ADR-215).
+
+**Added**
+
+- `graqle.licensing.ed25519_license` — ed25519-signed licences with a `kid`
+  (reuses the ed25519 key manifest; a revoked `kid` invalidates everything it
+  signed). The default verification path is now ed25519 (v2).
+- `graqle.licensing.crl` — ed25519-signed revocation list (per-licence revocation
+  by id) with monotonic-sequence rollback defence; supports air-gapped signed
+  import.
+- `graqle.licensing.nonce_store` — durable accept-once licence-nonce store
+  (replay protection).
+- `graqle.entitlement` — `@requires_edition` / `@requires_feature` gates. The
+  free Community core is never gated.
+- Offline expiry **grace window** (default 60 days, `GRAQLE_LICENSE_GRACE_DAYS`).
+
+**Changed**
+
+- Licence verification is dual-format: ed25519 (v2) preferred, legacy HMAC (v1)
+  accepted during a back-compat window. **v1 HMAC verification now requires a
+  configured `GRAQLE_LICENSE_KEY_SECRET`** — the public dev fallback no longer
+  grants trust (closes a forgery vector for the public wheel).
+
+**Security**
+
+- The Community wheel ships verification keys only — no private signing key, and
+  the HMAC signer (`keygen.py`) is excluded. A public install cannot mint a
+  licence. See ADR-215 for the migration + deprecation posture.
+
 ## 0.67.0 (2026-06-01) — [Open-core packaging carve-out + Apache-2.0]
 
 > The Community ``graqle`` wheel is now genuinely Community-only: the proprietary

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.67.0"
+__version__ = "0.68.0"

--- a/graqle/entitlement.py
+++ b/graqle/entitlement.py
@@ -1,0 +1,170 @@
+"""Edition / feature entitlement gating (WS-D D2).
+
+The decorators here are the first *enforcing* consumer of the WS-C edition axis
+(:func:`graqle.edition.detect_edition`) combined with the WS-D hardened licence
+verification (:class:`graqle.licensing.LicenseManager`). They turn "which edition
+am I?" from a *report* into an *enforced gate* on proprietary surfaces.
+
+* :func:`requires_edition` — gate a callable on the active edition being at least
+  the required :class:`~graqle.edition.Edition` (COMMUNITY < STUDIO < ENTERPRISE).
+* :func:`requires_feature` — gate on a licensed feature flag (delegates to the
+  shipped :func:`graqle.licensing.check_license`, which already raises
+  :class:`~graqle.licensing.manager.LicenseError`). Edition-aware: an
+  ENTERPRISE-edition install implicitly has every feature.
+
+GUARDRAIL (the load-bearing rule): **Community surfaces must NEVER be gated.**
+The free core (reasoning, governance, tamper-evidence, the offline verifier,
+local anchoring, the metering interface) stays unconditionally available. These
+decorators only belong on *proprietary* surfaces. A CI gate
+(``tests/test_entitlement/``) fails the build if a decorator lands on a
+Community-core module. The decorators themselves also refuse a nonsensical
+``requires_edition(Edition.COMMUNITY)`` (gating on the free floor is always a
+mistake — it would gate nothing, or signal confusion).
+
+Why edition AND licence (defence in depth): ``detect_edition()`` can be forced
+via ``GRAQLE_EDITION`` (a packaging/test switch, NOT a grant — ADR-214). So an
+entitlement gate must ALSO confirm a verified, non-revoked, non-expired licence
+of sufficient tier — otherwise setting ``GRAQLE_EDITION=enterprise`` would unlock
+paid features for free. The edition is the fast pre-check; the licence is the
+authority.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+from typing import Any, Callable, TypeVar
+
+from graqle.edition import Edition, detect_edition
+
+__all__ = ["EntitlementError", "requires_edition", "requires_feature"]
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+# Edition → the minimum LicenseTier that legitimately grants it (ADR-214 inverse).
+# A forced GRAQLE_EDITION must be backed by a licence of at least this tier.
+_EDITION_MIN_TIER = {
+    Edition.STUDIO: ("pro", "team", "enterprise"),
+    Edition.ENTERPRISE: ("enterprise",),
+}
+
+
+class EntitlementError(Exception):
+    """Raised when the active edition/licence does not satisfy a gated surface."""
+
+
+def _edition_rank(e: Edition) -> int:
+    return {Edition.COMMUNITY: 0, Edition.STUDIO: 1, Edition.ENTERPRISE: 2}[e]
+
+
+def _licence_tier_value() -> str:
+    """Active verified licence tier value (e.g. 'enterprise'), or 'free'. Fail-closed."""
+    try:
+        from graqle.licensing.manager import _get_manager
+
+        return _get_manager().current_tier.value
+    except Exception:  # noqa: BLE001 — no/broken licence => free (fail closed)
+        return "free"
+
+
+def _entitled_for(required: Edition) -> bool:
+    """True iff the active edition AND a sufficient verified licence satisfy ``required``.
+
+    Defence in depth: the EDITION must be >= required (fast check, honours
+    GRAQLE_EDITION), AND the verified LICENCE tier must be one that legitimately
+    grants ``required`` (so a forced edition without a real licence does not
+    unlock). COMMUNITY requires nothing.
+    """
+    if required is Edition.COMMUNITY:
+        return True
+    if _edition_rank(detect_edition()) < _edition_rank(required):
+        return False
+    return _licence_tier_value() in _EDITION_MIN_TIER[required]
+
+
+def requires_edition(required: Edition) -> Callable[[F], F]:
+    """Gate a (sync or async) callable on the active edition + a sufficient licence.
+
+    Raises :class:`EntitlementError` if the active edition is below ``required``
+    OR no verified licence of a tier that grants ``required`` is present.
+
+    ``requires_edition(Edition.COMMUNITY)`` is rejected at decoration time — the
+    free core is never gated (the WS-D guardrail), so gating on COMMUNITY is
+    always a programming error.
+    """
+    if not isinstance(required, Edition):
+        raise TypeError("requires_edition expects an Edition")
+    if required is Edition.COMMUNITY:
+        raise ValueError(
+            "requires_edition(Edition.COMMUNITY) is invalid — the Community core is "
+            "never gated. Gate only proprietary (Studio/Enterprise) surfaces."
+        )
+
+    def _decorator(func: F) -> F:
+        def _check() -> None:
+            if not _entitled_for(required):
+                raise EntitlementError(
+                    f"'{getattr(func, '__name__', 'this feature')}' requires the GraQle "
+                    f"{required.value.title()} edition with a valid licence. "
+                    f"Active edition: {detect_edition().value}, licence tier: "
+                    f"{_licence_tier_value()}."
+                )
+
+        if asyncio.iscoroutinefunction(func):
+            @functools.wraps(func)
+            async def _async(*args: Any, **kwargs: Any) -> Any:
+                _check()
+                return await func(*args, **kwargs)
+
+            return _async  # type: ignore[return-value]
+
+        @functools.wraps(func)
+        def _sync(*args: Any, **kwargs: Any) -> Any:
+            _check()
+            return func(*args, **kwargs)
+
+        return _sync  # type: ignore[return-value]
+
+    return _decorator
+
+
+def requires_feature(feature: str) -> Callable[[F], F]:
+    """Gate a callable on a licensed *feature* flag.
+
+    Delegates to :func:`graqle.licensing.check_license` (which raises the shipped
+    :class:`~graqle.licensing.manager.LicenseError` when the feature is not
+    available under the current licence). This composes with — does not duplicate
+    — the existing ``require_license`` decorator; use ``requires_feature`` from
+    the entitlement surface so edition + feature gating live in one place.
+
+    An ENTERPRISE-edition install (with a matching licence) implicitly satisfies
+    any feature gate (top tier has all features), short-circuiting the lookup.
+    """
+    if not isinstance(feature, str) or not feature:
+        raise ValueError("requires_feature expects a non-empty feature name")
+
+    def _decorator(func: F) -> F:
+        def _check() -> None:
+            # Top-tier short-circuit: a real ENTERPRISE entitlement has everything.
+            if _entitled_for(Edition.ENTERPRISE):
+                return
+            from graqle.licensing import check_license  # raises LicenseError if absent
+
+            check_license(feature)
+
+        if asyncio.iscoroutinefunction(func):
+            @functools.wraps(func)
+            async def _async(*args: Any, **kwargs: Any) -> Any:
+                _check()
+                return await func(*args, **kwargs)
+
+            return _async  # type: ignore[return-value]
+
+        @functools.wraps(func)
+        def _sync(*args: Any, **kwargs: Any) -> Any:
+            _check()
+            return func(*args, **kwargs)
+
+        return _sync  # type: ignore[return-value]
+
+    return _decorator

--- a/graqle/licensing/crl.py
+++ b/graqle/licensing/crl.py
@@ -1,0 +1,162 @@
+"""Ed25519-signed Certificate/Licence Revocation List (WS-D D1d).
+
+A CRL lets the issuer revoke INDIVIDUAL licences (by ``license_id``) without
+waiting for them to expire — the per-licence complement to ``kid``-revocation
+(which kills every licence a compromised key signed at once).
+
+The CRL is itself **ed25519-signed** (reusing :class:`Ed25519KeyManifest`), so an
+air-gapped / offline install can import a manually-fetched CRL and trust it
+**only if the signature verifies** — never a plain, unauthenticated import
+(sentinel hardening: integrity-verified, never plain). Wire format mirrors the
+licence token::
+
+    base64url(canonical_json_body) "." kid "." base64url(ed25519_signature)
+
+Body::
+
+    {format, issued_at, sequence, revoked_license_ids: [...], kid}
+
+* ``sequence`` — monotonically increasing; a verifier rejects a CRL whose
+  sequence is older than the last one it accepted (rollback / replay defence).
+* ``revoked_license_ids`` — the set of revoked ``license_id`` values.
+
+Pure stdlib + ``cryptography``. Ships in Community (verification + public key
+only — it can check a CRL but cannot forge one).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import datetime
+from typing import Any
+
+from graqle.governance.custody.ed25519_key_manifest import (
+    Ed25519KeyManifest,
+    UnknownKidError,
+)
+
+__all__ = [
+    "CRL_FORMAT_V1",
+    "CRLError",
+    "issue_crl",
+    "verify_crl",
+    "RevocationList",
+]
+
+CRL_FORMAT_V1 = "graqle-crl-v1"
+
+_BODY_FIELDS = ("format", "issued_at", "sequence", "revoked_license_ids", "kid")
+
+
+class CRLError(Exception):
+    """Raised when a CRL cannot be parsed or is structurally invalid."""
+
+
+def _b64url_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(s: str) -> bytes:
+    return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
+
+
+def _canonical_body(body: dict[str, Any]) -> bytes:
+    projected = {k: body.get(k) for k in _BODY_FIELDS}
+    # revoked_license_ids is order-insensitive; sort for a deterministic signature.
+    rids = projected.get("revoked_license_ids")
+    if isinstance(rids, list):
+        projected["revoked_license_ids"] = sorted(rids)
+    return json.dumps(projected, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+class RevocationList:
+    """A verified, in-memory revocation set with monotonic-sequence enforcement.
+
+    Holds the trusted CRL body after verification. :meth:`is_revoked` is the
+    hot-path check the licence manager calls per verification.
+    """
+
+    def __init__(self, revoked_license_ids: set[str], sequence: int, issued_at: str) -> None:
+        self._revoked = set(revoked_license_ids)
+        self.sequence = sequence
+        self.issued_at = issued_at
+
+    def is_revoked(self, license_id: str | None) -> bool:
+        """True iff ``license_id`` is on the revocation list. ``None`` is never revoked."""
+        return license_id is not None and license_id in self._revoked
+
+    @property
+    def count(self) -> int:
+        return len(self._revoked)
+
+
+def issue_crl(
+    manifest: Ed25519KeyManifest,
+    kid: str,
+    *,
+    issued_at: str,
+    sequence: int,
+    revoked_license_ids: list[str],
+    at: datetime | None = None,
+) -> str:
+    """Issue an ed25519-signed CRL token (SERVER-SIDE only — needs a private key)."""
+    if not isinstance(sequence, int) or sequence < 0:
+        raise CRLError("CRL sequence must be a non-negative int")
+    body: dict[str, Any] = {
+        "format": CRL_FORMAT_V1,
+        "issued_at": issued_at,
+        "sequence": sequence,
+        "revoked_license_ids": sorted(set(revoked_license_ids)),
+        "kid": kid,
+    }
+    message = _canonical_body(body)
+    signature = manifest.sign(kid, message, at=at)
+    return ".".join((_b64url_encode(message), kid, _b64url_encode(signature)))
+
+
+def verify_crl(
+    token: str,
+    manifest: Ed25519KeyManifest,
+    *,
+    min_sequence: int = -1,
+    at: datetime | None = None,
+) -> RevocationList | None:
+    """Verify a signed CRL token. Return a :class:`RevocationList`, or ``None``.
+
+    Returns ``None`` (never raises on a bad token — fail closed) if: the token is
+    malformed, the ``kid`` is unknown/untrusted/REVOKED, the signature is invalid,
+    or ``sequence <= min_sequence`` (rollback/replay defence — pass the last
+    accepted sequence as ``min_sequence`` so an older CRL cannot un-revoke a
+    licence). A trusted, fresh CRL yields the revocation set.
+    """
+    if not isinstance(token, str) or token.count(".") != 2:
+        return None
+    msg_b64, kid, sig_b64 = token.split(".")
+    if not kid:
+        return None
+    try:
+        message = _b64url_decode(msg_b64)
+        signature = _b64url_decode(sig_b64)
+        body = json.loads(message.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        return None
+    if not isinstance(body, dict) or body.get("format") != CRL_FORMAT_V1:
+        return None
+    if body.get("kid") != kid:
+        return None  # token kid vs signed-body kid mismatch => tamper
+    seq = body.get("sequence")
+    if not isinstance(seq, int) or seq <= min_sequence:
+        return None  # stale/rollback CRL rejected
+    rids = body.get("revoked_license_ids")
+    if not isinstance(rids, list) or not all(isinstance(r, str) for r in rids):
+        return None
+    # Recompute the signed message from the trusted field projection.
+    recomputed = _canonical_body(body)
+    try:
+        trusted = manifest.verify(kid, recomputed, signature, at=at)
+    except UnknownKidError:
+        return None
+    if not trusted:
+        return None
+    return RevocationList(set(rids), seq, str(body.get("issued_at", "")))

--- a/graqle/licensing/ed25519_license.py
+++ b/graqle/licensing/ed25519_license.py
@@ -1,0 +1,234 @@
+"""Ed25519-signed licence keys (WS-D D1a) — the asymmetric replacement for HMAC.
+
+Why this exists (grounded in the WS-C C1 carve-out):
+The legacy licence format (``manager.py``) is HMAC-SHA256 — symmetric. The same
+secret verifies AND signs, so any verifier must hold the signing secret. Since
+the Community wheel is now public (Apache-2.0) and ``graqle/licensing/`` ships in
+it, an HMAC verifier embeds the forging secret — anyone could mint an ENTERPRISE
+licence. (``keygen.py`` even warns: "embeds the HMAC signing secret … never
+distribute to end users".)
+
+Ed25519 closes that: the **private** signing key stays server-side (issuer only —
+Stripe webhook / admin keygen, excluded from the Community wheel); the Community
+wheel carries only the **public** verification key, which cannot forge anything.
+
+This module composes the SHIPPED ``Ed25519KeyManifest``
+(``graqle/governance/custody/ed25519_key_manifest.py``) — its windowed 3-state
+``kid`` lifecycle (ACTIVE→RETIRED→REVOKED) gives us **kid-revocation for free**:
+a REVOKED ``kid`` makes :meth:`Ed25519KeyManifest.verify` return ``False``, so
+every licence that ``kid`` signed is invalidated at once.
+
+Wire format (``v2`` licence)::
+
+    base64url(canonical_json_payload) "." kid "." base64url(ed25519_signature)
+
+The signature covers the canonical JSON of the payload. The ``kid`` travels in
+the token (so the verifier knows which public key to check) and is itself part of
+the signed payload (so it cannot be swapped). Payload fields::
+
+    {format, license_id, tier, holder, email, issued_at, expires_at,
+     features, nonce, kid}
+
+* ``license_id`` — stable unique id (CRL revocation targets this).
+* ``nonce`` — random per-issue value for replay protection (see
+  :mod:`graqle.licensing.nonce_store`).
+* ``format`` — ``"graqle-license-v2"`` (distinguishes from the legacy HMAC v1).
+
+Pure stdlib + ``cryptography`` (already a hard dependency). Ships in Community —
+it holds verification logic + the public key, never a private key.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+# Security observability (OWASP A09): verification REJECTIONS are logged at
+# WARNING so a flood of failed/forged/revoked attempts is visible to incident
+# response — WITHOUT changing the fail-closed return-None behaviour, and without
+# logging the token itself (no secret/PII in logs).
+logger = logging.getLogger("graqle.licensing.ed25519_license")
+
+from graqle.governance.custody.ed25519_key_manifest import (
+    Ed25519KeyManifest,
+    UnknownKidError,
+)
+
+__all__ = [
+    "LICENSE_FORMAT_V2",
+    "Ed25519LicenseError",
+    "issue_ed25519_license",
+    "parse_ed25519_license",
+    "verify_ed25519_license",
+]
+
+LICENSE_FORMAT_V2 = "graqle-license-v2"
+
+# Fields, in a fixed order, that constitute the signed payload. Canonicalised via
+# json.dumps(sort_keys=True) so signer and verifier agree byte-for-byte.
+_PAYLOAD_FIELDS = (
+    "format",
+    "license_id",
+    "tier",
+    "holder",
+    "email",
+    "issued_at",
+    "expires_at",
+    "features",
+    "nonce",
+    "kid",
+)
+
+
+class Ed25519LicenseError(Exception):
+    """Raised when an ed25519 licence cannot be parsed or is structurally invalid."""
+
+
+def _b64url_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(s: str) -> bytes:
+    pad = "=" * (-len(s) % 4)
+    return base64.urlsafe_b64decode(s + pad)
+
+
+def _canonical_payload_bytes(payload: dict[str, Any]) -> bytes:
+    """Deterministic bytes for signing/verification — only the allowlisted fields.
+
+    Projecting to ``_PAYLOAD_FIELDS`` (rather than signing the raw dict) means a
+    verifier recomputes the signed message from exactly the fields it trusts, so
+    an attacker cannot smuggle an unsigned extra field past the signature.
+    """
+    projected = {k: payload.get(k) for k in _PAYLOAD_FIELDS}
+    return json.dumps(projected, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+@dataclass(frozen=True)
+class _ParsedLicense:
+    """The decoded (not-yet-trusted) parts of an ed25519 licence token."""
+
+    payload: dict[str, Any]
+    kid: str
+    signature: bytes
+    signed_message: bytes
+
+
+def issue_ed25519_license(
+    manifest: Ed25519KeyManifest,
+    kid: str,
+    *,
+    license_id: str,
+    tier: str,
+    holder: str,
+    email: str,
+    issued_at: str,
+    nonce: str,
+    expires_at: str | None = None,
+    features: list[str] | None = None,
+    at: datetime | None = None,
+) -> str:
+    """Issue an ed25519-signed licence token (SERVER-SIDE only — needs a private key).
+
+    ``manifest`` must hold the private key for ``kid`` (it won't in a Community
+    install — issuance happens server-side). Timestamps are passed in (not read
+    from the clock) so issuance is deterministic and testable.
+    """
+    payload: dict[str, Any] = {
+        "format": LICENSE_FORMAT_V2,
+        "license_id": license_id,
+        "tier": tier,
+        "holder": holder,
+        "email": email,
+        "issued_at": issued_at,
+        "expires_at": expires_at,
+        "features": sorted(features or []),
+        "nonce": nonce,
+        "kid": kid,
+    }
+    message = _canonical_payload_bytes(payload)
+    signature = manifest.sign(kid, message, at=at)  # raises if kid can't sign
+    return ".".join(
+        (_b64url_encode(message), kid, _b64url_encode(signature))
+    )
+
+
+def parse_ed25519_license(token: str) -> _ParsedLicense:
+    """Decode a licence token into its parts WITHOUT verifying the signature.
+
+    Raises :class:`Ed25519LicenseError` on any structural problem (wrong shape,
+    bad base64, non-JSON payload, format mismatch, or a kid/payload-kid
+    disagreement — which would be a tamper attempt).
+    """
+    if not isinstance(token, str) or token.count(".") != 2:
+        raise Ed25519LicenseError("malformed ed25519 licence token (expected 3 dot-parts)")
+    msg_b64, kid, sig_b64 = token.split(".")
+    if not kid:
+        raise Ed25519LicenseError("ed25519 licence token has empty kid")
+    try:
+        signed_message = _b64url_decode(msg_b64)
+        signature = _b64url_decode(sig_b64)
+        payload = json.loads(signed_message.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise Ed25519LicenseError(f"undecodable ed25519 licence token: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise Ed25519LicenseError("ed25519 licence payload is not a JSON object")
+    if payload.get("format") != LICENSE_FORMAT_V2:
+        raise Ed25519LicenseError(
+            f"not a {LICENSE_FORMAT_V2} licence (format={payload.get('format')!r})"
+        )
+    # The kid in the token must equal the kid inside the signed payload — else an
+    # attacker could route verification to a different key than the one signed.
+    if payload.get("kid") != kid:
+        raise Ed25519LicenseError("ed25519 licence kid mismatch (token vs signed payload)")
+    # Recompute the signed message from the trusted field projection (defends
+    # against smuggled unsigned fields).
+    return _ParsedLicense(
+        payload=payload,
+        kid=kid,
+        signature=signature,
+        signed_message=_canonical_payload_bytes(payload),
+    )
+
+
+def verify_ed25519_license(
+    token: str,
+    manifest: Ed25519KeyManifest,
+    *,
+    at: datetime | None = None,
+) -> dict[str, Any] | None:
+    """Verify an ed25519 licence token. Return the trusted payload, or ``None``.
+
+    Returns the payload dict ONLY if: the token parses, its ``kid`` is registered
+    in ``manifest``, and ``manifest.verify`` trusts the signature at ``at`` (which
+    enforces kid-revocation — a REVOKED kid always fails — and the kid's validity
+    window). Returns ``None`` for any untrusted/forged/malformed token. Never
+    raises on a bad token (a caller treats ``None`` as "no valid licence"); this
+    is the security boundary, so it fails closed.
+
+    NOTE: expiry, grace, nonce-replay, and CRL checks are layered on TOP of this
+    by the manager — this function answers only "is the signature cryptographically
+    trusted under a non-revoked kid".
+    """
+    when = at if at is not None else datetime.now(timezone.utc)
+    try:
+        parsed = parse_ed25519_license(token)
+    except Ed25519LicenseError as exc:
+        logger.warning("ed25519 licence rejected: malformed/invalid token (%s)", exc)
+        return None
+    try:
+        trusted = manifest.verify(parsed.kid, parsed.signed_message, parsed.signature, at=when)
+    except UnknownKidError:
+        logger.warning("ed25519 licence rejected: unknown signing kid %r", parsed.kid)
+        return None  # unknown signer => not trusted (fail closed)
+    if not trusted:
+        logger.warning(
+            "ed25519 licence rejected: signature not trusted for kid %r "
+            "(revoked kid, bad signature, or out-of-window)", parsed.kid
+        )
+        return None
+    return parsed.payload

--- a/graqle/licensing/manager.py
+++ b/graqle/licensing/manager.py
@@ -29,7 +29,7 @@ import logging
 import os
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from functools import wraps
 from pathlib import Path
@@ -119,6 +119,35 @@ TIER_FEATURES: dict[LicenseTier, set[str]] = {
 # Pre-compute the ordered list for cumulative lookups.
 _TIER_ORDER: list[LicenseTier] = list(LicenseTier)
 
+# WS-D D1b: offline expiry grace window. Default 60 days (Harish Q-D2), overridable
+# via GRAQLE_LICENSE_GRACE_DAYS. Covers offline/air-gapped installs that cannot
+# refresh promptly; past it the licence is invalid.
+_DEFAULT_GRACE_DAYS = 60
+
+
+def _grace_delta() -> "timedelta":
+    """The configured grace window as a timedelta (>= 0; bad/negative => default)."""
+    raw = os.environ.get("GRAQLE_LICENSE_GRACE_DAYS")
+    days = _DEFAULT_GRACE_DAYS
+    if raw is not None:
+        try:
+            parsed = int(raw)
+            if parsed >= 0:
+                days = parsed
+        except (TypeError, ValueError):
+            pass  # malformed override => keep the safe default
+    return timedelta(days=days)
+
+
+def _as_utc_expiry(dt: "datetime") -> "datetime":
+    """Normalise an expiry datetime to aware-UTC (naive assumed UTC).
+
+    Defends the grace comparison against the naive/aware mismatch trap — a naive
+    ``expires_at`` (e.g. parsed from a tz-less ISO string) would otherwise raise
+    on comparison with ``now(timezone.utc)``.
+    """
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
 
 # ---------------------------------------------------------------------------
 # License dataclass
@@ -134,15 +163,52 @@ class License:
     issued_at: datetime
     expires_at: datetime | None = None  # ``None`` means perpetual
     features: set[str] = field(default_factory=set)
+    # WS-D D1a: populated for ed25519 (v2) licences; None for legacy HMAC (v1).
+    # license_id is the CRL revocation target; nonce drives replay protection;
+    # kid is the signing key id (kid-revocation invalidates all its licences).
+    license_id: str | None = None
+    nonce: str | None = None
+    kid: str | None = None
 
     # -- properties ----------------------------------------------------------
 
     @property
     def is_valid(self) -> bool:
-        """Return ``True`` if the license has not expired."""
+        """Return ``True`` iff the licence is STRICTLY within its validity window.
+
+        This keeps its long-standing meaning: expired (past ``expires_at``) ==
+        invalid, with no grace. A perpetual licence (``expires_at is None``) is
+        always valid. The WS-D D1b offline grace is a SEPARATE concept — see
+        :attr:`in_grace` / :attr:`is_valid_or_in_grace`, which the manager's
+        acceptance gate and ``current_tier`` use. Splitting them preserves the
+        original ``is_valid`` contract (and its tests) while still delivering the
+        grace allowance at the acceptance layer.
+        """
         if self.expires_at is None:
             return True
-        return datetime.now(timezone.utc) < self.expires_at
+        return datetime.now(timezone.utc) < _as_utc_expiry(self.expires_at)
+
+    @property
+    def in_grace(self) -> bool:
+        """True iff the licence is PAST ``expires_at`` but still within the grace window.
+
+        WS-D D1b: the grace is the offline-tolerance window AFTER strict expiry
+        (default 60 days, ``GRAQLE_LICENSE_GRACE_DAYS``). ``is_valid`` stays
+        STRICT (expired == invalid at ``expires_at``) — its long-standing meaning
+        is preserved; grace is a SEPARATE allowance applied by the licence
+        acceptance gate (:meth:`LicenseManager._accept_license`), not a silent
+        redefinition of ``is_valid``.
+        """
+        if self.expires_at is None:
+            return False
+        now = datetime.now(timezone.utc)
+        exp = _as_utc_expiry(self.expires_at)
+        return exp <= now < exp + _grace_delta()
+
+    @property
+    def is_valid_or_in_grace(self) -> bool:
+        """True iff the licence is strictly valid OR within the offline grace window."""
+        return self.is_valid or self.in_grace
 
     @property
     def all_features(self) -> set[str]:
@@ -174,6 +240,160 @@ def _get_verification_key() -> bytes:
     return b"graqle-dev-fallback-rotate-2025Q3"
 
 
+# WS-D D1a: the trusted ed25519 public-key manifest for licence verification.
+# Cached so the manifest (and any PEM parse) happens once. Public material only —
+# safe to ship in the Community wheel; it can verify but never sign/forge.
+_trusted_license_manifest: "object | None" = None
+_trusted_manifest_loaded = False
+
+
+def _get_trusted_license_manifest():
+    """Return the ed25519 ``Ed25519KeyManifest`` of trusted licence-signing keys.
+
+    Sources, in order:
+    1. ``GRAQLE_LICENSE_PUBLIC_KEYS`` env — JSON list of
+       ``{kid, public_key_pem, valid_from, valid_until, state}`` (the production
+       path; the deployer pins the trusted signer keys).
+    2. A vendored manifest file ``graqle/licensing/trusted_keys.json`` if present
+       (shipped public keys).
+    3. ``None`` — no ed25519 trust configured; v2 verification yields ``None`` and
+       the dual-verify path falls back to HMAC. (A Community user with no v2
+       licence is unaffected.)
+
+    Never raises: a malformed source logs a warning and yields ``None`` (fail
+    closed — an unverifiable manifest must not be treated as trusting anything).
+    """
+    global _trusted_license_manifest, _trusted_manifest_loaded  # noqa: PLW0603
+    if _trusted_manifest_loaded:
+        return _trusted_license_manifest
+    _trusted_manifest_loaded = True
+    _trusted_license_manifest = _build_trusted_license_manifest()
+    return _trusted_license_manifest
+
+
+def _build_trusted_license_manifest():
+    """Construct the trusted-key manifest from env or a vendored file (or None)."""
+    import json as _json
+    from datetime import datetime as _dt
+
+    from graqle.governance.custody.ed25519_key_manifest import (
+        Ed25519KeyManifest,
+        KeyState,
+    )
+    from cryptography.hazmat.primitives.serialization import load_pem_public_key
+
+    raw = os.environ.get("GRAQLE_LICENSE_PUBLIC_KEYS")
+    if not raw:
+        vendored = Path(__file__).with_name("trusted_keys.json")
+        if vendored.exists():
+            try:
+                raw = vendored.read_text(encoding="utf-8")
+            except OSError:
+                raw = None
+    if not raw:
+        return None  # no ed25519 trust configured
+
+    try:
+        entries = _json.loads(raw)
+        if not isinstance(entries, list):
+            raise ValueError("trusted-keys source must be a JSON list")
+        manifest = Ed25519KeyManifest()
+        for e in entries:
+            pub = load_pem_public_key(e["public_key_pem"].encode("utf-8"))
+            manifest.register(
+                kid=e["kid"],
+                public_key=pub,
+                valid_from=_dt.fromisoformat(e["valid_from"]),
+                valid_until=_dt.fromisoformat(e["valid_until"]),
+                state=KeyState(e.get("state", "active")),
+            )
+        return manifest
+    except Exception as exc:  # noqa: BLE001 — fail closed on a bad manifest
+        _license_logger.warning(
+            "GRAQLE_LICENSE_PUBLIC_KEYS / trusted_keys.json could not be parsed; "
+            "ed25519 licence verification disabled (falling back to HMAC). cause: %s",
+            exc,
+        )
+        return None
+
+
+# WS-D D1d: the active (verified) CRL. Loaded from GRAQLE_LICENSE_CRL (a signed
+# CRL token) or a vendored graqle/licensing/crl.token file; verified against the
+# trusted manifest. Cached. None => no CRL configured => nothing is CRL-revoked.
+_active_crl: "object | None" = None
+_active_crl_loaded = False
+
+
+def _get_active_crl():
+    """Return the verified :class:`RevocationList` (or None). Cached; fail-closed."""
+    global _active_crl, _active_crl_loaded  # noqa: PLW0603
+    if _active_crl_loaded:
+        return _active_crl
+    _active_crl_loaded = True
+    _active_crl = _build_active_crl()
+    return _active_crl
+
+
+def _build_active_crl():
+    """Load + verify the configured CRL token against the trusted manifest, or None."""
+    token = os.environ.get("GRAQLE_LICENSE_CRL")
+    if not token:
+        vendored = Path(__file__).with_name("crl.token")
+        if vendored.exists():
+            try:
+                token = vendored.read_text(encoding="utf-8").strip()
+            except OSError:
+                token = None
+    if not token:
+        return None
+    manifest = _get_trusted_license_manifest()
+    if manifest is None:
+        # A CRL we cannot verify must NOT be trusted (it could be a forged
+        # all-empty CRL that un-revokes everything). No manifest => no CRL.
+        _license_logger.warning(
+            "a CRL is configured but no trusted manifest is available to verify it; "
+            "ignoring the CRL (cannot trust an unverifiable revocation list)"
+        )
+        return None
+    try:
+        from graqle.licensing.crl import verify_crl
+
+        # min_sequence -1 accepts any non-negative sequence on first load. (A
+        # persistent last-accepted-sequence store is a future hardening; the
+        # signature + monotonic body already block a downgraded forgery.)
+        return verify_crl(token, manifest, min_sequence=-1)
+    except Exception:  # noqa: BLE001 — unverifiable CRL => fail closed to "no CRL"
+        _license_logger.warning("CRL could not be verified; ignoring it", exc_info=True)
+        return None
+
+
+# WS-D D1c: the licence nonce store (replay protection). OFF by default — it
+# writes to disk, and most installs don't need per-nonce replay defence. Opt in
+# by setting GRAQLE_LICENSE_NONCE_DIR to a writable directory.
+_nonce_store: "object | None" = None
+_nonce_store_loaded = False
+
+
+def _get_nonce_store():
+    """Return the configured :class:`LicenseNonceStore` (or None if disabled)."""
+    global _nonce_store, _nonce_store_loaded  # noqa: PLW0603
+    if _nonce_store_loaded:
+        return _nonce_store
+    _nonce_store_loaded = True
+    directory = os.environ.get("GRAQLE_LICENSE_NONCE_DIR")
+    if not directory:
+        _nonce_store = None
+        return None
+    try:
+        from graqle.licensing.nonce_store import LicenseNonceStore
+
+        _nonce_store = LicenseNonceStore(directory)
+    except Exception:  # noqa: BLE001 — a broken store must not block licence load
+        _license_logger.warning("nonce store init failed; replay protection off", exc_info=True)
+        _nonce_store = None
+    return _nonce_store
+
+
 class LicenseManager:
     """Offline license verification.  No phone-home, no telemetry."""
 
@@ -184,45 +404,170 @@ class LicenseManager:
     # -- loading -------------------------------------------------------------
 
     def _load_license(self) -> None:
-        """Attempt to load a license key from known locations."""
-        # 1. Environment variable
-        key = os.environ.get("COGNIGRAPH_LICENSE_KEY")
-        if key:
-            self._license = self._verify_key(key)
-            if self._license is not None:
-                return
+        """Attempt to load a license key from known locations.
 
-        # 2. User-level license file
-        license_path = Path.home() / ".graqle" / "license.key"
-        if license_path.exists():
-            key = license_path.read_text(encoding="utf-8").strip()
-            self._license = self._verify_key(key)
-            if self._license is not None:
+        Each candidate key is cryptographically verified (:meth:`_verify_key`),
+        then passed through :meth:`_accept_license` which applies the WS-D
+        post-verify gates (expiry+grace, CRL revocation, nonce replay). Only a
+        licence that passes ALL gates is accepted; otherwise the search continues
+        and ultimately falls back to the free tier.
+        """
+        for key in self._candidate_keys():
+            lic = self._accept_license(self._verify_key(key))
+            if lic is not None:
+                self._license = lic
                 return
-
-        # 3. Project-level license file
-        local_path = Path("graqle.license")
-        if local_path.exists():
-            key = local_path.read_text(encoding="utf-8").strip()
-            self._license = self._verify_key(key)
-            if self._license is not None:
-                return
-
         # No valid license — default to free tier.
         self._license = None
+
+    @staticmethod
+    def _candidate_keys() -> "list[str]":
+        """Yield licence-key strings from the known locations, in priority order."""
+        keys: list[str] = []
+        env = os.environ.get("COGNIGRAPH_LICENSE_KEY")
+        if env:
+            keys.append(env)
+        for path in (Path.home() / ".graqle" / "license.key", Path("graqle.license")):
+            try:
+                if path.exists():
+                    keys.append(path.read_text(encoding="utf-8").strip())
+            except OSError:
+                continue  # unreadable file => skip, try the next source
+        return keys
+
+    def _accept_license(self, lic: "License | None") -> "License | None":
+        """Apply WS-D post-verify gates; return the licence iff it passes all.
+
+        Gates (each fail-closed → return None → caller falls back to free tier):
+        1. **expiry + grace** — ``lic.is_valid`` (D1b: valid until expiry + grace).
+        2. **CRL revocation** — if a trusted CRL is configured and lists this
+           ``license_id``, reject (D1d). No CRL configured => not revoked.
+        3. **nonce replay** — if a nonce store is configured, the licence's nonce
+           must be accept-once; a replayed nonce is rejected (D1c). Legacy HMAC
+           licences (no nonce) skip this gate.
+
+        A gate failure NEVER raises — it degrades to "no valid licence".
+        """
+        if lic is None:
+            return None
+        try:
+            if not lic.is_valid_or_in_grace:
+                return None
+            if lic.license_id is not None:
+                crl = self._get_active_crl()
+                if crl is not None and crl.is_revoked(lic.license_id):
+                    _license_logger.warning(
+                        "licence %s is revoked by CRL (seq=%s); falling back to free tier",
+                        lic.license_id, crl.sequence,
+                    )
+                    return None
+            if lic.nonce is not None:
+                store = self._get_nonce_store()
+                if store is not None and not store.accept_once(lic.nonce):
+                    _license_logger.warning(
+                        "licence nonce replay detected (license_id=%s); rejecting",
+                        lic.license_id,
+                    )
+                    return None
+            return lic
+        except Exception:  # noqa: BLE001 — any gate fault fails closed to free tier
+            _license_logger.warning("licence post-verify gate errored; failing closed", exc_info=True)
+            return None
+
+    @staticmethod
+    def _get_active_crl():
+        """Load + verify the configured CRL (or None). Cached at module level."""
+        return _get_active_crl()
+
+    @staticmethod
+    def _get_nonce_store():
+        """Return the configured nonce store (or None if replay-protection off)."""
+        return _get_nonce_store()
 
     # -- verification --------------------------------------------------------
 
     def _verify_key(self, key: str) -> License | None:
-        """Verify a license key offline using HMAC-SHA256.
+        """Verify a licence key offline. Dual-format (WS-D D1a).
+
+        Dispatches by wire shape — ed25519 v2 (``payload.kid.sig``, 3 dot-parts)
+        is tried FIRST; the legacy HMAC v1 (``payload.sig``, 2 parts) is the
+        back-compat fallback for licences issued before the ed25519 migration.
+
+        ed25519 is asymmetric: the Community wheel verifies with a PUBLIC key it
+        cannot forge with (the private signing key stays server-side). HMAC is
+        symmetric and is retained only for a deprecation window — new licences are
+        issued as v2. Returns a :class:`License` on success, ``None`` otherwise.
+        """
+        if isinstance(key, str) and key.count(".") == 2:
+            lic = self._verify_key_ed25519(key)
+            if lic is not None:
+                return lic
+            # fall through: a malformed v2-shaped token is not a valid v1 either,
+            # but try HMAC anyway (cheap) so a genuine v1 key is never rejected on
+            # shape alone if the format tag was absent.
+        return self._verify_key_hmac(key)
+
+    def _verify_key_ed25519(self, key: str) -> License | None:
+        """Verify an ed25519 (v2) licence against the trusted public-key manifest.
+
+        Composes :func:`graqle.licensing.ed25519_license.verify_ed25519_license`
+        (signature + kid-revocation + kid-window) and maps the trusted payload to
+        a :class:`License`. Returns ``None`` for any untrusted/forged/malformed
+        token, or if no trusted manifest is configured. Fails closed.
+        """
+        try:
+            from graqle.licensing.ed25519_license import verify_ed25519_license
+
+            manifest = _get_trusted_license_manifest()
+            if manifest is None:
+                return None
+            payload = verify_ed25519_license(key, manifest)
+            if payload is None:
+                return None
+            return License(
+                tier=LicenseTier(payload["tier"]),
+                holder=payload.get("holder", "Unknown"),
+                email=payload.get("email", ""),
+                issued_at=datetime.fromisoformat(payload["issued_at"]),
+                expires_at=(
+                    datetime.fromisoformat(payload["expires_at"])
+                    if payload.get("expires_at")
+                    else None
+                ),
+                features=set(payload.get("features", [])),
+                license_id=payload.get("license_id"),
+                nonce=payload.get("nonce"),
+                kid=payload.get("kid"),
+            )
+        except Exception:  # noqa: BLE001 — untrusted input, fail closed to None
+            return None
+
+    def _verify_key_hmac(self, key: str) -> License | None:
+        """Verify a legacy HMAC-SHA256 (v1) licence key.
 
         Key format::
 
             base64url(json_payload).base64url(hmac_sha256_signature)
 
+        DEPRECATED (WS-D): symmetric — retained only for the back-compat window.
         Returns a :class:`License` on success or ``None`` on failure.
         """
         try:
+            # WS-D security gate (sentinel graq_predict vector #4): the HMAC
+            # secret's dev FALLBACK is a public literal that ships in the
+            # Community wheel. If no REAL secret is configured
+            # (GRAQLE_LICENSE_KEY_SECRET unset), the only available key is that
+            # public fallback — so an attacker could forge a v1 licence and slip
+            # it through the dual-verify fallback. Refuse to verify v1 in that
+            # case: a genuine legacy v1 customer licence was signed with the
+            # PRODUCTION secret, so verifying it legitimately REQUIRES that secret
+            # to be set (server-side). No real secret => no HMAC trust.
+            if not os.environ.get("GRAQLE_LICENSE_KEY_SECRET"):
+                return None
+
+            if not isinstance(key, str) or not key:
+                return None  # explicit type guard (defence-in-depth; also fail-closed)
+
             parts = key.split(".")
             if len(parts) != 2:
                 return None
@@ -265,8 +610,15 @@ class LicenseManager:
 
     @property
     def current_tier(self) -> LicenseTier:
-        """Return the active license tier (defaults to FREE)."""
-        if self._license is not None and self._license.is_valid:
+        """Return the active license tier (defaults to FREE).
+
+        WS-D D1b: honours the offline grace window — a licence that is strictly
+        valid OR within grace reports its tier. (``self._license`` is only set by
+        ``_load_license`` after passing the full acceptance gate, so a present
+        licence here is already CRL/nonce-clean; this guard re-confirms only the
+        time validity, now grace-aware.)
+        """
+        if self._license is not None and self._license.is_valid_or_in_grace:
             return self._license.tier
         return LicenseTier.FREE
 

--- a/graqle/licensing/nonce_store.py
+++ b/graqle/licensing/nonce_store.py
@@ -1,0 +1,231 @@
+"""Licence nonce replay-protection store (WS-D D1c).
+
+Each ed25519 licence carries a random ``nonce`` (see
+:mod:`graqle.licensing.ed25519_license`). This store records the nonces that
+have been *accepted*, so a licence token cannot be replayed after it has been
+superseded/revoked: the first time a nonce is seen it is recorded and accepted;
+a second presentation of the same nonce is rejected.
+
+This deliberately mirrors the proven WAL discipline of
+:class:`graqle.metering.dedupe.MeterDedupeStore` (temp → ``fsync`` → atomic
+``os.replace`` → directory ``fsync`` → post-write zero-length check; integrity
+digest + filename-stem validation on recovery; DoS size cap; corruption-skip).
+It differs in one respect: a licence ``nonce`` is an arbitrary opaque string
+(not a 64-hex digest), so the on-disk FILENAME is the SHA-256 of the nonce (a
+safe, fixed-width hex stem) while the entry body stores the original nonce +
+an integrity digest. Pure stdlib.
+
+Replay semantics (single authoritative source): :meth:`accept_once` returns
+``True`` exactly once per nonce (accept), ``False`` thereafter (replay). The
+durable record is written BEFORE ``True`` is returned, and the in-memory set is
+rebuilt from disk on startup, so a crash cannot cause a replay to be accepted
+twice. (Mirrors metering's persist-before-ack + recover-on-startup.)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+import threading
+from pathlib import Path
+
+__all__ = ["NonceStoreError", "LicenseNonceStore"]
+
+logger = logging.getLogger(__name__)
+
+_ENTRY_SUFFIX = ".nonce.json"
+# The filename stem is sha256(nonce) hex: 64 lowercase hex chars. Same structural
+# path-traversal guard as the metering store (the stem is always a digest we
+# computed, never attacker-controlled bytes).
+_STEM_LEN = 64
+_HEX_DIGITS = frozenset("0123456789abcdef")
+_MAX_ENTRY_BYTES = 1 * 1024 * 1024
+# A nonce longer than this is refused before hashing (defence against an absurd
+# input; a real licence nonce is a short random token).
+_MAX_NONCE_LEN = 4096
+
+
+class NonceStoreError(Exception):
+    """Raised for nonce-store operations that cannot proceed safely."""
+
+
+def _stem_for(nonce: str) -> str:
+    """SHA-256 hex of the nonce — the safe fixed-width filename stem."""
+    return hashlib.sha256(nonce.encode("utf-8")).hexdigest()
+
+
+def _is_valid_stem(stem: str) -> bool:
+    return len(stem) == _STEM_LEN and not (set(stem) - _HEX_DIGITS)
+
+
+def _safe_dir_fsync(dir_path: Path) -> None:
+    """fsync the directory on POSIX so the rename is durable; no-op on Windows."""
+    if os.name != "posix":
+        return
+    fd = None
+    try:
+        fd = os.open(str(dir_path), os.O_RDONLY)
+        os.fsync(fd)
+    except OSError as exc:
+        logger.warning("nonce-store directory fsync failed for %s: %s", dir_path, exc)
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+class LicenseNonceStore:
+    """Durable, thread-safe, accept-once gate for licence nonces.
+
+    Usage::
+
+        store = LicenseNonceStore(directory)
+        if not store.accept_once(license.nonce):
+            raise LicenseError("licence nonce replayed")
+
+    Parameters
+    ----------
+    directory:
+        Where nonce records live (created if absent). One file per accepted nonce.
+    """
+
+    def __init__(self, directory: str | Path) -> None:
+        self._dir = Path(directory)
+        self._lock = threading.RLock()
+        self._seen: set[str] = set()  # set of stems
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._recover()
+
+    # ---- public API -----------------------------------------------------------
+
+    def accept_once(self, nonce: str) -> bool:
+        """Record ``nonce`` and report whether it was new.
+
+        Returns ``True`` the first time a (well-formed, bounded) nonce is seen —
+        the caller accepts the licence — and ``False`` on any subsequent
+        presentation (a replay). A non-string or over-long nonce raises
+        :class:`NonceStoreError` (a malformed nonce is a verification-layer bug,
+        not a silently-accepted licence).
+        """
+        if not isinstance(nonce, str) or not nonce:
+            raise NonceStoreError("nonce must be a non-empty string")
+        if len(nonce) > _MAX_NONCE_LEN:
+            raise NonceStoreError(
+                f"nonce exceeds {_MAX_NONCE_LEN} chars; refusing (suspicious input)"
+            )
+        stem = _stem_for(nonce)
+        with self._lock:
+            if stem in self._seen:
+                return False
+            self._write_entry(stem, nonce)  # durable BEFORE acknowledging "new"
+            self._seen.add(stem)
+            return True
+
+    def has_seen(self, nonce: str) -> bool:
+        """True iff ``nonce`` has already been accepted (read-only)."""
+        if not isinstance(nonce, str) or not nonce or len(nonce) > _MAX_NONCE_LEN:
+            return False
+        with self._lock:
+            return _stem_for(nonce) in self._seen
+
+    @property
+    def count(self) -> int:
+        """Number of distinct accepted nonces (observability)."""
+        with self._lock:
+            return len(self._seen)
+
+    # ---- durable persistence --------------------------------------------------
+
+    def _entry_path(self, stem: str) -> Path:
+        if not _is_valid_stem(stem):
+            raise NonceStoreError("refusing to build a path from a malformed stem")
+        return self._dir / f"{stem}{_ENTRY_SUFFIX}"
+
+    @staticmethod
+    def _entry_digest(stem: str, nonce: str) -> str:
+        """Integrity checksum binding the stem to the stored nonce."""
+        return hashlib.sha256((stem + ":" + nonce).encode("utf-8")).hexdigest()
+
+    def _write_entry(self, stem: str, nonce: str) -> None:
+        """Atomically + durably write one nonce entry (temp → fsync → replace)."""
+        final_path = self._entry_path(stem)
+        if final_path.exists():
+            return  # idempotent on disk (in-flight retry)
+        payload = json.dumps(
+            {"stem": stem, "nonce": nonce, "digest": self._entry_digest(stem, nonce)},
+            ensure_ascii=False,
+            sort_keys=True,
+        ).encode("utf-8")
+        tmp_name: str | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="wb", dir=str(self._dir), prefix=f".{stem}.", suffix=".tmp", delete=False
+            ) as tmp:
+                tmp_name = tmp.name
+                tmp.write(payload)
+                tmp.flush()
+                os.fsync(tmp.fileno())
+            os.replace(tmp_name, str(final_path))
+            tmp_name = None
+            _safe_dir_fsync(self._dir)
+            try:
+                if final_path.stat().st_size == 0:
+                    raise NonceStoreError(
+                        f"nonce entry {final_path.name} is zero-length after write"
+                    )
+            except OSError as exc:
+                raise NonceStoreError(
+                    f"nonce entry {final_path.name} could not be stat'd after write: {exc}"
+                ) from exc
+        finally:
+            if tmp_name is not None:
+                try:
+                    os.unlink(tmp_name)
+                except OSError:
+                    pass
+
+    # ---- crash recovery -------------------------------------------------------
+
+    def _recover(self) -> None:
+        """Rebuild the in-memory seen-set from on-disk entries (corrupt => skip)."""
+        try:
+            entries = [
+                p for p in self._dir.iterdir()
+                if p.is_file() and p.name.endswith(_ENTRY_SUFFIX)
+            ]
+        except OSError:
+            return
+        for path in entries:
+            stem = self._read_entry(path)
+            if stem is not None:
+                self._seen.add(stem)
+
+    def _read_entry(self, path: Path) -> str | None:
+        """Parse + validate one entry. Returns the stem, or None if invalid."""
+        try:
+            if path.stat().st_size > _MAX_ENTRY_BYTES:
+                return None
+            data = json.loads(path.read_bytes().decode("utf-8"))
+        except (OSError, ValueError, UnicodeDecodeError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        stem = data.get("stem")
+        nonce = data.get("nonce")
+        digest = data.get("digest")
+        if not (isinstance(stem, str) and isinstance(nonce, str) and isinstance(digest, str)):
+            return None
+        if not _is_valid_stem(stem):
+            return None
+        if stem != path.name[: -len(_ENTRY_SUFFIX)]:
+            return None  # filename/content mismatch => corrupt
+        if stem != _stem_for(nonce):
+            return None  # stem must be sha256(nonce) — else tampered
+        if digest != self._entry_digest(stem, nonce):
+            return None  # integrity checksum mismatch => corrupt/tampered
+        return stem

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.67.0"
+version = "0.68.0"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,13 @@ exclude = [
     "graqle/leads/*",
     "graqle/studio/*",
     "graqle/server/*",
+    # WS-D D-pkg (ADR-BIZ-001): the admin licence SIGNER must not ship in the
+    # public Community wheel. keygen.py embeds the legacy HMAC signing secret
+    # (its own docstring: "never distribute to end users"); generate_key signs
+    # licences. With ed25519 (WS-D) the wheel verifies with a PUBLIC key only and
+    # cannot forge, but excluding the signer is belt-and-suspenders — the public
+    # artifact carries verification, never issuance.
+    "graqle/licensing/keygen.py",
 ]
 
 [tool.hatch.build.targets.wheel.force-include]

--- a/tests/test_cli/test_activate.py
+++ b/tests/test_cli/test_activate.py
@@ -11,9 +11,18 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _set_license_secret(monkeypatch):
+    """WS-D: v1 HMAC generate+verify round-trips require a real secret configured
+    (the public dev fallback is refused). `graq activate` verifies the key, so
+    these tests run with a real (test) secret — as production does."""
+    monkeypatch.setenv("GRAQLE_LICENSE_KEY_SECRET", "test-license-secret-activate")
 
 
 class TestActivateCommand:

--- a/tests/test_entitlement/test_entitlement.py
+++ b/tests/test_entitlement/test_entitlement.py
@@ -1,0 +1,241 @@
+"""Tests for edition/feature entitlement gating (WS-D D2) — all failure points.
+
+100% statement + branch coverage of graqle/entitlement.py, incl. the
+defence-in-depth invariant (forced GRAQLE_EDITION without a licence does NOT
+unlock) and the Community-never-gated guard.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import graqle.edition as E
+import graqle.entitlement as ENT
+from graqle.entitlement import (
+    Edition,
+    EntitlementError,
+    requires_edition,
+    requires_feature,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    monkeypatch.delenv("GRAQLE_EDITION", raising=False)
+    E.reset_edition_cache()
+    yield
+    E.reset_edition_cache()
+
+
+def _force_tier(monkeypatch, tier_name: str):
+    """Force the manager singleton to report a given licence tier."""
+    import graqle.licensing.manager as M
+
+    class _Mgr:
+        @property
+        def current_tier(self):
+            return getattr(M.LicenseTier, tier_name)
+
+    monkeypatch.setattr(M, "_manager", _Mgr())
+
+
+def _force_tier_raises(monkeypatch):
+    import graqle.licensing.manager as M
+
+    class _Boom:
+        @property
+        def current_tier(self):
+            raise RuntimeError("licence subsystem down")
+
+    monkeypatch.setattr(M, "_manager", _Boom())
+
+
+# ---- requires_edition decoration-time validation ------------------------------
+
+
+def test_requires_edition_rejects_community():
+    with pytest.raises(ValueError, match="never gated"):
+        requires_edition(Edition.COMMUNITY)
+
+
+def test_requires_edition_rejects_non_edition():
+    with pytest.raises(TypeError):
+        requires_edition("studio")  # type: ignore[arg-type]
+
+
+# ---- DEFENCE IN DEPTH: forced edition without licence ------------------------
+
+
+def test_forced_edition_without_licence_blocked(monkeypatch):
+    monkeypatch.setenv("GRAQLE_EDITION", "enterprise")
+    E.reset_edition_cache()
+    _force_tier(monkeypatch, "FREE")  # no real paid licence
+
+    @requires_edition(Edition.ENTERPRISE)
+    def secret():
+        return "unlocked"
+
+    with pytest.raises(EntitlementError):
+        secret()
+
+
+def test_edition_and_matching_licence_unlocks(monkeypatch):
+    monkeypatch.setenv("GRAQLE_EDITION", "enterprise")
+    E.reset_edition_cache()
+    _force_tier(monkeypatch, "ENTERPRISE")
+
+    @requires_edition(Edition.ENTERPRISE)
+    def secret():
+        return "unlocked"
+
+    assert secret() == "unlocked"
+
+
+def test_studio_gate_blocked_in_community(monkeypatch):
+    _force_tier(monkeypatch, "FREE")  # default community
+
+    @requires_edition(Edition.STUDIO)
+    def studio_only():
+        return "ok"
+
+    with pytest.raises(EntitlementError):
+        studio_only()
+
+
+def test_studio_gate_satisfied_by_pro_and_team(monkeypatch):
+    for tier in ("PRO", "TEAM"):
+        monkeypatch.setenv("GRAQLE_EDITION", "studio")
+        E.reset_edition_cache()
+        _force_tier(monkeypatch, tier)
+
+        @requires_edition(Edition.STUDIO)
+        def f():
+            return tier
+
+        assert f() == tier
+
+
+def test_enterprise_gate_not_satisfied_by_team(monkeypatch):
+    # edition forced enterprise but licence only team => blocked (tier insufficient)
+    monkeypatch.setenv("GRAQLE_EDITION", "enterprise")
+    E.reset_edition_cache()
+    _force_tier(monkeypatch, "TEAM")
+
+    @requires_edition(Edition.ENTERPRISE)
+    def f():
+        return "x"
+
+    with pytest.raises(EntitlementError):
+        f()
+
+
+def test_licence_exception_fails_closed(monkeypatch):
+    monkeypatch.setenv("GRAQLE_EDITION", "enterprise")
+    E.reset_edition_cache()
+    _force_tier_raises(monkeypatch)
+
+    @requires_edition(Edition.ENTERPRISE)
+    def f():
+        return "x"
+
+    with pytest.raises(EntitlementError):
+        f()  # licence read raised → treated as free → blocked
+
+
+# ---- async support ------------------------------------------------------------
+
+
+def test_requires_edition_async(monkeypatch):
+    _force_tier(monkeypatch, "FREE")
+
+    @requires_edition(Edition.STUDIO)
+    async def af():
+        return "ok"
+
+    with pytest.raises(EntitlementError):
+        asyncio.run(af())
+
+
+def test_requires_edition_async_unlocks(monkeypatch):
+    monkeypatch.setenv("GRAQLE_EDITION", "enterprise")
+    E.reset_edition_cache()
+    _force_tier(monkeypatch, "ENTERPRISE")
+
+    @requires_edition(Edition.ENTERPRISE)
+    async def af():
+        return "ok"
+
+    assert asyncio.run(af()) == "ok"
+
+
+def test_metadata_preserved(monkeypatch):
+    @requires_edition(Edition.STUDIO)
+    def documented():
+        """Doc stays."""
+
+    assert documented.__name__ == "documented"
+    assert documented.__doc__ == "Doc stays."
+
+
+# ---- requires_feature ---------------------------------------------------------
+
+
+def test_requires_feature_rejects_empty():
+    with pytest.raises(ValueError):
+        requires_feature("")
+
+
+def test_requires_feature_enterprise_shortcircuits(monkeypatch):
+    monkeypatch.setenv("GRAQLE_EDITION", "enterprise")
+    E.reset_edition_cache()
+    _force_tier(monkeypatch, "ENTERPRISE")
+
+    @requires_feature("any_feature")
+    def f():
+        return "ok"
+
+    assert f() == "ok"  # top-tier short-circuit, no check_license call
+
+
+def test_requires_feature_delegates_to_check_license(monkeypatch):
+    _force_tier(monkeypatch, "FREE")
+    called = {}
+
+    def fake_check(feature):
+        called["feature"] = feature
+
+    monkeypatch.setattr("graqle.licensing.check_license", fake_check)
+
+    @requires_feature("ontology_generator")
+    def f():
+        return "ok"
+
+    assert f() == "ok"
+    assert called["feature"] == "ontology_generator"
+
+
+def test_requires_feature_async(monkeypatch):
+    monkeypatch.setenv("GRAQLE_EDITION", "enterprise")
+    E.reset_edition_cache()
+    _force_tier(monkeypatch, "ENTERPRISE")
+
+    @requires_feature("x")
+    async def af():
+        return "ok"
+
+    assert asyncio.run(af()) == "ok"
+
+
+def test_licence_tier_value_helper_fail_closed(monkeypatch):
+    _force_tier_raises(monkeypatch)
+    assert ENT._licence_tier_value() == "free"
+
+
+def test_entitled_for_community_is_always_true(monkeypatch):
+    # _entitled_for(COMMUNITY) returns True unconditionally (the free floor needs
+    # no edition/licence). Direct unit — decorators reject COMMUNITY at decoration,
+    # so this defensive branch is exercised here.
+    _force_tier(monkeypatch, "FREE")
+    assert ENT._entitled_for(Edition.COMMUNITY) is True

--- a/tests/test_licensing/test_crl.py
+++ b/tests/test_licensing/test_crl.py
@@ -1,0 +1,160 @@
+"""Tests for the ed25519-signed CRL (WS-D D1d) — all failure points.
+
+100% statement + branch coverage of graqle/licensing/crl.py.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from graqle.governance.custody.ed25519_key_manifest import Ed25519KeyManifest, KeyState
+from graqle.licensing.crl import CRL_FORMAT_V1, CRLError, issue_crl, verify_crl
+
+_NOW = datetime(2026, 6, 1, tzinfo=timezone.utc)
+_VF, _VU = _NOW - timedelta(days=1), _NOW + timedelta(days=365)
+
+
+@pytest.fixture
+def keys():
+    priv = Ed25519PrivateKey.generate()
+    server = Ed25519KeyManifest()
+    server.register("crl-kid", priv.public_key(), _VF, _VU, KeyState.ACTIVE, private_key=priv)
+    client = Ed25519KeyManifest()
+    client.register("crl-kid", priv.public_key(), _VF, _VU, KeyState.ACTIVE)
+    return server, client
+
+
+def _crl(server, **over):
+    kw = dict(issued_at=_NOW.isoformat(), sequence=5, revoked_license_ids=["L-1", "L-2"], at=_NOW)
+    kw.update(over)
+    return issue_crl(server, "crl-kid", **kw)
+
+
+def test_issue_verify_roundtrip(keys):
+    server, client = keys
+    rl = verify_crl(_crl(server), client, min_sequence=-1, at=_NOW)
+    assert rl is not None
+    assert rl.is_revoked("L-1") and rl.is_revoked("L-2")
+    assert not rl.is_revoked("L-9")
+    assert not rl.is_revoked(None)
+    assert rl.sequence == 5 and rl.count == 2
+    assert rl.issued_at == _NOW.isoformat()
+
+
+def test_dedup_revoked_ids(keys):
+    server, client = keys
+    rl = verify_crl(_crl(server, revoked_license_ids=["L-1", "L-1", "L-2"]), client, at=_NOW)
+    assert rl.count == 2
+
+
+def test_rollback_defence(keys):
+    server, client = keys
+    tok = _crl(server, sequence=5)
+    assert verify_crl(tok, client, min_sequence=5, at=_NOW) is None  # equal => rejected
+    assert verify_crl(tok, client, min_sequence=6, at=_NOW) is None  # older => rejected
+    assert verify_crl(tok, client, min_sequence=4, at=_NOW) is not None
+
+
+def test_tampered_rejected(keys):
+    server, client = keys
+    tok = _crl(server)
+    bad = ("Z" + tok[1:]) if tok[0] != "Z" else ("Y" + tok[1:])
+    assert verify_crl(bad, client, at=_NOW) is None
+
+
+def test_revoked_kid_kills_crl_trust(keys):
+    server, client = keys
+    tok = _crl(server)
+    client.revoke("crl-kid")
+    assert verify_crl(tok, client, at=_NOW) is None
+
+
+def test_unknown_kid_fails_closed(keys):
+    server, _ = keys
+    assert verify_crl(_crl(server), Ed25519KeyManifest(), at=_NOW) is None
+
+
+@pytest.mark.parametrize("bad", ["", "one.two", "a.b.c.d", 123, None])
+def test_malformed_shape_returns_none(bad):
+    assert verify_crl(bad, Ed25519KeyManifest()) is None  # type: ignore[arg-type]
+
+
+def test_empty_kid_returns_none():
+    assert verify_crl("msg..sig", Ed25519KeyManifest()) is None
+
+
+def test_undecodable_returns_none():
+    assert verify_crl("!!!.kid.!!!", Ed25519KeyManifest()) is None
+
+
+def test_wrong_format_returns_none(keys):
+    _, client = keys
+    body = base64.urlsafe_b64encode(json.dumps({"format": "x", "kid": "crl-kid"}).encode()).rstrip(b"=").decode()
+    sig = base64.urlsafe_b64encode(b"x").rstrip(b"=").decode()
+    assert verify_crl(f"{body}.crl-kid.{sig}", client, at=_NOW) is None
+
+
+def test_kid_mismatch_returns_none(keys):
+    server, client = keys
+    msg, kid, sig = _crl(server).split(".")
+    assert verify_crl(f"{msg}.crl-OTHER.{sig}", client, at=_NOW) is None
+
+
+def test_non_int_sequence_returns_none(keys):
+    _, client = keys
+    body = base64.urlsafe_b64encode(
+        json.dumps({"format": CRL_FORMAT_V1, "kid": "crl-kid", "sequence": "nope",
+                    "revoked_license_ids": []}).encode()
+    ).rstrip(b"=").decode()
+    sig = base64.urlsafe_b64encode(b"x").rstrip(b"=").decode()
+    assert verify_crl(f"{body}.crl-kid.{sig}", client, at=_NOW) is None
+
+
+def test_non_list_revoked_ids_returns_none(keys):
+    _, client = keys
+    body = base64.urlsafe_b64encode(
+        json.dumps({"format": CRL_FORMAT_V1, "kid": "crl-kid", "sequence": 1,
+                    "revoked_license_ids": "not-a-list"}).encode()
+    ).rstrip(b"=").decode()
+    sig = base64.urlsafe_b64encode(b"x").rstrip(b"=").decode()
+    assert verify_crl(f"{body}.crl-kid.{sig}", client, at=_NOW) is None
+
+
+def test_non_str_revoked_id_returns_none(keys):
+    _, client = keys
+    body = base64.urlsafe_b64encode(
+        json.dumps({"format": CRL_FORMAT_V1, "kid": "crl-kid", "sequence": 1,
+                    "revoked_license_ids": [1, 2]}).encode()
+    ).rstrip(b"=").decode()
+    sig = base64.urlsafe_b64encode(b"x").rstrip(b"=").decode()
+    assert verify_crl(f"{body}.crl-kid.{sig}", client, at=_NOW) is None
+
+
+# ---- issue failure points -----------------------------------------------------
+
+
+def test_canonical_body_handles_non_list_rids():
+    # Direct unit of the helper: when revoked_license_ids is absent/non-list, the
+    # sort branch is skipped (defensive — verify_crl rejects non-list before this,
+    # but the helper must be total).
+    from graqle.licensing.crl import _canonical_body
+    out = _canonical_body({"format": CRL_FORMAT_V1, "kid": "k", "sequence": 1,
+                           "issued_at": "t", "revoked_license_ids": None})
+    assert b"revoked_license_ids" in out
+
+
+def test_issue_negative_sequence_rejected(keys):
+    server, _ = keys
+    with pytest.raises(CRLError, match="sequence"):
+        _crl(server, sequence=-1)
+
+
+def test_issue_requires_private_key(keys):
+    _, client = keys
+    with pytest.raises(Exception):  # KeyNotSignableError (public-only)
+        _crl(client)

--- a/tests/test_licensing/test_ed25519_license.py
+++ b/tests/test_licensing/test_ed25519_license.py
@@ -1,0 +1,184 @@
+"""Tests for ed25519 licence sign/verify (WS-D D1a) — all failure points.
+
+100% statement + branch coverage of graqle/licensing/ed25519_license.py.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from graqle.governance.custody.ed25519_key_manifest import Ed25519KeyManifest, KeyState
+from graqle.licensing.ed25519_license import (
+    LICENSE_FORMAT_V2,
+    Ed25519LicenseError,
+    issue_ed25519_license,
+    parse_ed25519_license,
+    verify_ed25519_license,
+)
+
+_NOW = datetime(2026, 6, 1, tzinfo=timezone.utc)
+_VF = _NOW - timedelta(days=1)
+_VU = _NOW + timedelta(days=365)
+
+
+@pytest.fixture
+def keys():
+    priv = Ed25519PrivateKey.generate()
+    server = Ed25519KeyManifest()
+    server.register("kid-1", priv.public_key(), _VF, _VU, KeyState.ACTIVE, private_key=priv)
+    client = Ed25519KeyManifest()  # public-only (what ships in the wheel)
+    client.register("kid-1", priv.public_key(), _VF, _VU, KeyState.ACTIVE)
+    return server, client
+
+
+def _issue(server, **over):
+    kw = dict(
+        license_id="L-1", tier="enterprise", holder="Acme", email="a@acme.com",
+        issued_at=_NOW.isoformat(), nonce="N-1",
+        expires_at=(_NOW + timedelta(days=300)).isoformat(), features=["f1"], at=_NOW,
+    )
+    kw.update(over)
+    return issue_ed25519_license(server, "kid-1", **kw)
+
+
+# ---- happy path ---------------------------------------------------------------
+
+
+def test_issue_verify_roundtrip(keys):
+    server, client = keys
+    tok = _issue(server)
+    payload = verify_ed25519_license(tok, client, at=_NOW)
+    assert payload is not None
+    assert payload["tier"] == "enterprise"
+    assert payload["license_id"] == "L-1"
+    assert payload["nonce"] == "N-1"
+    assert payload["kid"] == "kid-1"
+    assert payload["format"] == LICENSE_FORMAT_V2
+    assert payload["features"] == ["f1"]
+
+
+def test_features_sorted_and_default_empty(keys):
+    server, client = keys
+    tok = _issue(server, features=["z", "a"])
+    assert verify_ed25519_license(tok, client, at=_NOW)["features"] == ["a", "z"]
+    tok2 = _issue(server, features=None)
+    assert verify_ed25519_license(tok2, client, at=_NOW)["features"] == []
+
+
+def test_perpetual_license_expires_at_none(keys):
+    server, client = keys
+    tok = _issue(server, expires_at=None)
+    assert verify_ed25519_license(tok, client, at=_NOW)["expires_at"] is None
+
+
+# ---- verify failure points ----------------------------------------------------
+
+
+def test_tampered_payload_rejected(keys):
+    server, client = keys
+    tok = _issue(server)
+    bad = ("X" + tok[1:]) if tok[0] != "X" else ("Y" + tok[1:])
+    assert verify_ed25519_license(bad, client, at=_NOW) is None
+
+
+def test_tampered_signature_rejected(keys):
+    server, client = keys
+    tok = _issue(server)
+    msg, kid, sig = tok.split(".")
+    bad = ".".join((msg, kid, ("A" + sig[1:]) if sig[0] != "A" else ("B" + sig[1:])))
+    assert verify_ed25519_license(bad, client, at=_NOW) is None
+
+
+def test_kid_revocation_invalidates(keys):
+    server, client = keys
+    tok = _issue(server)
+    client.revoke("kid-1")
+    assert verify_ed25519_license(tok, client, at=_NOW) is None
+
+
+def test_unknown_kid_fails_closed(keys):
+    server, _ = keys
+    tok = _issue(server)
+    empty = Ed25519KeyManifest()
+    assert verify_ed25519_license(tok, empty, at=_NOW) is None
+
+
+def test_out_of_window_rejected(keys):
+    server, client = keys
+    tok = _issue(server)
+    # verify far past the key's valid_until window
+    assert verify_ed25519_license(tok, client, at=_VU + timedelta(days=1)) is None
+
+
+def test_verify_defaults_at_to_now(keys):
+    server, client = keys
+    tok = _issue(server)
+    # at=None path: key window is _VF.._VU; real now() is outside (2026-06 fixture
+    # vs system clock) — just assert it does not raise and returns None-or-payload.
+    result = verify_ed25519_license(tok, client)
+    assert result is None or isinstance(result, dict)
+
+
+# ---- parse failure points -----------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", ["", "onlyonepart", "two.parts", "a.b.c.d", 123, None])
+def test_parse_malformed_shape(bad):
+    with pytest.raises(Ed25519LicenseError):
+        parse_ed25519_license(bad)  # type: ignore[arg-type]
+
+
+def test_parse_empty_kid():
+    with pytest.raises(Ed25519LicenseError, match="empty kid"):
+        parse_ed25519_license("YQ.." + "")  # 3 parts but empty kid → actually 2 dots
+
+
+def test_parse_undecodable_base64():
+    with pytest.raises(Ed25519LicenseError, match="undecodable"):
+        parse_ed25519_license("!!!.kid.!!!")
+
+
+def test_parse_non_object_payload():
+    import base64
+    # valid base64 of a JSON array (not an object)
+    arr = base64.urlsafe_b64encode(b"[1,2]").rstrip(b"=").decode()
+    sig = base64.urlsafe_b64encode(b"x").rstrip(b"=").decode()
+    with pytest.raises(Ed25519LicenseError, match="not a JSON object"):
+        parse_ed25519_license(f"{arr}.kid.{sig}")
+
+
+def test_parse_wrong_format():
+    import base64, json
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"format": "something-else", "kid": "kid-1"}).encode()
+    ).rstrip(b"=").decode()
+    sig = base64.urlsafe_b64encode(b"x").rstrip(b"=").decode()
+    with pytest.raises(Ed25519LicenseError, match="not a"):
+        parse_ed25519_license(f"{payload}.kid-1.{sig}")
+
+
+def test_parse_kid_mismatch_is_tamper(keys):
+    server, _ = keys
+    tok = _issue(server)
+    msg, kid, sig = tok.split(".")
+    # swap the token kid to something other than the signed-payload kid
+    with pytest.raises(Ed25519LicenseError, match="kid mismatch"):
+        parse_ed25519_license(f"{msg}.kid-OTHER.{sig}")
+
+
+def test_verify_returns_none_on_parse_error(keys):
+    _, client = keys
+    # verify swallows parse errors → None (fail closed)
+    assert verify_ed25519_license("garbage.token.here", client, at=_NOW) is None
+
+
+# ---- issue failure points -----------------------------------------------------
+
+
+def test_issue_requires_private_key(keys):
+    _, client = keys  # public-only manifest cannot sign
+    with pytest.raises(Exception):  # KeyNotSignableError
+        _issue(client)

--- a/tests/test_licensing/test_keygen.py
+++ b/tests/test_licensing/test_keygen.py
@@ -18,6 +18,21 @@ import pytest
 from graqle.licensing.keygen import generate_license_key, main
 from graqle.licensing.manager import LicenseManager, LicenseTier
 
+_TEST_SECRET = "test-license-secret-keygen"
+
+
+@pytest.fixture(autouse=True)
+def _set_license_secret(monkeypatch):
+    """Configure a real HMAC secret so v1 generate+verify round-trips work.
+
+    WS-D: v1 HMAC verification now REQUIRES GRAQLE_LICENSE_KEY_SECRET to be set
+    (the dev fallback is public and refused). These keygen tests exercise the v1
+    generate→verify path, so they must run with a real (test) secret — exactly
+    as production issuance does.
+    """
+    monkeypatch.setenv("GRAQLE_LICENSE_KEY_SECRET", _TEST_SECRET)
+
+
 # ---------------------------------------------------------------------------
 # generate_license_key
 # ---------------------------------------------------------------------------

--- a/tests/test_licensing/test_manager.py
+++ b/tests/test_licensing/test_manager.py
@@ -348,12 +348,33 @@ class TestLicenseManagerLoading:
         mgr = _make_manager_safe(COGNIGRAPH_LICENSE_KEY="invalid.key")
         assert mgr.current_tier == LicenseTier.FREE
 
-    def test_expired_key_falls_to_free(self):
+    def test_expired_within_grace_keeps_tier(self):
+        # WS-D D1b: a licence expired 1 day ago is within the 60-day offline grace
+        # window, so it RETAINS its tier (the grace allowance — supersedes the
+        # pre-WS-D "expired => free" behaviour).
         expired = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
         key = _generate_key("pro", expires_at=expired)
         mgr = _make_manager_safe(COGNIGRAPH_LICENSE_KEY=key)
-        # Key verified but expired => current_tier returns FREE
+        assert mgr.current_tier == LicenseTier.PRO
+
+    def test_expired_past_grace_falls_to_free(self):
+        # Past the grace window (>60 days expired) => FREE.
+        expired = (datetime.now(timezone.utc) - timedelta(days=90)).isoformat()
+        key = _generate_key("pro", expires_at=expired)
+        mgr = _make_manager_safe(COGNIGRAPH_LICENSE_KEY=key)
         assert mgr.current_tier == LicenseTier.FREE
+
+    def test_expired_within_grace_falls_to_free_with_zero_grace(self):
+        # With grace disabled (0 days), expiry is strict again => FREE.
+        import os
+        expired = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        key = _generate_key("pro", expires_at=expired)
+        os.environ["GRAQLE_LICENSE_GRACE_DAYS"] = "0"
+        try:
+            mgr = _make_manager_safe(COGNIGRAPH_LICENSE_KEY=key)
+            assert mgr.current_tier == LicenseTier.FREE
+        finally:
+            os.environ.pop("GRAQLE_LICENSE_GRACE_DAYS", None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_licensing/test_manager_wsd.py
+++ b/tests/test_licensing/test_manager_wsd.py
@@ -1,0 +1,235 @@
+"""Tests for the WS-D LicenseManager hardening delta — all gate + loader paths.
+
+Covers: dual-verify (v2 ed25519 + v1 HMAC fallback), the grace window,
+CRL-revocation gate, nonce-replay gate, and every loader (trusted manifest,
+CRL, nonce store) incl. their fail-closed branches.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+import graqle.licensing.manager as M
+from graqle.governance.custody.ed25519_key_manifest import Ed25519KeyManifest, KeyState
+from graqle.licensing.crl import issue_crl
+from graqle.licensing.ed25519_license import issue_ed25519_license
+from graqle.licensing.manager import License, LicenseTier
+
+_NOW = datetime.now(timezone.utc)
+_VF, _VU = _NOW - timedelta(days=1), _NOW + timedelta(days=3650)
+
+
+@pytest.fixture
+def server_kid():
+    priv = Ed25519PrivateKey.generate()
+    server = Ed25519KeyManifest()
+    server.register("k1", priv.public_key(), _VF, _VU, KeyState.ACTIVE, private_key=priv)
+    pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
+    ).decode()
+    return server, pem
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches(monkeypatch):
+    for n in ("_trusted_manifest_loaded", "_active_crl_loaded", "_nonce_store_loaded"):
+        monkeypatch.setattr(M, n, False, raising=False)
+    monkeypatch.setattr(M, "_trusted_license_manifest", None, raising=False)
+    monkeypatch.setattr(M, "_active_crl", None, raising=False)
+    monkeypatch.setattr(M, "_nonce_store", None, raising=False)
+    for v in ("GRAQLE_LICENSE_PUBLIC_KEYS", "GRAQLE_LICENSE_CRL", "GRAQLE_LICENSE_NONCE_DIR",
+              "COGNIGRAPH_LICENSE_KEY", "GRAQLE_LICENSE_GRACE_DAYS"):
+        monkeypatch.delenv(v, raising=False)
+    yield
+
+
+def _trust(monkeypatch, pem):
+    monkeypatch.setenv("GRAQLE_LICENSE_PUBLIC_KEYS", json.dumps(
+        [{"kid": "k1", "public_key_pem": pem, "valid_from": _VF.isoformat(),
+          "valid_until": _VU.isoformat(), "state": "active"}]))
+    M._trusted_manifest_loaded = False
+
+
+def _v2(server, **over):
+    kw = dict(license_id="L-1", tier="enterprise", holder="A", email="a@a",
+              issued_at=_NOW.isoformat(), nonce="N-1",
+              expires_at=(_NOW + timedelta(days=300)).isoformat(), at=_NOW)
+    kw.update(over)
+    return issue_ed25519_license(server, "k1", **kw)
+
+
+def _load(monkeypatch, token):
+    monkeypatch.setenv("COGNIGRAPH_LICENSE_KEY", token)
+    for n in ("_trusted_manifest_loaded", "_active_crl_loaded", "_nonce_store_loaded"):
+        setattr(M, n, False)
+    return M.LicenseManager().current_tier.value
+
+
+# ---- dual-verify --------------------------------------------------------------
+
+
+def test_v2_ed25519_load(monkeypatch, server_kid):
+    server, pem = server_kid
+    _trust(monkeypatch, pem)
+    assert _load(monkeypatch, _v2(server)) == "enterprise"
+
+
+def test_v1_hmac_backcompat(monkeypatch):
+    # v1 HMAC verifies ONLY when a real secret is configured (server-side / issuer).
+    monkeypatch.setenv("GRAQLE_LICENSE_KEY_SECRET", "real-production-secret")
+    v1 = M.LicenseManager.generate_key("pro", "B", "b@b", None)
+    assert _load(monkeypatch, v1) == "pro"
+
+
+def test_v1_downgrade_attack_blocked_without_secret(monkeypatch):
+    # SECURITY (sentinel graq_predict vector #4): an attacker with only the public
+    # Community wheel knows the dev-fallback HMAC secret. They forge a v1 ENTERPRISE
+    # key with it. With NO GRAQLE_LICENSE_KEY_SECRET configured, HMAC verification
+    # is REFUSED → the downgrade-forgery is blocked → free tier.
+    monkeypatch.setenv("GRAQLE_LICENSE_KEY_SECRET", "real-production-secret")
+    forged = M.LicenseManager.generate_key("enterprise", "Attacker", "x@x", None)
+    monkeypatch.delenv("GRAQLE_LICENSE_KEY_SECRET", raising=False)  # public wheel: no secret
+    # the forged key (signed with whatever secret) must NOT verify when no secret set
+    assert _load(monkeypatch, forged) == "free"
+
+
+def test_v1_hmac_rejects_non_string_key(monkeypatch):
+    # explicit type guard: a None/non-str key fails closed (no crash)
+    monkeypatch.setenv("GRAQLE_LICENSE_KEY_SECRET", "s1")
+    mgr = M.LicenseManager.__new__(M.LicenseManager)
+    assert mgr._verify_key_hmac(None) is None  # type: ignore[arg-type]
+    assert mgr._verify_key_hmac(123) is None  # type: ignore[arg-type]
+    assert mgr._verify_key_hmac("") is None
+
+
+def test_v1_hmac_refused_when_no_secret(monkeypatch):
+    # Even a legitimately-generated v1 key won't verify with no secret configured
+    # (the dev fallback is public and refused) — fail closed.
+    monkeypatch.setenv("GRAQLE_LICENSE_KEY_SECRET", "s1")
+    v1 = M.LicenseManager.generate_key("team", "B", "b@b", None)
+    monkeypatch.delenv("GRAQLE_LICENSE_KEY_SECRET", raising=False)
+    mgr = M.LicenseManager.__new__(M.LicenseManager)
+    assert mgr._verify_key_hmac(v1) is None
+
+
+def test_v2_without_trusted_manifest_falls_back_to_free(monkeypatch, server_kid):
+    server, _ = server_kid
+    # no GRAQLE_LICENSE_PUBLIC_KEYS => ed25519 path returns None => HMAC fails => free
+    assert _load(monkeypatch, _v2(server)) == "free"
+
+
+def test_garbage_key_free(monkeypatch):
+    assert _load(monkeypatch, "not-a-valid-key") == "free"
+
+
+# ---- grace gate ---------------------------------------------------------------
+
+
+def test_expired_in_grace_still_valid(monkeypatch, server_kid):
+    server, pem = server_kid
+    _trust(monkeypatch, pem)
+    tok = _v2(server, tier="team", expires_at=(_NOW - timedelta(days=10)).isoformat())
+    assert _load(monkeypatch, tok) == "team"
+
+
+def test_expired_past_grace_free(monkeypatch, server_kid):
+    server, pem = server_kid
+    _trust(monkeypatch, pem)
+    tok = _v2(server, tier="team", expires_at=(_NOW - timedelta(days=90)).isoformat())
+    assert _load(monkeypatch, tok) == "free"
+
+
+# ---- CRL gate -----------------------------------------------------------------
+
+
+def test_crl_revokes_license(monkeypatch, server_kid):
+    server, pem = server_kid
+    _trust(monkeypatch, pem)
+    monkeypatch.setenv("GRAQLE_LICENSE_CRL",
+                       issue_crl(server, "k1", issued_at=_NOW.isoformat(), sequence=1,
+                                 revoked_license_ids=["L-1"], at=_NOW))
+    assert _load(monkeypatch, _v2(server)) == "free"
+
+
+def test_crl_does_not_revoke_other(monkeypatch, server_kid):
+    server, pem = server_kid
+    _trust(monkeypatch, pem)
+    monkeypatch.setenv("GRAQLE_LICENSE_CRL",
+                       issue_crl(server, "k1", issued_at=_NOW.isoformat(), sequence=1,
+                                 revoked_license_ids=["L-OTHER"], at=_NOW))
+    assert _load(monkeypatch, _v2(server)) == "enterprise"
+
+
+def test_crl_ignored_without_manifest(monkeypatch, server_kid):
+    server, _ = server_kid
+    # CRL configured but no trusted manifest => CRL ignored (can't trust it)
+    monkeypatch.setenv("GRAQLE_LICENSE_CRL",
+                       issue_crl(server, "k1", issued_at=_NOW.isoformat(), sequence=1,
+                                 revoked_license_ids=["L-1"], at=_NOW))
+    assert M._get_active_crl() is None
+
+
+# ---- nonce gate ---------------------------------------------------------------
+
+
+def test_nonce_replay_blocked(monkeypatch, server_kid, tmp_path):
+    server, pem = server_kid
+    _trust(monkeypatch, pem)
+    monkeypatch.setenv("GRAQLE_LICENSE_NONCE_DIR", str(tmp_path))
+    tok = _v2(server)
+    assert _load(monkeypatch, tok) == "enterprise"   # first accept
+    assert _load(monkeypatch, tok) == "free"          # replay → free
+
+
+def test_nonce_store_off_by_default(monkeypatch):
+    assert M._get_nonce_store() is None
+
+
+def test_nonce_store_init_failure_disables(monkeypatch):
+    monkeypatch.setenv("GRAQLE_LICENSE_NONCE_DIR", "\x00illegal")  # invalid path
+    M._nonce_store_loaded = False
+    # init failure must not raise; store disabled
+    assert M._get_nonce_store() is None
+
+
+# ---- loaders: fail-closed branches -------------------------------------------
+
+
+def test_trusted_manifest_malformed_disables(monkeypatch):
+    monkeypatch.setenv("GRAQLE_LICENSE_PUBLIC_KEYS", "{ not json")
+    M._trusted_manifest_loaded = False
+    assert M._get_trusted_license_manifest() is None
+
+
+def test_trusted_manifest_none_when_unset(monkeypatch):
+    M._trusted_manifest_loaded = False
+    assert M._get_trusted_license_manifest() is None
+
+
+def test_grace_delta_default_and_override(monkeypatch):
+    from graqle.licensing.manager import _grace_delta
+    assert _grace_delta() == timedelta(days=60)
+    monkeypatch.setenv("GRAQLE_LICENSE_GRACE_DAYS", "30")
+    assert _grace_delta() == timedelta(days=30)
+    monkeypatch.setenv("GRAQLE_LICENSE_GRACE_DAYS", "-5")  # negative => default
+    assert _grace_delta() == timedelta(days=60)
+    monkeypatch.setenv("GRAQLE_LICENSE_GRACE_DAYS", "abc")  # malformed => default
+    assert _grace_delta() == timedelta(days=60)
+
+
+def test_accept_license_none_passthrough():
+    mgr = M.LicenseManager.__new__(M.LicenseManager)
+    assert mgr._accept_license(None) is None
+
+
+def test_candidate_keys_skips_unreadable(monkeypatch, tmp_path):
+    # exercise the OSError-skip branch in _candidate_keys
+    from pathlib import Path as _P
+    monkeypatch.setattr(_P, "exists", lambda self: (_ for _ in ()).throw(OSError("no")))
+    assert isinstance(M.LicenseManager._candidate_keys(), list)

--- a/tests/test_licensing/test_manager_wsd.py
+++ b/tests/test_licensing/test_manager_wsd.py
@@ -191,10 +191,20 @@ def test_nonce_store_off_by_default(monkeypatch):
     assert M._get_nonce_store() is None
 
 
-def test_nonce_store_init_failure_disables(monkeypatch):
-    monkeypatch.setenv("GRAQLE_LICENSE_NONCE_DIR", "\x00illegal")  # invalid path
+def test_nonce_store_init_failure_disables(monkeypatch, tmp_path):
+    # If LicenseNonceStore construction raises for any reason, replay protection
+    # is disabled (None) without propagating — must never block licence load.
+    # Inject the failure portably by patching the constructor: a null-byte env
+    # value is rejected by os.environ on Linux BEFORE our code runs (AUD-010
+    # class: Windows-local-green != Linux-CI), so we patch the class instead.
+    monkeypatch.setenv("GRAQLE_LICENSE_NONCE_DIR", str(tmp_path))
+    import graqle.licensing.nonce_store as ns_mod
+
+    def boom(self, directory):
+        raise OSError("simulated nonce-store init failure")
+
+    monkeypatch.setattr(ns_mod.LicenseNonceStore, "__init__", boom)
     M._nonce_store_loaded = False
-    # init failure must not raise; store disabled
     assert M._get_nonce_store() is None
 
 

--- a/tests/test_licensing/test_nonce_store.py
+++ b/tests/test_licensing/test_nonce_store.py
@@ -1,0 +1,278 @@
+"""Tests for the licence nonce replay store (WS-D D1c) — all failure points.
+
+100% statement + branch coverage of graqle/licensing/nonce_store.py, with
+fault-injection for the WAL write/recovery defensive paths.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from graqle.licensing import nonce_store as ns_mod
+from graqle.licensing.nonce_store import (
+    _ENTRY_SUFFIX,
+    LicenseNonceStore,
+    NonceStoreError,
+    _is_valid_stem,
+    _safe_dir_fsync,
+    _stem_for,
+)
+
+
+# ---- accept-once core ---------------------------------------------------------
+
+
+def test_accept_once_then_replay(tmp_path):
+    s = LicenseNonceStore(tmp_path)
+    assert s.accept_once("nonce-A") is True
+    assert s.accept_once("nonce-A") is False
+    assert s.accept_once("nonce-A") is False
+    assert s.has_seen("nonce-A")
+    assert s.count == 1
+
+
+def test_distinct_nonces(tmp_path):
+    s = LicenseNonceStore(tmp_path)
+    assert s.accept_once("a") and s.accept_once("b")
+    assert s.count == 2
+
+
+def test_has_seen_read_only(tmp_path):
+    s = LicenseNonceStore(tmp_path)
+    assert s.has_seen("x") is False
+    assert s.count == 0
+
+
+@pytest.mark.parametrize("bad", ["", None, 123])
+def test_accept_once_rejects_bad(tmp_path, bad):
+    s = LicenseNonceStore(tmp_path)
+    with pytest.raises(NonceStoreError):
+        s.accept_once(bad)  # type: ignore[arg-type]
+
+
+def test_accept_once_rejects_overlong(tmp_path):
+    s = LicenseNonceStore(tmp_path)
+    with pytest.raises(NonceStoreError, match="exceeds"):
+        s.accept_once("x" * (ns_mod._MAX_NONCE_LEN + 1))
+
+
+def test_has_seen_handles_bad_input(tmp_path):
+    s = LicenseNonceStore(tmp_path)
+    assert s.has_seen("") is False
+    assert s.has_seen(None) is False  # type: ignore[arg-type]
+    assert s.has_seen("y" * (ns_mod._MAX_NONCE_LEN + 1)) is False
+
+
+# ---- durability + recovery ----------------------------------------------------
+
+
+def test_recovery_across_restart(tmp_path):
+    LicenseNonceStore(tmp_path).accept_once("keep-me")
+    s2 = LicenseNonceStore(tmp_path)
+    assert s2.has_seen("keep-me")
+    assert s2.accept_once("keep-me") is False
+
+
+def test_entry_written_with_digest(tmp_path):
+    s = LicenseNonceStore(tmp_path)
+    s.accept_once("n1")
+    stem = _stem_for("n1")
+    entry = tmp_path / f"{stem}{_ENTRY_SUFFIX}"
+    data = json.loads(entry.read_text())
+    assert data["nonce"] == "n1" and data["stem"] == stem
+
+
+def test_write_idempotent_on_disk(tmp_path):
+    s = LicenseNonceStore(tmp_path)
+    s.accept_once("n1")
+    s._write_entry(_stem_for("n1"), "n1")  # early-return path (exists)
+    assert (tmp_path / f"{_stem_for('n1')}{_ENTRY_SUFFIX}").exists()
+
+
+def test_entry_path_rejects_bad_stem(tmp_path):
+    s = LicenseNonceStore(tmp_path)
+    with pytest.raises(NonceStoreError):
+        s._entry_path("../escape")
+
+
+# ---- corruption-skip recovery -------------------------------------------------
+
+
+def _good_entry(tmp_path, nonce):
+    stem = _stem_for(nonce)
+    (tmp_path / f"{stem}{_ENTRY_SUFFIX}").write_text(
+        json.dumps({"stem": stem, "nonce": nonce,
+                    "digest": hashlib.sha256((stem + ":" + nonce).encode()).hexdigest()})
+    )
+    return stem
+
+
+def test_recovery_skips_corrupt_json(tmp_path):
+    (tmp_path / f"{_stem_for('a')}{_ENTRY_SUFFIX}").write_text("{ bad")
+    assert LicenseNonceStore(tmp_path).count == 0
+
+
+def test_recovery_skips_non_dict(tmp_path):
+    (tmp_path / f"{_stem_for('a')}{_ENTRY_SUFFIX}").write_text("[1]")
+    assert LicenseNonceStore(tmp_path).count == 0
+
+
+def test_recovery_skips_missing_fields(tmp_path):
+    (tmp_path / f"{_stem_for('a')}{_ENTRY_SUFFIX}").write_text(json.dumps({"stem": _stem_for("a")}))
+    assert LicenseNonceStore(tmp_path).count == 0
+
+
+def test_recovery_skips_invalid_stem(tmp_path):
+    (tmp_path / f"{_stem_for('a')}{_ENTRY_SUFFIX}").write_text(
+        json.dumps({"stem": "short", "nonce": "a", "digest": "x"}))
+    assert LicenseNonceStore(tmp_path).count == 0
+
+
+def test_recovery_skips_filename_mismatch(tmp_path):
+    # filename stem for 'a' but body stem for 'b'
+    other = _stem_for("b")
+    (tmp_path / f"{_stem_for('a')}{_ENTRY_SUFFIX}").write_text(
+        json.dumps({"stem": other, "nonce": "b",
+                    "digest": hashlib.sha256((other + ":b").encode()).hexdigest()}))
+    assert LicenseNonceStore(tmp_path).count == 0
+
+
+def test_recovery_skips_stem_not_hash_of_nonce(tmp_path):
+    stem = _stem_for("a")
+    # stem matches filename but nonce doesn't hash to it
+    (tmp_path / f"{stem}{_ENTRY_SUFFIX}").write_text(
+        json.dumps({"stem": stem, "nonce": "DIFFERENT",
+                    "digest": hashlib.sha256((stem + ":DIFFERENT").encode()).hexdigest()}))
+    assert LicenseNonceStore(tmp_path).count == 0
+
+
+def test_recovery_skips_digest_mismatch(tmp_path):
+    stem = _stem_for("a")
+    (tmp_path / f"{stem}{_ENTRY_SUFFIX}").write_text(
+        json.dumps({"stem": stem, "nonce": "a", "digest": "deadbeef"}))
+    assert LicenseNonceStore(tmp_path).count == 0
+
+
+def test_recovery_skips_oversized(tmp_path, monkeypatch):
+    _good_entry(tmp_path, "a")
+    monkeypatch.setattr(ns_mod, "_MAX_ENTRY_BYTES", 1)
+    assert LicenseNonceStore(tmp_path).count == 0
+
+
+def test_recovery_one_bad_keeps_good(tmp_path):
+    _good_entry(tmp_path, "good")
+    (tmp_path / f"{_stem_for('bad')}{_ENTRY_SUFFIX}").write_text("corrupt")
+    s = LicenseNonceStore(tmp_path)
+    assert s.count == 1 and s.has_seen("good")
+
+
+def test_recovery_unreadable_dir(tmp_path, monkeypatch):
+    s = LicenseNonceStore(tmp_path)
+    monkeypatch.setattr(Path, "iterdir", lambda self: (_ for _ in ()).throw(OSError("no perms")))
+    s._recover()  # must not raise
+    assert s.count == 0
+
+
+def test_recovery_ignores_non_entry_files(tmp_path):
+    (tmp_path / "README.txt").write_text("x")
+    (tmp_path / "sub").mkdir()
+    s = LicenseNonceStore(tmp_path)
+    s.accept_once("a")
+    assert s.count == 1
+
+
+# ---- write-path fault injection ----------------------------------------------
+
+
+def test_write_zero_length_raises(tmp_path, monkeypatch):
+    s = LicenseNonceStore(tmp_path)
+    stem = _stem_for("z")
+    final_str = str(s._entry_path(stem))
+    real = Path.stat
+
+    def fake(self, *a, **k):
+        st = real(self, *a, **k)
+        if str(self) == final_str and st.st_size > 0:
+            class _Z:
+                st_size = 0
+            return _Z()
+        return st
+
+    monkeypatch.setattr(Path, "stat", fake)
+    with pytest.raises(NonceStoreError, match="zero-length"):
+        s._write_entry(stem, "z")
+
+
+def test_write_stat_oserror_raises(tmp_path, monkeypatch):
+    s = LicenseNonceStore(tmp_path)
+    stem = _stem_for("z")
+    final_str = str(s._entry_path(stem))
+    real = Path.stat
+
+    def fake(self, *a, **k):
+        st = real(self, *a, **k)
+        if str(self) == final_str and st.st_size > 0:
+            raise OSError("stat failed")
+        return st
+
+    monkeypatch.setattr(Path, "stat", fake)
+    with pytest.raises(NonceStoreError, match="could not be stat'd"):
+        s._write_entry(stem, "z")
+
+
+def test_write_cleans_tmp_on_replace_failure(tmp_path, monkeypatch):
+    s = LicenseNonceStore(tmp_path)
+    monkeypatch.setattr(ns_mod.os, "replace", lambda a, b: (_ for _ in ()).throw(OSError("nope")))
+    with pytest.raises(OSError):
+        s._write_entry(_stem_for("z"), "z")
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_write_unlink_failure_swallowed(tmp_path, monkeypatch):
+    s = LicenseNonceStore(tmp_path)
+    monkeypatch.setattr(ns_mod.os, "replace", lambda a, b: (_ for _ in ()).throw(OSError("nope")))
+    monkeypatch.setattr(ns_mod.os, "unlink", lambda p: (_ for _ in ()).throw(OSError("unlink")))
+    with pytest.raises(OSError, match="nope"):
+        s._write_entry(_stem_for("z"), "z")
+
+
+# ---- helpers + _safe_dir_fsync branches ---------------------------------------
+
+
+def test_is_valid_stem():
+    assert _is_valid_stem(_stem_for("x"))
+    assert not _is_valid_stem("short")
+    assert not _is_valid_stem("g" * 64)  # non-hex
+
+
+def test_safe_dir_fsync_non_posix(tmp_path, monkeypatch):
+    monkeypatch.setattr(ns_mod.os, "name", "nt")
+    _safe_dir_fsync(tmp_path)
+
+
+def test_safe_dir_fsync_posix_success(tmp_path, monkeypatch):
+    monkeypatch.setattr(ns_mod.os, "name", "posix")
+    calls = {"f": 0, "c": 0}
+    monkeypatch.setattr(ns_mod.os, "open", lambda p, f: 7)
+    monkeypatch.setattr(ns_mod.os, "fsync", lambda fd: calls.__setitem__("f", 1))
+    monkeypatch.setattr(ns_mod.os, "close", lambda fd: calls.__setitem__("c", 1))
+    _safe_dir_fsync(tmp_path)
+    assert calls == {"f": 1, "c": 1}
+
+
+def test_safe_dir_fsync_posix_open_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(ns_mod.os, "name", "posix")
+    monkeypatch.setattr(ns_mod.os, "open", lambda p, f: (_ for _ in ()).throw(OSError("no")))
+    _safe_dir_fsync(tmp_path)  # swallowed
+
+
+def test_safe_dir_fsync_posix_close_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(ns_mod.os, "name", "posix")
+    monkeypatch.setattr(ns_mod.os, "open", lambda p, f: 7)
+    monkeypatch.setattr(ns_mod.os, "fsync", lambda fd: None)
+    monkeypatch.setattr(ns_mod.os, "close", lambda fd: (_ for _ in ()).throw(OSError("close")))
+    _safe_dir_fsync(tmp_path)  # swallowed in finally

--- a/tests/test_packaging/test_community_never_gated.py
+++ b/tests/test_packaging/test_community_never_gated.py
@@ -1,0 +1,114 @@
+"""Guardrail: Community-core surfaces must NEVER be entitlement-gated (WS-D D2).
+
+The free core stays unconditionally available. This AST gate fails the build if
+``@requires_edition`` / ``@requires_feature`` (the WS-D D2 entitlement gates) or
+the legacy ``@require_license`` decorator is applied to a function/method in a
+Community-CORE module. Proprietary surfaces (excluded from the Community wheel)
+and the licensing/entitlement machinery itself are exempt.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_GATING_DECORATORS = {"requires_edition", "requires_feature", "require_license"}
+
+# Community CORE that must remain free + ungated. Conservative allowlist of the
+# subtrees the open-core promise protects (ADR-BIZ-001 §3.3).
+_CORE_PREFIXES = (
+    "core",
+    "reasoning",
+    "governance/tamper_evidence",
+    "governance/runtime",
+    "verify",
+    "metering",
+    "edition.py",
+)
+
+# Exempt: the proprietary backends (not in the Community wheel) + the
+# licensing/entitlement machinery (which legitimately references the decorators).
+_EXEMPT_PREFIXES = ("cloud", "leads", "studio", "server", "licensing", "entitlement.py")
+
+
+def _graqle_root() -> Path:
+    return Path(__file__).resolve().parents[2] / "graqle"
+
+
+def _is_core(rel: str) -> bool:
+    rel = rel.replace("\\", "/")
+    if any(rel == e or rel.startswith(e + "/") or rel.startswith(e) for e in _EXEMPT_PREFIXES):
+        return False
+    return any(rel == p or rel.startswith(p + "/") or rel.startswith(p) for p in _CORE_PREFIXES)
+
+
+def _decorator_name(node: ast.expr) -> str | None:
+    """Extract the decorator's callable name (handles @x, @x(...), @mod.x, @mod.x(...))."""
+    if isinstance(node, ast.Call):
+        node = node.func
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _gated_defs(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), str(path))
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for dec in node.decorator_list:
+                name = _decorator_name(dec)
+                if name in _GATING_DECORATORS:
+                    offenders.append(f"{node.name} (@{name})")
+    return offenders
+
+
+def test_no_community_core_surface_is_entitlement_gated():
+    root = _graqle_root()
+    violations: dict[str, list[str]] = {}
+    for path in root.rglob("*.py"):
+        rel = str(path.relative_to(root))
+        if not _is_core(rel):
+            continue
+        gated = _gated_defs(path)
+        if gated:
+            violations[rel] = gated
+    assert not violations, (
+        "WS-D guardrail violation: Community-core surfaces must NEVER be gated. "
+        "Remove the entitlement decorator (the free core is unconditional):\n"
+        + "\n".join(f"  {m}: {d}" for m, d in violations.items())
+    )
+
+
+# ---- meta-tests: the gate actually fires / classifies correctly --------------
+
+
+def test_gate_detects_planted_gated_core(tmp_path):
+    f = tmp_path / "planted.py"
+    f.write_text("@requires_edition(Edition.STUDIO)\ndef core_thing():\n    pass\n", encoding="utf-8")
+    assert _gated_defs(f) == ["core_thing (@requires_edition)"]
+
+
+def test_gate_handles_plain_and_attribute_decorators(tmp_path):
+    f = tmp_path / "p.py"
+    f.write_text(
+        "@require_license\ndef a():\n    pass\n"
+        "@mod.requires_feature('x')\ndef b():\n    pass\n",
+        encoding="utf-8",
+    )
+    names = _gated_defs(f)
+    assert "a (@require_license)" in names and "b (@requires_feature)" in names
+
+
+def test_core_classification():
+    assert _is_core("core/graph.py")
+    assert _is_core("metering/events.py")
+    assert _is_core("edition.py")
+    assert not _is_core("licensing/manager.py")   # exempt (machinery)
+    assert not _is_core("entitlement.py")          # exempt (defines the gates)
+    assert not _is_core("studio/app.py")           # proprietary
+    assert not _is_core("cli/commands/cloud.py")   # not core (proprietary surface)

--- a/tests/test_server/test_stripe_webhook.py
+++ b/tests/test_server/test_stripe_webhook.py
@@ -67,7 +67,11 @@ class TestStripeSignatureVerification:
 class TestLicenseGeneration:
     """Tests for license key generation from Stripe checkout."""
 
-    def test_generate_from_checkout_session(self) -> None:
+    def test_generate_from_checkout_session(self, monkeypatch) -> None:
+        # WS-D: v1 HMAC verify now requires a real secret (the public dev fallback
+        # is refused). The Stripe issuer signs with the production secret, so this
+        # generate→verify round-trip runs with a real (test) secret configured.
+        monkeypatch.setenv("GRAQLE_LICENSE_KEY_SECRET", "test-stripe-secret")
         from graqle.server.stripe_webhook import generate_license_from_checkout
 
         session = {


### PR DESCRIPTION
## v0.68.0 — Ed25519 licence hardening + edition gating

Public release of WS-D (private #170). The licence layer moves to **ed25519** (asymmetric): the Community wheel verifies with a **public key it cannot forge with**; the private signer stays server-side. Adds offline grace, revocation, replay protection, and edition/feature gating. Existing HMAC licences keep working during a deprecation window (**ADR-215**).

### Added
- `graqle.licensing.ed25519_license` — ed25519 licences with a `kid` (revoked kid invalidates all it signed); default verify path.
- `graqle.licensing.crl` — ed25519-signed revocation list (per-licence) with monotonic-sequence rollback defence.
- `graqle.licensing.nonce_store` — durable accept-once replay protection.
- `graqle.entitlement` — `@requires_edition` / `@requires_feature`; the free core is never gated.
- 60-day offline grace (`GRAQLE_LICENSE_GRACE_DAYS`).

### Changed / Security
- Dual-format verify: ed25519 (v2) preferred, legacy HMAC (v1) accepted during a back-compat window. **v1 verify now requires a configured `GRAQLE_LICENSE_KEY_SECRET`** — the public dev fallback no longer grants trust (closes a forgery vector). The wheel ships verification keys only; `keygen.py` (the signer) is excluded.

### Pre-deployment patent-leak scan (built public wheel) — PASS
0 proprietary files · keygen excluded · 0 trade-secret literals · **no ed25519 private-key material** · version 0.68.0.

### Tests
206 WS-D tests, 100% stmt+branch on the new modules; 0% regression. End-to-end Phase-7 sentinel (a v1-downgrade forgery BLOCKER was caught + fixed + test-proven).

🤖 Generated with [Claude Code](https://claude.com/claude-code)