### PR TITLE
v0.70.1: activation correctness fix (reasoning activates indexed code)

### DIFF
--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.70.0"
+__version__ = "0.70.1"

--- a/graqle/activation/factory_helpers.py
+++ b/graqle/activation/factory_helpers.py
@@ -149,14 +149,34 @@ def _make_full_activator(graph: Any) -> FullActivator:  # noqa: ARG001
 
 
 def _make_cypher_activation(graph: Any) -> Any:
-    """(neo4j, semantic) -> CypherActivation."""
+    """(neo4j, semantic) -> CypherActivation.
+
+    The embedding engine MUST come from create_embedding_engine(cfg) — NOT a
+    bare EmbeddingEngine() — so the query embeds in the SAME space as the Neo4j
+    vector index. A hardcoded EmbeddingEngine() produced 384-dim MiniLM vectors
+    (and in fact failed to construct when embeddings.model was a Titan id),
+    which cannot query the 1024-dim Titan vector index: vector_search then
+    raised and CypherActivation silently fell back to the full graph. Mirrors
+    _make_chunk_scorer so both semantic paths share one embedding space.
+    """
     from graqle.activation.cypher_activation import CypherActivation
-    from graqle.activation.embeddings import EmbeddingEngine
+    from graqle.activation.embeddings import create_embedding_engine
+
+    cfg = graph.config
+    try:
+        emb_engine = create_embedding_engine(cfg)
+    except Exception as exc:
+        logger.warning(
+            "CypherActivation: embedding engine init failed (%s); proceeding "
+            "with default engine",
+            type(exc).__name__,
+        )
+        emb_engine = None
 
     return CypherActivation(
         connector=graph._neo4j_connector,
-        embedding_engine=EmbeddingEngine(),
-        max_nodes=graph.config.activation.max_nodes,
+        embedding_engine=emb_engine,
+        max_nodes=cfg.activation.max_nodes,
     )
 
 

--- a/graqle/core/graph.py
+++ b/graqle/core/graph.py
@@ -2419,47 +2419,70 @@ class Graqle:
 
         query_lower = query.lower()
 
-        # Build a lookup: bare_name → node_id, full_label → node_id
-        # Only for nodes whose label looks like a filename (contains '.')
-        label_to_id: dict[str, str] = {}
-        bare_to_id: dict[str, str] = {}
+        # Build a lookup: filename-with-extension → {node_ids sharing that file}.
+        #
+        # CRITICAL: match on the FILENAME extracted from the node ID PATH, NOT
+        # node.label. In this graph labels are symbol names ("get_proof") or
+        # description text — never filenames — so the old label-based matching
+        # (a) never matched a real file and (b) false-fired on incidental query
+        # words that happened to be bare tokens ("gate" in "require_role gate
+        # access", "api" inside "read_api", "dashboard" inside a path), shadowing
+        # the semantic CypherActivation path. Node IDs ARE the path, e.g.
+        # "studio_backend/dashboard/read_api.py::get_proof" -> "read_api.py".
+        # We only seed when the full filename token (with its real extension)
+        # appears in the query at a word boundary — GRAQLE option (d).
+        fname_to_ids: dict[str, set[str]] = {}
+        fname_to_paths: dict[str, set[str]] = {}
+        for nid in self.nodes:
+            # Strip a trailing "::symbol" so foo.py::bar -> foo.py. split() with
+            # no "::" returns the whole id unchanged, so this is always safe.
+            path = nid.split("::", 1)[0].replace("\\", "/").lower()
+            base = path.rsplit("/", 1)[-1]
+            # Require a real-looking extension (".py", ".ts", ".tsx", ...).
+            # base is already lowercased, so uppercase extensions are covered.
+            if len(base) >= 3 and _re.search(r"\.[a-z0-9]{1,8}$", base):
+                fname_to_ids.setdefault(base, set()).add(nid)
+                fname_to_paths.setdefault(base, set()).add(path)
 
-        for nid, node in self.nodes.items():
-            label = (node.label or "").strip()
-            if not label or len(label) < 3:
-                continue
-
-            label_lower = label.lower()
-            # Normalize paths to basename
-            if "/" in label_lower or "\\" in label_lower:
-                label_lower = label_lower.replace("\\", "/").rsplit("/", 1)[-1]
-
-            if "." in label_lower:
-                # It looks like a filename
-                label_to_id[label_lower] = nid
-                bare = label_lower.rsplit(".", 1)[0]
-                if len(bare) >= 3:
-                    bare_to_id[bare] = nid
-
-        if not label_to_id and not bare_to_id:
+        if not fname_to_ids:
             return None
 
