### PR TITLE
release(0.71.0): governance constitution — changelog + README + version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## 0.71.0 (2026-06-07) — [Governance constitution: a governed first run]
+
+> `graq init` now sets up a **governed development experience out of the box**.
+> The full GraQle rulebook ships as a single source of truth and is rendered
+> into your AI tool's instruction file, so a brand-new user pair-programs with a
+> disciplined senior engineer from the first command — not a generic assistant.
+> Implements ADR-222 P1 (+ the bundled Claude Code install-time guardrail).
+
+**Added**
+
+- **`graqle/data/constitution/`** — the governance constitution as modular,
+  shippable Markdown fragments and the single source of truth for every client:
+  - `00-core` — the prime rules (governed tools only; five non-negotiables;
+    when to use GraQle).
+  - `10-tools` — the full MCP tool inventory by role + cheapest-correct-tool
+    selection.
+  - `20-workflows` — the 9-phase backbone, per-task phase subsets, and the
+    private→public ship sequence.
+  - `30-cost` — token cost-optimisation rules.
+  - `40-workarounds` — learned-behaviour workarounds and protected-path /
+    spend-governance rules.
+  - `50-eu-ai-act` — the configurable, **off-by-default** EU AI Act section.
+- **`graq init`** assembles the constitution via `importlib.resources` (sorted,
+  UTF-8) and renders it into `CLAUDE.md`. It is **fail-safe**: if the package
+  data is unavailable it degrades to an inline fallback, so `graq init` never
+  breaks on a stripped wheel.
+
+**Changed**
+
+- `graq gate-install` now merges a `permissions` backstop into
+  `.claude/settings.json` **non-destructively** (deny native write/exec, allow
+  the governed `graq_*`/`kogni_*` tools; user entries preserved). This is the
+  structural layer behind the existing PreToolUse hook for Claude Code.
+
+**Notes**
+
+- The constitution renders into `CLAUDE.md` today; `AGENTS.md` (Codex) and
+  `.cursorrules` / `.windsurfrules` writers follow in a later release (ADR-222 P2).
+- The EU AI Act section is a configurable helper that **supports** the Act's
+  record-keeping / traceability expectations; it makes no claim that the Act
+  requires any specific switch.
+
+---
+
 ## 0.68.0 (2026-06-02) — [Ed25519 licence hardening + edition gating]
 
 > The licence layer moves to **ed25519** (asymmetric): the Community wheel

--- a/README.md
+++ b/README.md
@@ -170,10 +170,19 @@ Runs **fully offline** with Ollama. No telemetry. Code stays on your machine. AP
 ## Governance gate — drop-in for Claude Code, Cursor, VS Code
 
 ```bash
-graq gate-install      # one-time, project-local
+graq init              # sets up a governed project (writes the constitution → CLAUDE.md)
+graq gate-install      # one-time, project-local — enforce it for Claude Code
 ```
 
-Routes every native write/edit/bash through GraQle's governance gates. Plans required for risky changes. Trade-secret scanning on git commits. Path-traversal hardening on subprocess capture. CG-01 through CG-20 — all on, all auditable.
+**`graq init` writes the GraQle constitution into your project**, so your AI tool
+behaves like a disciplined senior engineer from the very first command: governed
+tools only (every change is checked), a defined *investigate → plan → review →
+apply → learn* workflow, built-in token-cost rules, and the project's known
+pitfalls baked in. One rulebook — shipped as
+[`graqle/data/constitution/`](./graqle/data/constitution/) — renders for every
+client, so editing it once keeps Claude Code, Cursor, and VS Code in sync.
+
+`gate-install` then routes every native write/edit/bash through GraQle's governance gates and adds a `permissions` backstop to `.claude/settings.json`. Plans required for risky changes. Trade-secret scanning on git commits. Path-traversal hardening on subprocess capture. CG-01 through CG-20 — all on, all auditable.
 
 → [Governance Gate spec](./docs/governance-gate.md)
 
@@ -255,22 +264,27 @@ The EU AI Act docs are deliberately open to contribution — **corrections, tran
 
 ---
 
-## What's new in v0.62.0
+## What's new in v0.71.0
 
