### PR TITLE
feat(licensing): ed25519 v2 Stripe issuance [v0.69.0]

### DIFF
--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.68.1"
+__version__ = "0.69.0"

--- a/graqle/server/stripe_webhook.py
+++ b/graqle/server/stripe_webhook.py
@@ -111,8 +111,123 @@ def verify_stripe_signature(payload: bytes, signature: str, secret: str) -> bool
         return False
 
 
+# ── ed25519 issuance (ADR-215 §5 cutover) ──────────────────────────────────
+# The licence-issuing key is a DEDICATED ed25519 key (separate from the
+# proof-bundle / Rekor keys), held server-side in AWS Secrets Manager. The
+# Community wheel verifies with the PUBLIC key only and cannot forge (asymmetric);
+# this issuer is in graqle/server/* which is excluded from the public wheel.
+#
+# Env:
+#   GRAQLE_LICENSE_ISSUING_SECRET_ID — Secrets Manager id of the ed25519 seed
+#     (64-char hex SecretString, or 32 raw SecretBinary bytes).
+#   GRAQLE_LICENSE_ISSUING_KID — the signing kid (published to the trust source).
+#   AWS_REGION / GRAQLE_LICENSE_ISSUING_REGION — region (default eu-central-1).
+# The issuing key is fetched from Secrets Manager once and cached for the life of
+# a warm Lambda container, then reused. This is the standard AWS Lambda pattern
+# (the SDK's own anchor signer caches the same way): the private key has to be in
+# this process's memory to sign at all, so per-request re-fetch would add latency
+# + Secrets Manager API cost without reducing the in-memory exposure (the key is
+# in memory during every signing regardless). Rotation is handled by Secrets
+# Manager versioning + a new key picked up on the next cold start. The key never
+# leaves this process — never logged, never serialised, never in the response.
+_ISSUING_MANIFEST: Any = None  # cached across warm Lambda invocations
+_ISSUING_KID: str | None = None
+
+# A licence-issuing key is trusted across a wide window at sign time; the licence
+# carries its own issued_at/expires_at as the real lifecycle. We register the kid
+# ACTIVE over a wide window so signing never trips the manifest's own window
+# guard; revocation lives in the published trust source + the CRL.
+_WIDE_FROM = datetime(1970, 1, 1, tzinfo=timezone.utc)
+_WIDE_UNTIL = datetime(9999, 12, 31, tzinfo=timezone.utc)
+
+
+class IssuanceError(Exception):
+    """Raised when a licence cannot be issued (config / key / signing failure)."""
+
+
+def _seed_bytes_from_secret(resp: dict[str, Any]) -> bytes:
+    """Extract a 32-byte ed25519 seed from a Secrets Manager response.
+
+    Accepts ``SecretBinary`` (raw 32 bytes) or ``SecretString`` (64-char hex).
+    """
+    binary = resp.get("SecretBinary")
+    if binary:
+        return bytes(binary)
+    text = resp.get("SecretString")
+    if isinstance(text, str) and text.strip():
+        try:
+            return bytes.fromhex(text.strip())
+        except ValueError as exc:
+            raise IssuanceError("SecretString must be a 64-char hex ed25519 seed") from exc
+    raise IssuanceError("issuing secret has neither SecretBinary nor SecretString")
+
+
+def _get_issuing_manifest() -> tuple[Any, str]:
+    """Build (and cache) the Ed25519KeyManifest holding the licence private key.
+
+    Returns ``(manifest, kid)``. Raises :class:`IssuanceError` if the issuing
+    env/secret is not configured (issuance fails loudly rather than silently
+    falling back to an unforgeable-but-wrong key).
+    """
+    global _ISSUING_MANIFEST, _ISSUING_KID
+    if _ISSUING_MANIFEST is not None and _ISSUING_KID is not None:
+        return _ISSUING_MANIFEST, _ISSUING_KID
+
+    secret_id = os.environ.get("GRAQLE_LICENSE_ISSUING_SECRET_ID")
+    kid = os.environ.get("GRAQLE_LICENSE_ISSUING_KID")
+    if not secret_id or not kid:
+        raise IssuanceError(
+            "ed25519 licence issuance requires GRAQLE_LICENSE_ISSUING_SECRET_ID "
+            "and GRAQLE_LICENSE_ISSUING_KID"
+        )
+    region = (
+        os.environ.get("GRAQLE_LICENSE_ISSUING_REGION")
+        or os.environ.get("AWS_REGION")
+        or "eu-central-1"
+    )
+
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    from graqle.governance.custody.ed25519_key_manifest import Ed25519KeyManifest
+
+    import boto3
+
+    client = boto3.client("secretsmanager", region_name=region)
+    try:
+        resp = client.get_secret_value(SecretId=secret_id)
+    except Exception as exc:
+        # Log the detail server-side (CloudWatch) but raise a GENERIC message —
+        # the underlying boto3 error can embed the secret ARN / AWS internals,
+        # which must not leak into a caller-visible exception (A09).
+        logger.error("licence issuing key fetch failed: %s", exc)
+        raise IssuanceError("could not fetch the licence issuing key") from None
+    seed = _seed_bytes_from_secret(resp)
+    if len(seed) != 32:
+        raise IssuanceError("licence issuing seed must be 32 ed25519 bytes")
+    try:
+        priv = Ed25519PrivateKey.from_private_bytes(seed)
+    except Exception as exc:
+        raise IssuanceError(f"invalid ed25519 issuing seed: {exc}") from exc
+
+    manifest = Ed25519KeyManifest()
+    manifest.register(
+        kid=kid,
+        public_key=priv.public_key(),
+        valid_from=_WIDE_FROM,
+        valid_until=_WIDE_UNTIL,
+        private_key=priv,
+    )
+    _ISSUING_MANIFEST, _ISSUING_KID = manifest, kid
+    return manifest, kid
+
+
 def generate_license_from_checkout(session: dict[str, Any]) -> dict[str, Any]:
-    """Generate a GraQle license key from a Stripe checkout session.
+    """Generate a GraQle ed25519 (v2) license key from a Stripe checkout session.
+
+    Cutover (ADR-215 §5): issues an ed25519-signed v2 licence (forgery-resistant —
+    the public wheel verifies with the public key and cannot mint) instead of the
+    legacy HMAC v1. Existing v1 customers keep working via the manager's dual-verify
+    until their licence renews as v2.
 
     Parameters
     ----------
@@ -122,9 +237,11 @@ def generate_license_from_checkout(session: dict[str, Any]) -> dict[str, Any]:
     Returns
     -------
     dict
-        Contains: license_key, tier, email, holder, expires_at
+        Contains: license_key, license_id, tier, email, holder, expires_at, ...
     """
-    from graqle.licensing.manager import LicenseManager
+    import secrets
+
+    from graqle.licensing.ed25519_license import issue_ed25519_license
 
     # Extract customer info
     email = session.get("customer_email") or session.get("customer_details", {}).get("email", "")
@@ -137,31 +254,47 @@ def generate_license_from_checkout(session: dict[str, Any]) -> dict[str, Any]:
 
     # Duration
     duration_days = TIER_DURATION_DAYS.get(tier, 365)
-    expires_at = (
-        datetime.now(timezone.utc) + timedelta(days=duration_days)
-    ).isoformat()
+    now = datetime.now(timezone.utc)
+    issued_at = now.isoformat()
+    expires_at = (now + timedelta(days=duration_days)).isoformat()
 
-    # Generate the signed license key
-    license_key = LicenseManager.generate_key(
+    # license_id is derived from the Stripe session so it is stable + idempotent
+    # on webhook retries (a retry re-issues the SAME license_id, not a second
+    # licence) and traceable to the purchase; the CRL revokes against it.
+    session_id = session.get("id", "")
+    license_id = f"lic_{session_id}" if session_id else f"lic_{secrets.token_hex(12)}"
+    nonce = secrets.token_hex(16)  # fresh per issue — replay protection
+
+    manifest, kid = _get_issuing_manifest()
+    license_key = issue_ed25519_license(
+        manifest,
+        kid,
+        license_id=license_id,
         tier=tier,
         holder=name or email,
         email=email,
+        issued_at=issued_at,
+        nonce=nonce,
         expires_at=expires_at,
+        features=[],  # parity with v1: tier drives entitlement (cutover v1)
+        at=now,
     )
 
     result = {
         "license_key": license_key,
+        "license_id": license_id,
         "tier": tier,
         "email": email,
         "holder": name or email,
         "expires_at": expires_at,
-        "stripe_session_id": session.get("id", ""),
+        "stripe_session_id": session_id,
         "stripe_customer_id": session.get("customer", ""),
+        "license_format": "graqle-license-v2",
     }
 
     logger.info(
-        f"License generated: tier={tier}, email={email}, "
-        f"expires={expires_at}, session={session.get('id', '')}"
+        "ed25519 licence issued: license_id=%s tier=%s email=%s expires=%s session=%s kid=%s",
+        license_id, tier, email, expires_at, session_id, kid,
     )
 
     return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.68.1"
+version = "0.69.0"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_server/test_stripe_webhook.py
+++ b/tests/test_server/test_stripe_webhook.py
@@ -14,6 +14,37 @@ import hmac
 import json
 import time
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _issuing_key(monkeypatch):
+    """Inject a fresh in-memory ed25519 licence-issuing key for every test.
+
+    The cutover (ADR-215 §5) issues ed25519 v2 licences signed with a Secrets-
+    Manager key; tests substitute a generated key by patching _get_issuing_manifest
+    so no AWS is touched. The one test that asserts "issuance fails without a key"
+    overrides this by clearing the module globals + env itself.
+    """
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    from graqle.governance.custody.ed25519_key_manifest import Ed25519KeyManifest
+    import graqle.server.stripe_webhook as sw
+
+    priv = Ed25519PrivateKey.generate()
+    kid = "graqle-license-test"
+    manifest = Ed25519KeyManifest()
+    manifest.register(
+        kid=kid,
+        public_key=priv.public_key(),
+        valid_from=sw._WIDE_FROM,
+        valid_until=sw._WIDE_UNTIL,
+        private_key=priv,
+    )
+    monkeypatch.setattr(sw, "_get_issuing_manifest", lambda: (manifest, kid))
+    # Expose for tests that want to verify the issued token.
+    return manifest, kid
+
 
 class TestStripeSignatureVerification:
     """Tests for Stripe webhook signature verification."""
@@ -67,12 +98,10 @@ class TestStripeSignatureVerification:
 class TestLicenseGeneration:
     """Tests for license key generation from Stripe checkout."""
 
-    def test_generate_from_checkout_session(self, monkeypatch) -> None:
-        # WS-D: v1 HMAC verify now requires a real secret (the public dev fallback
-        # is refused). The Stripe issuer signs with the production secret, so this
-        # generate→verify round-trip runs with a real (test) secret configured.
-        monkeypatch.setenv("GRAQLE_LICENSE_KEY_SECRET", "test-stripe-secret")
+    def test_generate_from_checkout_issues_ed25519_v2(self, _issuing_key) -> None:
+        manifest, kid = _issuing_key
         from graqle.server.stripe_webhook import generate_license_from_checkout
+        from graqle.licensing.ed25519_license import verify_ed25519_license
 
         session = {
             "id": "cs_test_123",
@@ -88,21 +117,33 @@ class TestLicenseGeneration:
         assert result["tier"] == "team"
         assert result["email"] == "buyer@company.com"
         assert result["holder"] == "Jane Buyer"
-        assert result["license_key"]  # Non-empty
-        assert "." in result["license_key"]  # payload.signature format
+        assert result["license_format"] == "graqle-license-v2"
+        # license_id is derived from the Stripe session (stable + idempotent).
+        assert result["license_id"] == "lic_cs_test_123"
+        # v2 token shape: payload.kid.sig (3 dot-parts).
+        assert result["license_key"].count(".") == 2
 
-        # Verify the generated key is valid
-        from graqle.licensing.manager import LicenseManager
-        manager = LicenseManager.__new__(LicenseManager)
-        manager._license = None
-        license_obj = manager._verify_key(result["license_key"])
+        # The issued token verifies against the SAME issuing key (the public half).
+        payload = verify_ed25519_license(result["license_key"], manifest)
+        assert payload is not None
+        assert payload["tier"] == "team"
+        assert payload["email"] == "buyer@company.com"
+        assert payload["license_id"] == "lic_cs_test_123"
+        assert payload["format"] == "graqle-license-v2"
+        assert payload["nonce"]  # a fresh replay nonce is present
 
-        assert license_obj is not None
-        assert license_obj.tier.value == "team"
-        assert license_obj.email == "buyer@company.com"
-        assert license_obj.is_valid is True
+    def test_issuance_idempotent_license_id_on_retry(self) -> None:
+        """A Stripe webhook retry re-issues the SAME license_id (derived from session)."""
+        from graqle.server.stripe_webhook import generate_license_from_checkout
 
-    def test_enterprise_tier_mapping(self) -> None:
+        session = {"id": "cs_retry_1", "customer_email": "a@b.com",
+                   "customer_details": {"name": "A"}, "metadata": {"graqle_tier": "pro"},
+                   "payment_status": "paid"}
+        r1 = generate_license_from_checkout(session)
+        r2 = generate_license_from_checkout(session)
+        assert r1["license_id"] == r2["license_id"] == "lic_cs_retry_1"
+
+    def test_enterprise_tier_mapping(self, monkeypatch) -> None:
         from graqle.server.stripe_webhook import generate_license_from_checkout
 
         session = {
@@ -117,7 +158,7 @@ class TestLicenseGeneration:
         result = generate_license_from_checkout(session)
         assert result["tier"] == "enterprise"
 
-    def test_default_tier_is_team(self) -> None:
+    def test_default_tier_is_team(self, monkeypatch) -> None:
         from graqle.server.stripe_webhook import generate_license_from_checkout
 
         session = {
@@ -131,6 +172,22 @@ class TestLicenseGeneration:
 
         result = generate_license_from_checkout(session)
         assert result["tier"] == "team"
+
+    def test_issuance_requires_configured_key(self, monkeypatch) -> None:
+        """Issuance fails loudly (no silent fallback) when the issuing key is unset."""
+        import importlib
+
+        import graqle.server.stripe_webhook as sw
+
+        # Reload the module so the autouse fixture's patch of _get_issuing_manifest
+        # is gone — we want the REAL builder, which must fail without config.
+        sw = importlib.reload(sw)
+        monkeypatch.setattr(sw, "_ISSUING_MANIFEST", None)
+        monkeypatch.setattr(sw, "_ISSUING_KID", None)
+        monkeypatch.delenv("GRAQLE_LICENSE_ISSUING_SECRET_ID", raising=False)
+        monkeypatch.delenv("GRAQLE_LICENSE_ISSUING_KID", raising=False)
+        with pytest.raises(sw.IssuanceError):
+            sw.generate_license_from_checkout({"id": "cs_x", "metadata": {}, "payment_status": "paid"})
 
 
 class TestWebhookEventHandler:


### PR DESCRIPTION
## feat(licensing): issue ed25519 v2 licences from the Stripe webhook (v0.69.0)

The Stripe checkout webhook now issues **ed25519-signed v2** licences instead of the legacy **HMAC v1** — **forgery-resistant**: the published package verifies with the **public key only and cannot mint** a licence (asymmetric). This completes the ed25519 licence migration on the issuance side.

### What changed
- `generate_license_from_checkout` → `issue_ed25519_license`, signed with a **dedicated** ed25519 key fetched from a configured secret store (`GRAQLE_LICENSE_ISSUING_SECRET_ID` + `GRAQLE_LICENSE_ISSUING_KID`), cached for the process lifetime. The key is **never logged, serialised, or returned**. Issuance **fails CLOSED + loud** when the key is unconfigured (no silent fallback).
- `license_id = "lic_" + stripe_session_id` (stable + **idempotent** on webhook retries); `nonce = secrets.token_hex(16)` (replay protection); `features = []`.
- **Existing v1 customers keep working** via the manager's dual-verify until renewal mints a v2 — **issuer-only change; the verifier is untouched**.

### Tests
**15 stripe tests** (issue→verify round-trip, idempotent `license_id`, fails-closed-without-key) + **160 licensing tests** pass — **0 regression**. An A09 exception-leak (Secrets Manager detail in the error message) was hardened to a generic message.

---
v0.69.0. Cherry-picked from the internal cutover (private PR #176).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