+        # A precise file reference (e.g. "read_api.py") maps to only a handful of
+        # symbol nodes. A common basename ("__init__.py") maps to hundreds across
+        # packages — seeding all of them floods activation and shadows semantics.
+        # For such ambiguous filenames, require the query to ALSO name a full path
+        # so we can scope to the intended package; otherwise skip the filename
+        # and let the semantic CypherActivation path handle it.
+        _COMMON_BASENAME_MAX = 12
+
         matched_nodes: set[str] = set()
+        for fname, nids in fname_to_ids.items():
+            if fname not in query_lower:
+                continue
+            # Word-boundary guard so "api.py" does not match inside
+            # "read_api.py" and a real filename is not a substring of a word.
+            pattern = (
+                rf"(?:^|[\s\-/\\,;:\"'()])"
+                rf"{_re.escape(fname)}"
+                rf"(?:[\s\-/\\,;:\"'()]|$)"
+            )
+            if not _re.search(pattern, query_lower):
+                continue
 
-        # Check full filename matches (e.g., "auth.ts" in query)
-        for fname, nid in label_to_id.items():
-            if fname in query_lower:
-                matched_nodes.add(nid)
-
-        # Check bare name matches with word boundary (e.g., "auth" in query)
-        for bare, nid in bare_to_id.items():
-            if nid in matched_nodes:
-                continue  # Already matched by full name
-            if bare in query_lower:
-                # Word boundary check to avoid substring false matches
-                pattern = rf"(?:^|[\s\-_/\\.,;:\"'()]){_re.escape(bare)}(?:[\s\-_/\\.,;:\"'()]|$)"
-                if _re.search(pattern, query_lower):
-                    matched_nodes.add(nid)
+            if len(nids) > _COMMON_BASENAME_MAX:
+                # Ambiguous common basename — only accept nodes whose full path
+                # the query explicitly names (directory-scoped disambiguation).
+                scoped_paths = {
+                    p for p in fname_to_paths[fname] if p in query_lower
+                }
+                if not scoped_paths:
+                    continue  # no path context → defer to semantic activation
+                matched_nodes.update(
+                    n for n in nids
+                    if n.split("::", 1)[0].replace("\\", "/").lower() in scoped_paths
+                )
+            else:
+                matched_nodes.update(nids)
 
         if not matched_nodes:
             return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.70.0"