-**Runtime Governance Layer R2 — continuous anchoring as a service.** The cryptographic substrate (v0.59.0) and the `attest()` capture path (v0.60.0) and FastAPI middleware (v0.61.0) were always meant to be operated continuously in production. v0.62.0 lands that operator surface as first-class CLI:
+**A governed first run.** `graq init` now sets up a governed development
+experience out of the box. The full GraQle rulebook — the **constitution** —
+ships as a single source of truth and is rendered into your AI tool's instruction
+file, so a brand-new user pair-programs with a disciplined senior engineer from
+the first command instead of a generic assistant.
 
-- **`graqle govern serve`** — long-lived anchoring worker over the shipped Layer 5 Committer + LocalReplayQueue. Fail-closed precondition (refuses `attestation.security.fail_open_on_anchor_error=true`), bounded shutdown, atomic health snapshots.
-- **`graqle govern serve --once`** — cron-style single-tick mode for environments where a long-lived service isn't appropriate.
-- **`graqle govern health`** — reads `.graqle/govern.health.json` and prints the Article-72-style monitoring snapshot as JSON. Pipes cleanly into any external monitor.
-- **`WorkerHealth.to_dict()`** — programmatic Article 72 surface for libraries: `running`, `ticks`, `records_committed`, `records_anchored`, `backfill_count`, `replay_queue_depth`, `seconds_since_last_anchor`, `last_error_type`, `status_counts`.
-- **Comprehensively tested** — full statement+branch coverage on the worker, end-to-end dogfooded from a clean PyPI wheel, CI matrix across Linux + Windows on Python 3.10 / 3.11 / 3.12.
+- **The constitution** ([`graqle/data/constitution/`](./graqle/data/constitution/)) — governed-tools-only rules, the 9-phase workflow, the full MCP tool inventory, token-cost rules, learned-behaviour workarounds, and a configurable (off-by-default) EU AI Act section. Modular Markdown fragments; edit once, every client stays in sync.
+- **`graq init`** assembles and renders it into `CLAUDE.md`, with a fail-safe fallback so init never breaks on a stripped wheel.
+- **`graq gate-install`** adds a non-destructive `permissions` backstop to `.claude/settings.json` (deny native write/exec, allow the governed `graq_*` tools) behind the existing PreToolUse hook.
 
-→ [Full v0.62.0 changelog](./CHANGELOG.md)
+> `AGENTS.md` (Codex) and `.cursorrules` / `.windsurfrules` rendering follow in the next release.
+
+→ [Full v0.71.0 changelog](./CHANGELOG.md)
 
 ---
 
 ## Recent releases
 
+- **v0.62.0** — Runtime R2: `graqle govern serve` continuous anchoring worker + `govern health` Article-72 monitoring snapshot.
 - **v0.61.0** — Runtime R1: FastAPI middleware + `@governed` decorator. Drop-in governance for any FastAPI app.
 - **v0.60.0** — Runtime R0 Mode A: `GovernedRuntime.attest()` and PII-safe `pseudonymize_ref()`.
 - **v0.59.0** — Layer 5 cryptographic substrate GA: RFC 8785 canonicalisation + RFC 6962 Merkle commitments + ed25519 signatures + Sigstore Rekor anchoring + local replay queue.

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.70.1"
+__version__ = "0.71.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.70.1"
+version = "0.71.0"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Release 0.71.0 — Governance constitution (docs + version)

Release of the P1 governance constitution (code already merged via #192). **Docs + version only.**

- **version** → **0.71.0** (`pyproject.toml` + `graqle/__version__.py`; import-verified; wheel builds as `graqle-0.71.0` with all 6 constitution fragments present).
- **CHANGELOG**: new `0.71.0` entry for the governance constitution (kept the existing 0.68.0+ history below it).
- **README**: Governance-gate section now highlights `graq init` writes the constitution into `CLAUDE.md` (new-user awareness); What's-new → v0.71.0; v0.62.0 moved into Recent releases.

Cherry-pick of private `260add0b`; the only conflict was the version line (0.70.1 → 0.71.0) + the CHANGELOG top entry, both resolved to 0.71.0 / both entries kept.

EU AI Act wording: **SUPPORTS** the Act's traceability — not "required by the Act."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