+version = "0.70.1"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_activation/test_direct_file_lookup.py
+++ b/tests/test_activation/test_direct_file_lookup.py
@@ -1,0 +1,115 @@
+"""Regression tests for Graqle._direct_file_lookup.
+
+These lock in the 2026-06-06 fix (graph-fix CR): _direct_file_lookup must match
+on FILENAMES extracted from node IDs (the path), NOT node labels. In real graphs
+labels are symbol/description names, so label-based matching never matched a file
+and false-fired on incidental query words ("gate", "api", "dashboard"), shadowing
+the semantic CypherActivation path. It must also NOT over-activate on common
+basenames like __init__.py shared across many packages.
+
+V-MARKER: V-GRAPH-FIX-NATIVE-003 — new test file created via native Write
+(graq_generate S-010 path-resolution gap on this Neo4j-backed session).
+"""
+
+import pytest
+
+from graqle.core.graph import Graqle
+from graqle.core.node import CogniNode
+
+
+def _graph(node_ids):
+    g = Graqle()
+    for nid in node_ids:
+        # label = bare symbol/module name, mirroring how real graphs are built
+        # (labels are NEVER filenames — that was the root cause of the bug).
+        label = nid.split("::", 1)[-1] if "::" in nid else nid.rsplit("/", 1)[-1]
+        g.add_node(
+            CogniNode(
+                id=nid,
+                label=label,
+                entity_type="Function" if "::" in nid else "PythonModule",
+                description=label,
+            )
+        )
+    return g
+
+
+class TestDirectFileLookupMatchesNodeIdPath:
+    def test_named_file_activates_its_nodes(self):
+        g = _graph([
+            "studio_backend/dashboard/read_api.py",
+            "studio_backend/dashboard/read_api.py::get_proof",
+            "studio_backend/dashboard/read_api.py::require_role",
+            "graqle/studio/routes/dashboard.py::dashboard",
+        ])
+        hits = g._direct_file_lookup("explain read_api.py")
+        assert hits is not None
+        assert "studio_backend/dashboard/read_api.py::get_proof" in hits
+        # Unrelated dashboard.py node must NOT be activated.
+        assert "graqle/studio/routes/dashboard.py::dashboard" not in hits
+
+    def test_full_path_in_query_activates(self):
+        g = _graph([
+            "studio_backend/dashboard/read_api.py::get_proof",
+            "studio_backend/dashboard/read_api.py::get_usage",
+        ])
+        hits = g._direct_file_lookup(
+            "what does studio_backend/dashboard/read_api.py do"
+        )
+        assert hits is not None
+        assert "studio_backend/dashboard/read_api.py::get_proof" in hits
+
+
+class TestDirectFileLookupNoFalseFire:
+    def test_english_word_matching_a_basename_does_not_fire(self):
+        # 'gate' is a real bare token of gate.py, but the query is English prose,
+        # not a file reference. Old code false-fired; the fix returns None.
+        g = _graph([
+            "graqle/intelligence/gate.py::list",
+            "graqle/intelligence/gate.py::get_impact",
+        ])
+        assert g._direct_file_lookup("how does the role gate access work") is None
+
+    def test_api_substring_inside_read_api_does_not_match_api_py(self):
+        # 'api.py' must NOT match inside the word 'read_api' (word-boundary guard).
+        g = _graph([
+            "graqle/studio/routes/api.py::studio_chat",
+            "studio_backend/dashboard/read_api.py::get_proof",
+        ])
+        hits = g._direct_file_lookup("how does read_api handle tenants")
+        # 'read_api' (no extension) is prose here -> no filename token -> None.
+        assert hits is None
+
+    def test_pure_semantic_query_returns_none(self):
+        g = _graph([
+            "studio_backend/dashboard/read_api.py::get_proof",
+        ])
+        assert g._direct_file_lookup(
+            "how do we stop one tenant reading another tenant's data"
+        ) is None
+
+
+class TestDirectFileLookupCommonBasenameGuard:
+    def test_bare_common_basename_does_not_explode(self):
+        # Many __init__.py across packages. A bare '__init__.py' query must NOT
+        # seed all of them.
+        ids = [f"pkg{i}/__init__.py::x" for i in range(40)]
+        g = _graph(ids)
+        hits = g._direct_file_lookup("what is in __init__.py")
+        assert hits is None
+
+    def test_path_scoped_common_basename_matches_only_that_package(self):
+        ids = [f"pkg{i}/__init__.py::x" for i in range(40)]
+        ids.append("studio_backend/metering/__init__.py")
+        g = _graph(ids)
+        hits = g._direct_file_lookup(
+            "what is in studio_backend/metering/__init__.py"
+        )
+        assert hits is not None
+        assert "studio_backend/metering/__init__.py" in hits
+        # Must not have pulled in the 40 unrelated __init__.py nodes.
+        assert all("pkg" not in h or "metering" in h for h in hits)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## v0.70.1 — activation correctness fix (graph reasoning now activates indexed code)

Patch release fixing a **global reasoning-quality bug** in the activation path.
Two SDK functions on the core `_activate_subgraph` path were broken:

1. **`graqle/activation/factory_helpers.py::_make_cypher_activation`** — the
   `(neo4j, semantic)` activator constructed a hardcoded local `EmbeddingEngine()`
   (384-dim MiniLM) instead of `create_embedding_engine(cfg)`. Against a 1024-dim
   Titan/Bedrock vector index this raised inside the vector search (and the bare
   engine even fails to *construct* when `embeddings.model` is a Titan id), so
   `CypherActivation` silently fell back to the full graph. **Impact: every user
   on a Neo4j backend with cloud embeddings got degraded (effectively random)
   activation.** Now uses the configured engine so query and index share one space.

2. **`graqle/core/graph.py::_direct_file_lookup`** — matched query tokens against
   node *labels* assuming labels are filenames. In real graphs labels are symbol
   or description names, so it (a) never matched a real file and (b) false-fired on
   incidental query words that happened to be bare tokens of other files,
   shadowing the semantic path. **Impact: degraded reasoning for all users on all
   backends.** Now matches filenames extracted from node-ID *paths*, with a
   word-boundary guard and a path-scoping guard so common basenames (e.g.
   `__init__.py`) don't over-activate.

### Verification

`_activate_subgraph` now activates the correct, content-bearing nodes (proven on a
133k-node Neo4j graph: the target file's nodes rank #1 by vector relevance; common
basenames no longer explode; pure-semantic queries correctly defer to vector
search). **7 new regression tests** in `tests/test_activation/test_direct_file_lookup.py`.

No API changes. No behavior added — purely a correctness fix. SemVer **patch**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
