### PR TITLE
feat(track-b): Team Graph Monetization — registry + team-aware paths + share API/CLI

### DIFF
--- a/graqle/cli/commands/team.py
+++ b/graqle/cli/commands/team.py
@@ -295,3 +295,88 @@ def team_info() -> None:
     console.print("  Observability:  [dim]Coming soon[/dim]")
     console.print("  Metrics:        [dim]Coming soon[/dim]")
     console.print("  Cross-repo:     [dim]Coming soon[/dim]")
+
+
+@team_app.command("share")
+def team_share(
+    project: str = typer.Option("", "--project", "-p", help="Project name (default: repo folder)"),
+    root: str = typer.Option(".", "--root", help="Repo root containing graqle.json"),
+) -> None:
+    """Share your local graph as the TEAM graph (Track B).
+
+    \b
+    Publishes this repo's graqle.json to the team's shared graph so every
+    active team member resolves to it ("one teaches, everyone benefits").
+    Requires Team plan, an active membership, and a teach role
+    (owner/admin/member — viewers are read-only).
+
+    \b
+    Examples:
+        graq team share
+        graq team share --project Brand_Collaboration
+    """
+    if not _check_team_gate():
+        raise typer.Exit(1)
+
+    from pathlib import Path
+
+    from graqle.cloud.credentials import load_credentials
+    from graqle.cloud.gateway import CloudGateway
+    from graqle.cloud.team import load_team_config
+    from graqle.cloud.team_registry import member_hash
+
+    config = load_team_config()
+    if not config.is_configured:
+        console.print(
+            "[yellow]No team configured.[/yellow] "
+            "Create one: [cyan]graq team create <name>[/cyan]"
+        )
+        raise typer.Exit(1)
+
+    creds = load_credentials()
+    if not creds.email:
+        console.print("[yellow]Not logged in.[/yellow] Run [cyan]graq login[/cyan] first.")
+        raise typer.Exit(1)
+
+    root_path = Path(root).resolve()
+    graph_path = root_path / "graqle.json"
+    if not graph_path.exists():
+        console.print(f"[bold red]No graqle.json found in {root_path}[/bold red]")
+        console.print("Build the graph first: [cyan]graq scan repo .[/cyan]")
+        raise typer.Exit(1)
+
+    project_name = project or root_path.name
+    graph_data = graph_path.read_text(encoding="utf-8")
+
+    gateway = CloudGateway(api_key=creds.api_key)
+    result = gateway.share_graph_to_team(
+        graph_data=graph_data,
+        member_hash=member_hash(creds.email),
+        team_id=config.team_id,
+        project=project_name,
+    )
+
+    status = result.get("status")
+    if status == "shared":
+        console.print(Panel(
+            f"[bold green]Graph shared with your team![/bold green]\n\n"
+            f"  Team:     [bold]{config.team_name}[/bold] ([cyan]{config.team_id}[/cyan])\n"
+            f"  Project:  {project_name}\n\n"
+            f"[dim]Active members can now read it with the team graph scope.[/dim]",
+            border_style="green",
+            title="Shared to Team",
+        ))
+    elif result.get("code") == "FORBIDDEN":
+        console.print("[bold red]Not permitted to share to this team.[/bold red]")
+        console.print(
+            "[dim]You need a teach role (owner/admin/member). Viewers are read-only.[/dim]"
+        )
+        raise typer.Exit(1)
+    elif result.get("code") == "NOT_CONNECTED":
+        console.print(
+            "[yellow]Not connected to GraQle Cloud.[/yellow] Run [cyan]graq login[/cyan]."
+        )
+        raise typer.Exit(1)
+    else:
+        console.print(f"[bold red]Share failed:[/bold red] {result.get('error', 'unknown error')}")
+        raise typer.Exit(1)

--- a/graqle/cloud/gateway.py
+++ b/graqle/cloud/gateway.py
@@ -252,17 +252,42 @@ class CloudGateway:
         email: str,
         project: str,
         scorecard_data: str | None = None,
+        team_id: str | None = None,
     ) -> dict[str, Any]:
         """Upload a full graph to S3 cloud storage.
 
         This is the real cloud upload — not a stub.
+
+        Track B (B2.1): when ``team_id`` is provided, the graph is written to the
+        TEAM prefix ``graphs/team-{team_id}/{project}`` so every team member's
+        read resolves to it (the shared-graph monetization path). When ``team_id``
+        is None (the default) the behaviour is BYTE-IDENTICAL to before: the
+        per-user prefix ``graphs/{sha256(email)}/{project}``. The caller is
+        responsible for authorising the team write (``share_graph_to_team`` does
+        the RBAC check via :class:`~graqle.cloud.team_registry.TeamRegistry`);
+        ``team_id`` here is a validated slug, never a raw client value.
         """
         if not self.is_connected:
             return {"error": "Not connected to GraQle Cloud", "code": "NOT_CONNECTED"}
 
         import hashlib
-        email_hash = hashlib.sha256(email.lower().encode()).hexdigest()
-        s3_prefix = f"graphs/{email_hash}/{project}"
+
+        from graqle.cloud.team_registry import _PROJECT_NAME_RE, _TEAM_ID_RE
+
+        # Sentinel SF-TRACKB-1: validate ``project`` HERE (gateway boundary), not
+        # only at the HTTP layer — a path-traversal value like '../../other-tenant'
+        # would otherwise escape the per-tenant S3 prefix (OWASP A01). This is the
+        # single chokepoint both the HTTP endpoint and the CLI funnel through.
+        if not isinstance(project, str) or not _PROJECT_NAME_RE.match(project):
+            return {"error": f"invalid project: {project!r}", "status": "failed"}
+
+        if team_id is not None:
+            if not _TEAM_ID_RE.match(team_id):
+                return {"error": f"invalid team_id: {team_id!r}", "status": "failed"}
+            s3_prefix = f"graphs/{team_id}/{project}"
+        else:
+            email_hash = hashlib.sha256(email.lower().encode()).hexdigest()
+            s3_prefix = f"graphs/{email_hash}/{project}"
 
         try:
             import boto3
@@ -289,6 +314,64 @@ class CloudGateway:
         except Exception as e:
             logger.error("Cloud upload failed: %s", e)
             return {"error": str(e), "status": "failed"}
+
+    def share_graph_to_team(
+        self,
+        graph_data: str,
+        member_hash: str,
+        team_id: str,
+        project: str,
+        registry: Any = None,
+        scorecard_data: str | None = None,
+    ) -> dict[str, Any]:
+        """Explicit "Share to team" — publish the caller's graph as the TEAM graph.
+
+        Track B (B2.3, monetization moment). The authorisation is the whole point:
+
+        * ``member_hash`` is the caller's VERIFIED identity (sha256(lower(email))
+          from :func:`graqle.studio.auth.verified_email_from_request`), NEVER a raw
+          header value.
+        * The caller MUST have ``can_teach`` on ``team_id`` (owner/admin/member);
+          a ``viewer`` or non-member is rejected with a FORBIDDEN result — the
+          RBAC check runs against the registry row keyed by the verified hash, so a
+          forged role cannot escalate (same trust model as A1b).
+        * Only after the check passes does the graph land at
+          ``graphs/team-{team_id}/{project}`` (via :meth:`upload_graph`), where every
+          member's read resolves to it.
+
+        Returns ``{"status": "shared", ...}`` on success, or a ``FORBIDDEN`` /
+        error dict. Fails CLOSED: any registry/authorisation failure denies.
+        """
+        if not self.is_connected:
+            return {"error": "Not connected to GraQle Cloud", "code": "NOT_CONNECTED"}
+
+        from graqle.cloud.team_registry import (
+            ForbiddenError,
+            TeamRegistry,
+            TeamRegistryError,
+        )
+
+        reg = registry if registry is not None else TeamRegistry()
+        try:
+            reg.assert_can_write(member_hash, team_id)
+        except ForbiddenError as exc:
+            logger.info("share_graph_to_team denied for %s…: %s", member_hash[:8], exc)
+            return {"status": "forbidden", "code": "FORBIDDEN", "error": str(exc)}
+        except TeamRegistryError as exc:
+            logger.warning("share_graph_to_team registry error: %s", exc)
+            return {"status": "failed", "error": str(exc)}
+
+        result = self.upload_graph(
+            graph_data=graph_data,
+            email="",  # unused on the team path
+            project=project,
+            scorecard_data=scorecard_data,
+            team_id=team_id,
+        )
+        if result.get("status") == "uploaded":
+            result["status"] = "shared"
+            result["team_id"] = team_id
+        return result
 
     def push_delta(self, delta: dict[str, Any], team_id: str) -> dict[str, Any]:
         """Push a delta to the cloud graph.
@@ -328,19 +411,37 @@ class CloudGateway:
             "phase": "foundation",
         }
 
-    def register_team(self, team_name: str, owner_email: str) -> dict[str, Any]:
-        """Register a new team with the cloud gateway.
+    def register_team(
+        self,
+        team_name: str,
+        owner_email: str,
+        registry: Any = None,
+    ) -> dict[str, Any]:
+        """Register a new team in the cloud registry (Track B, B1.2).
 
-        Phase 1: Returns local config. Phase 2+: actual registration.
+        Creates the team in the DynamoDB :class:`~graqle.cloud.team_registry.
+        TeamRegistry` with ``owner_email`` (the caller's VERIFIED identity) as the
+        ``owner`` member. Returns the real ``team_id``. ``registry`` is injectable
+        for tests. On a registry error the team is NOT created — we surface the
+        failure rather than silently pretending success.
         """
         if not self.is_connected:
             return {"error": "Not connected to GraQle Cloud", "code": "NOT_CONNECTED"}
 
+        from graqle.cloud.team_registry import TeamRegistry, TeamRegistryError
+
+        reg = registry if registry is not None else TeamRegistry()
+        try:
+            rec = reg.register_team(team_name, owner_email)
+        except TeamRegistryError as exc:
+            return {"status": "failed", "error": str(exc)}
+
         return {
-            "status": "registered_locally",
-            "team_id": f"team-{team_name.lower().replace(' ', '-')}",
-            "message": "Team registered locally (cloud registration available in next release)",
-            "phase": "foundation",
+            "status": "registered",
+            "team_id": rec.team_id,
+            "team_name": rec.team_name,
+            "owner_hash": rec.owner_hash,
+            "message": f"Team '{rec.team_name}' registered as {rec.team_id}",
         }
 
     def get_observability(self, team_id: str) -> dict[str, Any]:

--- a/graqle/cloud/team_registry.py
+++ b/graqle/cloud/team_registry.py
@@ -1,0 +1,378 @@
+# V-TRACKB-NATIVE-001: new-file creation via native Write (S-010: graq_write
+# rejects absolute source-tree paths — MCP resolves against site-packages).
+"""GraQle Cloud Team Registry — the DynamoDB source of truth for teams (Track B).
+
+This is the cloud-side registry behind ``graqle.cloud.team`` (which is a LOCAL
+``.graqle/team.json`` cache). It answers the one question the team-graph feature
+turns on:
+
+    "Given a VERIFIED member identity, which team's shared graph may they read or
+     write, and with what role?"
+
+THE SECURITY BOUNDARY (carries A1b forward)
+-------------------------------------------
+* Identity is ALWAYS a ``member_hash`` = ``sha256(lower(email))`` derived from a
+  *verified* token upstream (``graqle.studio.auth.verified_email_from_request``).
+  This module never accepts a raw header email — callers pass the already-hashed,
+  already-verified identity. The hash IS the tenant/member key (ADR-PHASE5-001).
+* ``resolve_team_for_member`` returns a team ONLY if an ACTIVE member row exists.
+  No membership → no team → no shared graph (fail closed).
+* Writes to a team graph require ``can_teach`` (owner/admin/member). ``viewer`` is
+  read-only. Role is re-checked here AND server-side at the write site (defence in
+  depth) — a forged role cannot escalate because role comes from the registry row,
+  keyed by the verified ``member_hash``, never from the client.
+* ``team_id`` used to build the S3 prefix is ALWAYS the value returned by a
+  registry lookup, never a client-supplied string — closing the same class of hole
+  as the A1b ``x-user-email`` trap.
+
+Table shape (``graqle-teams``, PAY_PER_REQUEST, ~$1-2/mo)
+---------------------------------------------------------
+* PK ``team_id``  (e.g. ``team-acme``)
+* SK ``META``                      → the team record
+* SK ``MEMBER#{member_hash}``      → one row per member
+* GSI ``member-index`` on ``member_hash`` → list a member's teams in O(1)
+
+The DynamoDB client is injectable (``table_resource``) so the whole module is
+unit-testable offline with a fake/moto table — no AWS calls in tests.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+import time
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger("graqle.cloud.team_registry")
+
+_DEFAULT_TABLE = "graqle-teams"
+_DEFAULT_REGION = "eu-central-1"
+_MEMBER_INDEX = "member-index"
+
+# Roles that may WRITE/teach the team graph (matches TeamMember.can_teach).
+_TEACH_ROLES = ("owner", "admin", "member")
+_ADMIN_ROLES = ("owner", "admin")
+_VALID_ROLES = ("owner", "admin", "member", "viewer")
+_ACTIVE = "active"
+
+# team_id is interpolated into an S3 key — restrict it hard (same discipline as
+# the studio project-name guard). Lowercase slug only.
+_TEAM_ID_RE = re.compile(r"\A[a-z0-9][a-z0-9-]{1,62}\Z")
+# Project name is ALSO interpolated into the S3 key (graphs/{owner}/{project}/...).
+# Path-traversal guard: allowed charset AND must contain at least one
+# alphanumeric, so an all-dots segment ('.', '..') — which would escape the
+# tenant prefix as a path component — is rejected. Single source of truth for any
+# caller building a graph key (gateway + studio routes).
+_PROJECT_NAME_RE = re.compile(r"\A(?=.*[A-Za-z0-9])[A-Za-z0-9._\- ]{1,128}\Z")
+_EMAIL_RE = re.compile(r"\A[^\s@\x00-\x1f]{1,64}@[^\s@\x00-\x1f]{1,255}\.[^\s@\x00-\x1f]{2,}\Z")
+
+
+class TeamRegistryError(Exception):
+    """Base error for registry operations."""
+
+
+class ForbiddenError(TeamRegistryError):
+    """The caller's verified identity is not permitted this action (fail closed)."""
+
+
+class NotFoundError(TeamRegistryError):
+    """Team or member does not exist."""
+
+
+def member_hash(email: str) -> str:
+    """``sha256(lower(email))`` — the member/tenant key (matches auth.tenant_hash)."""
+    return hashlib.sha256(email.strip().lower().encode()).hexdigest()
+
+
+def slug_team_id(team_name: str) -> str:
+    """Derive a safe ``team-<slug>`` id from a display name."""
+    base = re.sub(r"[^a-z0-9]+", "-", team_name.strip().lower()).strip("-")
+    base = base or "team"
+    candidate = f"team-{base}"[:63]
+    return candidate
+
+
+@dataclass(frozen=True)
+class TeamRecord:
+    team_id: str
+    team_name: str
+    owner_hash: str
+    created_at: str
+    plan: str = "team"
+
+
+@dataclass(frozen=True)
+class MemberRecord:
+    team_id: str
+    member_hash: str
+    role: str
+    status: str
+    joined_at: str
+
+    @property
+    def can_teach(self) -> bool:
+        return self.status == _ACTIVE and self.role in _TEACH_ROLES
+
+    @property
+    def can_admin(self) -> bool:
+        return self.status == _ACTIVE and self.role in _ADMIN_ROLES
+
+
+def _now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _valid_email(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    v = value.strip()
+    return v.lower() if _EMAIL_RE.match(v) else None
+
+
+class TeamRegistry:
+    """DynamoDB-backed team registry. Inject ``table_resource`` for tests.
+
+    Every method that grants access takes a ``caller_hash`` (the VERIFIED member
+    identity) and fails CLOSED: an unknown/inactive caller, a missing team, or a
+    role too low for the action raises rather than silently succeeding.
+    """
+
+    def __init__(
+        self,
+        table_name: str = _DEFAULT_TABLE,
+        region_name: str = _DEFAULT_REGION,
+        table_resource: Any = None,
+    ):
+        self._table_name = table_name
+        self._region = region_name
+        self._table = table_resource  # lazily built if None
+
+    # ---- low-level table access (injectable) ----
+
+    @property
+    def table(self) -> Any:
+        if self._table is None:
+            import boto3
+
+            self._table = boto3.resource(
+                "dynamodb", region_name=self._region
+            ).Table(self._table_name)
+        return self._table
+
+    @staticmethod
+    def _member_sk(mh: str) -> str:
+        return f"MEMBER#{mh}"
+
+    # ---- team lifecycle ----
+
+    def register_team(self, team_name: str, owner_email: str) -> TeamRecord:
+        """Create a team; the owner is added as an active ``owner`` member.
+
+        ``owner_email`` must be a verified email (the caller's own). Returns the
+        created :class:`TeamRecord`. Idempotent-ish: a colliding team_id raises.
+        """
+        email = _valid_email(owner_email)
+        if not email:
+            raise TeamRegistryError("owner_email is not a valid email")
+        team_id = slug_team_id(team_name)
+        if not _TEAM_ID_RE.match(team_id):
+            raise TeamRegistryError(f"derived team_id is invalid: {team_id!r}")
+
+        owner = member_hash(email)
+        created = _now()
+        meta = {
+            "team_id": team_id,
+            "sk": "META",
+            "team_name": team_name.strip()[:128],
+            "owner_hash": owner,
+            "created_at": created,
+            "plan": "team",
+        }
+        member = {
+            "team_id": team_id,
+            "sk": self._member_sk(owner),
+            "member_hash": owner,
+            "role": "owner",
+            "status": _ACTIVE,
+            "joined_at": created,
+        }
+        # Conditional put: do not clobber an existing team.
+        try:
+            self.table.put_item(
+                Item=meta,
+                ConditionExpression="attribute_not_exists(team_id)",
+            )
+        except Exception as exc:  # noqa: BLE001
+            if _is_conditional_failure(exc):
+                raise TeamRegistryError(f"team already exists: {team_id}") from exc
+            raise
+        self.table.put_item(Item=member)
+        logger.info("registered team %s (owner %s…)", team_id, owner[:8])
+        return TeamRecord(team_id, meta["team_name"], owner, created)
+
+    def get_team(self, team_id: str) -> TeamRecord:
+        item = self._get(team_id, "META")
+        if not item:
+            raise NotFoundError(f"no such team: {team_id}")
+        return TeamRecord(
+            team_id=item["team_id"],
+            team_name=item.get("team_name", ""),
+            owner_hash=item.get("owner_hash", ""),
+            created_at=item.get("created_at", ""),
+            plan=item.get("plan", "team"),
+        )
+
+    # ---- membership ----
+
+    def add_member(
+        self,
+        caller_hash: str,
+        team_id: str,
+        invitee_email: str,
+        role: str = "member",
+        status: str = "invited",
+    ) -> MemberRecord:
+        """Invite/add a member. Caller must be an active admin/owner of the team."""
+        if role not in _VALID_ROLES:
+            raise TeamRegistryError(f"invalid role: {role}")
+        self._require_admin(caller_hash, team_id)
+        email = _valid_email(invitee_email)
+        if not email:
+            raise TeamRegistryError("invitee_email is not a valid email")
+        mh = member_hash(email)
+        existing = self._get(team_id, self._member_sk(mh))
+        if existing:
+            raise TeamRegistryError("already a member")
+        joined = _now()
+        self.table.put_item(
+            Item={
+                "team_id": team_id,
+                "sk": self._member_sk(mh),
+                "member_hash": mh,
+                "role": role,
+                "status": status,
+                "joined_at": joined,
+            }
+        )
+        return MemberRecord(team_id, mh, role, status, joined)
+
+    def accept_invite(self, caller_hash: str, team_id: str) -> MemberRecord:
+        """A pending invitee (identified by their OWN verified hash) goes active."""
+        item = self._get(team_id, self._member_sk(caller_hash))
+        if not item:
+            raise NotFoundError("no invitation for this identity")
+        self.table.update_item(
+            Key={"team_id": team_id, "sk": self._member_sk(caller_hash)},
+            UpdateExpression="SET #s = :a",
+            ExpressionAttributeNames={"#s": "status"},
+            ExpressionAttributeValues={":a": _ACTIVE},
+        )
+        return MemberRecord(
+            team_id, caller_hash, item.get("role", "member"), _ACTIVE,
+            item.get("joined_at", ""),
+        )
+
+    def remove_member(self, caller_hash: str, team_id: str, target_hash: str) -> None:
+        """Remove a member. Caller must be admin/owner; the owner cannot be removed."""
+        self._require_admin(caller_hash, team_id)
+        team = self.get_team(team_id)
+        if target_hash == team.owner_hash:
+            raise ForbiddenError("cannot remove the team owner")
+        self.table.delete_item(
+            Key={"team_id": team_id, "sk": self._member_sk(target_hash)}
+        )
+
+    def get_membership(self, caller_hash: str, team_id: str) -> MemberRecord | None:
+        """Return the caller's member row for a team, or None (no exception)."""
+        item = self._get(team_id, self._member_sk(caller_hash))
+        if not item:
+            return None
+        return MemberRecord(
+            team_id, caller_hash, item.get("role", "viewer"),
+            item.get("status", ""), item.get("joined_at", ""),
+        )
+
+    # ---- the resolution the graph path depends on ----
+
+    def resolve_team_for_member(self, caller_hash: str) -> MemberRecord | None:
+        """Return the caller's ACTIVE team membership, or None (fail closed).
+
+        Uses the ``member-index`` GSI to find the caller's team(s); returns the
+        first ACTIVE one. None means "no team graph for you" — the caller falls
+        back to their own per-user graph. NEVER raises on a missing/forged caller.
+        """
+        if not _is_hash(caller_hash):
+            return None
+        try:
+            resp = self.table.query(
+                IndexName=_MEMBER_INDEX,
+                KeyConditionExpression="member_hash = :m",
+                ExpressionAttributeValues={":m": caller_hash},
+            )
+        except Exception as exc:  # noqa: BLE001 - registry unreachable → fail closed
+            logger.warning("team resolve query failed: %s", type(exc).__name__)
+            return None
+        for item in resp.get("Items", []):
+            if item.get("status") == _ACTIVE and _TEAM_ID_RE.match(
+                str(item.get("team_id", ""))
+            ):
+                return MemberRecord(
+                    team_id=item["team_id"],
+                    member_hash=caller_hash,
+                    role=item.get("role", "viewer"),
+                    status=_ACTIVE,
+                    joined_at=item.get("joined_at", ""),
+                )
+        return None
+
+    def assert_can_write(self, caller_hash: str, team_id: str) -> MemberRecord:
+        """Authorise a team-graph WRITE. Raises ForbiddenError if not allowed."""
+        m = self.get_membership(caller_hash, team_id)
+        if m is None or not m.can_teach:
+            raise ForbiddenError("not permitted to write this team graph")
+        return m
+
+    # ---- internals ----
+
+    def _require_admin(self, caller_hash: str, team_id: str) -> MemberRecord:
+        m = self.get_membership(caller_hash, team_id)
+        if m is None or not m.can_admin:
+            raise ForbiddenError("admin role required")
+        return m
+
+    def _get(self, team_id: str, sk: str) -> dict[str, Any] | None:
+        try:
+            resp = self.table.get_item(Key={"team_id": team_id, "sk": sk})
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("registry get_item failed: %s", type(exc).__name__)
+            return None
+        item = resp.get("Item")
+        return item if isinstance(item, dict) else None
+
+
+def _is_hash(value: Any) -> bool:
+    return isinstance(value, str) and bool(re.fullmatch(r"[0-9a-f]{64}", value))
+
+
+def _is_conditional_failure(exc: Exception) -> bool:
+    name = type(exc).__name__
+    if name == "ConditionalCheckFailedException":
+        return True
+    resp = getattr(exc, "response", None)
+    if isinstance(resp, dict):
+        return resp.get("Error", {}).get("Code") == "ConditionalCheckFailedException"
+    return False
+
+
+__all__ = [
+    "TeamRegistry",
+    "TeamRecord",
+    "MemberRecord",
+    "TeamRegistryError",
+    "ForbiddenError",
+    "NotFoundError",
+    "member_hash",
+    "slug_team_id",
+]

--- a/graqle/studio/auth.py
+++ b/graqle/studio/auth.py
@@ -229,4 +229,62 @@ def tenant_hash(email: str) -> str:
     return hashlib.sha256(email.strip().lower().encode()).hexdigest()
 
 
-__all__ = ["verified_email_from_request", "tenant_hash"]
+# ── team-aware S3 owner resolution (Track B, B2.2) ──
+# The S3 graph key is ``graphs/{owner}/{project}/graqle.json``. ``owner`` is
+# normally ``sha256(lower(email))`` (the caller's own graph). When the caller is
+# an ACTIVE member of a team AND explicitly asks for team scope (header
+# ``x-graph-scope: team``), ``owner`` becomes ``team-{team_id}`` so they read the
+# SHARED team graph. Membership is resolved from the registry keyed by the
+# VERIFIED email's hash — never a client-supplied team id — so a forged scope
+# header can only ever resolve to a team the caller actually belongs to.
+
+_TEAM_SCOPE_VALUES = ("team", "shared")
+
+
+def _wants_team_scope(request: Any) -> bool:
+    try:
+        scope = request.headers.get("x-graph-scope", "")
+    except Exception:  # noqa: BLE001
+        return False
+    return isinstance(scope, str) and scope.strip().lower() in _TEAM_SCOPE_VALUES
+
+
+def resolve_graph_owner_prefix(request: Any, registry: Any = None) -> str | None:
+    """Return the S3 owner segment for the caller, or None if unauthenticated.
+
+    * No verified email → None (caller gets no per-tenant graph; same as before).
+    * ``x-graph-scope: team`` AND the verified caller is an ACTIVE team member →
+      ``team-{team_id}`` (the shared graph).
+    * Otherwise → ``sha256(lower(email))`` (the caller's own graph — unchanged
+      default behaviour; team resolution NEVER changes the self path implicitly).
+
+    Fails CLOSED to the SELF prefix on any registry error — a team lookup failure
+    must never deny a user their own graph, and must never grant a team graph
+    without an active membership.
+    """
+    email = verified_email_from_request(request)
+    if not email:
+        return None
+
+    self_prefix = tenant_hash(email)
+    if not _wants_team_scope(request):
+        return self_prefix
+
+    try:
+        from graqle.cloud.team_registry import TeamRegistry
+
+        reg = registry if registry is not None else TeamRegistry()
+        membership = reg.resolve_team_for_member(self_prefix)
+    except Exception as exc:  # noqa: BLE001 - registry unavailable → fall back to self
+        logger.warning(
+            "studio auth: team resolve failed, using self graph (%s)", type(exc).__name__
+        )
+        return self_prefix
+
+    if membership is not None and getattr(membership, "team_id", None):
+        return membership.team_id  # already a validated 'team-<slug>'
+    # Asked for team scope but not an active member → their own graph (not denied).
+    return self_prefix
+
+
+__all__ = ["verified_email_from_request", "tenant_hash", "resolve_graph_owner_prefix"]

--- a/graqle/studio/routes/api.py
+++ b/graqle/studio/routes/api.py
@@ -35,7 +35,6 @@ async def _load_project_graph(request: Request, project: str):
 
     Uses in-memory cache to avoid re-downloading on every request.
     """
-    import hashlib
     import json
     import os
 
@@ -51,18 +50,21 @@ async def _load_project_graph(request: Request, project: str):
     # unverified base64-decode of a JWT accepts a self-minted ``alg:none`` token
     # — either one previously allowed a forged identity to read ANY tenant's
     # graph (OWASP A01). ``verified_email_from_request`` fails closed.
-    from graqle.studio.auth import verified_email_from_request
+    # V-TRACKB-NATIVE-003: Track B (B2.2) — resolve the S3 OWNER segment via the
+    # central auth trust root. Normally sha256(verified email); when the caller is
+    # an ACTIVE team member AND sent ``x-graph-scope: team`` it becomes
+    # ``team-{team_id}`` (the SHARED team graph). owner is None when unauthenticated.
+    from graqle.studio.auth import resolve_graph_owner_prefix
 
-    email = verified_email_from_request(request)
+    owner = resolve_graph_owner_prefix(request)
 
-    if not email:
-        logger.debug("No verified email for project graph loading")
+    if not owner:
+        logger.debug("No verified identity for project graph loading")
         return None
 
-    # Compute S3 key
-    email_hash = hashlib.sha256(email.lower().encode()).hexdigest()
+    # Compute S3 key (owner = sha256(email) for self, or 'team-{id}' for team graph)
     bucket = os.environ.get("GRAQLE_GRAPHS_BUCKET", "graqle-graphs-eu")
-    s3_key = f"graphs/{email_hash}/{project}/graqle.json"
+    s3_key = f"graphs/{owner}/{project}/graqle.json"
 
     try:
         import boto3
@@ -126,7 +128,9 @@ async def _load_project_graph(request: Request, project: str):
 # Project name validation: reject path traversal, separators, and control chars.
 # Project names are user-supplied (``x-project-name`` header) and are interpolated
 # into an S3 key in :func:`_load_project_graph` — see SF-07 sentinel MAJOR #1.
-_PROJECT_NAME_RE = re.compile(r"\A[A-Za-z0-9._\- ]{1,128}\Z")
+# SF-TRACKB-1: the (?=.*[A-Za-z0-9]) lookahead also rejects an all-dots segment
+# ('.', '..') which would escape the tenant prefix as a path component.
+_PROJECT_NAME_RE = re.compile(r"\A(?=.*[A-Za-z0-9])[A-Za-z0-9._\- ]{1,128}\Z")
 
 
 async def _resolve_graph_for_request(request: Request):
@@ -1039,6 +1043,115 @@ async def cloud_disconnect():
     from graqle.cloud.credentials import clear_credentials
     clear_credentials()
     return {"success": True}
+
+
+# ---------- Team graph (Track B, B2.3) ----------
+
+
+@router.get("/team/membership")
+async def team_membership(request: Request):
+    """Return the caller's active team membership, or null (Track B).
+
+    Identity comes ONLY from a verified Cognito token (A1b). The Studio UI uses
+    this to decide whether to offer the "team graph" scope and the Share action.
+    """
+    from graqle.studio.auth import tenant_hash, verified_email_from_request
+
+    email = verified_email_from_request(request)
+    if not email:
+        return JSONResponse({"team": None, "error": "Not authenticated"}, status_code=401)
+
+    try:
+        from graqle.cloud.team_registry import TeamRegistry
+
+        membership = TeamRegistry().resolve_team_for_member(tenant_hash(email))
+    except Exception as exc:  # noqa: BLE001 - registry unavailable → no team (fail closed)
+        logger.warning("team membership lookup failed: %s", type(exc).__name__)
+        return {"team": None}
+
+    if membership is None:
+        return {"team": None}
+    return {
+        "team": {
+            "team_id": membership.team_id,
+            "role": membership.role,
+            "can_teach": membership.can_teach,
+        }
+    }
+
+
+@router.post("/team/share")
+async def team_share_endpoint(request: Request):
+    """Publish the caller's project graph as the SHARED team graph (Track B).
+
+    Body: ``{"project": "<name>"}``. The caller's identity is the VERIFIED email
+    (A1b); authorisation (must be an active team member with a teach role) and the
+    team-prefix routing are enforced by ``gateway.share_graph_to_team`` /
+    ``TeamRegistry`` — a forged identity or a viewer cannot write. The graph
+    published is the one already loaded for this caller+project from their OWN
+    per-user S3 prefix (so they can only share what they themselves own).
+    """
+    import os
+
+    from graqle.studio.auth import tenant_hash, verified_email_from_request
+
+    email = verified_email_from_request(request)
+    if not email:
+        return JSONResponse({"error": "Not authenticated"}, status_code=401)
+
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001
+        body = {}
+    project = body.get("project") if isinstance(body, dict) else None
+    if not isinstance(project, str) or not _PROJECT_NAME_RE.match(project):
+        return JSONResponse({"error": "invalid or missing project"}, status_code=400)
+
+    member = tenant_hash(email)
+
+    # Resolve the team for this verified member (fail closed → 403 if none).
+    try:
+        from graqle.cloud.team_registry import TeamRegistry
+
+        registry = TeamRegistry()
+        membership = registry.resolve_team_for_member(member)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("team/share registry error: %s", type(exc).__name__)
+        return JSONResponse({"error": "team registry unavailable"}, status_code=503)
+
+    if membership is None:
+        return JSONResponse({"error": "not a team member"}, status_code=403)
+
+    # Load the caller's OWN graph for this project from S3 (their per-user prefix).
+    try:
+        import boto3
+
+        bucket = os.environ.get("GRAQLE_GRAPHS_BUCKET", "graqle-graphs-eu")
+        s3 = boto3.client("s3", region_name=os.environ.get("AWS_REGION", "eu-central-1"))
+        key = f"graphs/{member}/{project}/graqle.json"
+        graph_data = s3.get_object(Bucket=bucket, Key=key)["Body"].read().decode("utf-8")
+    except Exception as exc:  # noqa: BLE001
+        logger.info("team/share: caller has no graph at their prefix: %s", type(exc).__name__)
+        return JSONResponse({"error": "no graph to share for this project"}, status_code=404)
+
+    from graqle.cloud.gateway import CloudGateway
+
+    gateway = CloudGateway(api_key="studio")  # connected marker; S3 write uses Lambda role
+    result = gateway.share_graph_to_team(
+        graph_data=graph_data,
+        member_hash=member,
+        team_id=membership.team_id,
+        project=project,
+        registry=registry,
+    )
+
+    if result.get("status") == "shared":
+        return {"status": "shared", "team_id": membership.team_id, "project": project}
+    if result.get("code") == "FORBIDDEN":
+        return JSONResponse({"error": "not permitted to share (need teach role)"}, status_code=403)
+    return JSONResponse(
+        {"error": result.get("error", "share failed")}, status_code=502
+    )
 
 
 # ---------- Settings ----------

--- a/tests/test_cli/test_team_share.py
+++ b/tests/test_cli/test_team_share.py
@@ -1,0 +1,136 @@
+# V-TRACKB-NATIVE-004: new test file via native Write (S-010).
+"""Tests for `graq team share` (Track B B1.3) — publish local graph to the team."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from graqle.cli.commands.team import team_app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def repo_with_graph(tmp_path: Path) -> Path:
+    (tmp_path / "graqle.json").write_text('{"nodes":[{"id":"n1"}],"links":[]}', encoding="utf-8")
+    return tmp_path
+
+
+def _creds(email="dev@acme.com", api_key="grq_test"):
+    c = MagicMock()
+    c.email = email
+    c.api_key = api_key
+    return c
+
+
+def _team(configured=True, team_id="team-acme", team_name="Acme"):
+    cfg = MagicMock()
+    cfg.is_configured = configured
+    cfg.team_id = team_id
+    cfg.team_name = team_name
+    return cfg
+
+
+def _patch(gate=True, creds=None, team=None, gateway_result=None):
+    """Patch the share command's collaborators."""
+    creds = creds if creds is not None else _creds()
+    team = team if team is not None else _team()
+    gw = MagicMock()
+    gw.share_graph_to_team.return_value = gateway_result or {
+        "status": "shared", "team_id": team.team_id
+    }
+    return (
+        patch("graqle.cli.commands.team._check_team_gate", return_value=gate),
+        patch("graqle.cloud.credentials.load_credentials", return_value=creds),
+        patch("graqle.cloud.team.load_team_config", return_value=team),
+        patch("graqle.cloud.gateway.CloudGateway", return_value=gw),
+        gw,
+    )
+
+
+def test_share_success(repo_with_graph):
+    p_gate, p_creds, p_team, p_gw, gw = _patch()
+    with p_gate, p_creds, p_team, p_gw:
+        res = runner.invoke(
+            team_app, ["share", "--root", str(repo_with_graph), "--project", "Brand"]
+        )
+    assert res.exit_code == 0
+    assert "shared with your team" in res.stdout.lower()
+    # the gateway was called with the team id + project + a member hash (64 hex)
+    kwargs = gw.share_graph_to_team.call_args.kwargs
+    assert kwargs["team_id"] == "team-acme"
+    assert kwargs["project"] == "Brand"
+    assert len(kwargs["member_hash"]) == 64
+
+
+def test_share_defaults_project_to_repo_folder(repo_with_graph):
+    p_gate, p_creds, p_team, p_gw, gw = _patch()
+    with p_gate, p_creds, p_team, p_gw:
+        res = runner.invoke(team_app, ["share", "--root", str(repo_with_graph)])
+    assert res.exit_code == 0
+    assert gw.share_graph_to_team.call_args.kwargs["project"] == repo_with_graph.name
+
+
+def test_share_blocked_by_plan_gate(repo_with_graph):
+    p_gate, p_creds, p_team, p_gw, _ = _patch(gate=False)
+    with p_gate, p_creds, p_team, p_gw:
+        res = runner.invoke(team_app, ["share", "--root", str(repo_with_graph)])
+    assert res.exit_code == 1
+
+
+def test_share_no_team_configured(repo_with_graph):
+    p_gate, p_creds, p_team, p_gw, _ = _patch(team=_team(configured=False))
+    with p_gate, p_creds, p_team, p_gw:
+        res = runner.invoke(team_app, ["share", "--root", str(repo_with_graph)])
+    assert res.exit_code == 1
+    assert "no team configured" in res.stdout.lower()
+
+
+def test_share_not_logged_in(repo_with_graph):
+    p_gate, p_creds, p_team, p_gw, _ = _patch(creds=_creds(email=""))
+    with p_gate, p_creds, p_team, p_gw:
+        res = runner.invoke(team_app, ["share", "--root", str(repo_with_graph)])
+    assert res.exit_code == 1
+    assert "not logged in" in res.stdout.lower()
+
+
+def test_share_no_graph_file(tmp_path: Path):
+    p_gate, p_creds, p_team, p_gw, _ = _patch()
+    with p_gate, p_creds, p_team, p_gw:
+        res = runner.invoke(team_app, ["share", "--root", str(tmp_path)])
+    assert res.exit_code == 1
+    assert "no graqle.json" in res.stdout.lower()
+
+
+def test_share_forbidden(repo_with_graph):
+    p_gate, p_creds, p_team, p_gw, _ = _patch(
+        gateway_result={"status": "forbidden", "code": "FORBIDDEN", "error": "not permitted"}
+    )
+    with p_gate, p_creds, p_team, p_gw:
+        res = runner.invoke(team_app, ["share", "--root", str(repo_with_graph)])
+    assert res.exit_code == 1
+    assert "not permitted to share" in res.stdout.lower()
+
+
+def test_share_not_connected(repo_with_graph):
+    p_gate, p_creds, p_team, p_gw, _ = _patch(
+        gateway_result={"status": "error", "code": "NOT_CONNECTED"}
+    )
+    with p_gate, p_creds, p_team, p_gw:
+        res = runner.invoke(team_app, ["share", "--root", str(repo_with_graph)])
+    assert res.exit_code == 1
+    assert "not connected" in res.stdout.lower()
+
+
+def test_share_generic_failure(repo_with_graph):
+    p_gate, p_creds, p_team, p_gw, _ = _patch(
+        gateway_result={"status": "failed", "error": "s3 exploded"}
+    )
+    with p_gate, p_creds, p_team, p_gw:
+        res = runner.invoke(team_app, ["share", "--root", str(repo_with_graph)])
+    assert res.exit_code == 1
+    assert "share failed" in res.stdout.lower()

--- a/tests/test_cloud/test_gateway.py
+++ b/tests/test_cloud/test_gateway.py
@@ -55,11 +55,10 @@ class TestCloudGateway:
         assert result.get("phase") == "foundation"
         assert "delta" in result
 
-    def test_register_team_foundation(self):
-        gw = CloudGateway(api_key="grq_test123")
+    def test_register_team_not_connected(self):
+        gw = CloudGateway()
         result = gw.register_team("My Team", "owner@test.com")
-        assert result.get("phase") == "foundation"
-        assert "team-my-team" in result.get("team_id", "")
+        assert result.get("code") == "NOT_CONNECTED"
 
     def test_observability_foundation(self):
         gw = CloudGateway(api_key="grq_test123")
@@ -112,3 +111,169 @@ class TestCloudValueProps:
             assert len(prop["features"]) > 0
             assert "min_plan" in prop
             assert "price" in prop
+
+
+# ───────────────────────────── Track B (B2.1) ──────────────────────────────
+# Team-aware upload_graph + the explicit share_graph_to_team RBAC gate.
+
+import hashlib
+from unittest.mock import MagicMock, patch
+
+from graqle.cloud.team_registry import ForbiddenError
+
+
+def _put_keys(mock_s3):
+    """Return the list of S3 Keys that were put_object'd."""
+    return [c.kwargs["Key"] for c in mock_s3.put_object.call_args_list]
+
+
+class TestTeamAwareUpload:
+    def test_user_path_is_byte_identical_when_no_team(self):
+        gw = CloudGateway(api_key="grq_test123")
+        mock_s3 = MagicMock()
+        with patch("boto3.client", return_value=mock_s3):
+            res = gw.upload_graph('{"nodes":[]}', "dev@acme.com", "proj")
+        assert res["status"] == "uploaded"
+        eh = hashlib.sha256(b"dev@acme.com").hexdigest()
+        assert res["s3_prefix"] == f"graphs/{eh}/proj"
+        assert _put_keys(mock_s3) == [f"graphs/{eh}/proj/graqle.json"]
+
+    def test_team_id_routes_to_team_prefix(self):
+        gw = CloudGateway(api_key="grq_test123")
+        mock_s3 = MagicMock()
+        with patch("boto3.client", return_value=mock_s3):
+            res = gw.upload_graph('{"nodes":[]}', "dev@acme.com", "proj",
+                                  team_id="team-acme")
+        assert res["status"] == "uploaded"
+        assert res["s3_prefix"] == "graphs/team-acme/proj"
+        # email is NOT in the key on the team path
+        assert _put_keys(mock_s3) == ["graphs/team-acme/proj/graqle.json"]
+
+    def test_invalid_team_id_is_rejected_before_any_write(self):
+        gw = CloudGateway(api_key="grq_test123")
+        mock_s3 = MagicMock()
+        with patch("boto3.client", return_value=mock_s3):
+            res = gw.upload_graph('{"nodes":[]}', "dev@acme.com", "proj",
+                                  team_id="../../etc")
+        assert res["status"] == "failed"
+        mock_s3.put_object.assert_not_called()
+
+    def test_upload_not_connected(self):
+        gw = CloudGateway()  # no key
+        res = gw.upload_graph("{}", "a@b.co", "proj", team_id="team-acme")
+        assert res.get("code") == "NOT_CONNECTED"
+
+    def test_traversal_project_is_rejected_before_any_write(self):
+        # Sentinel SF-TRACKB-1: a path-traversal project must be rejected at the
+        # gateway boundary (defence-in-depth, not only the HTTP layer).
+        gw = CloudGateway(api_key="grq_test123")
+        mock_s3 = MagicMock()
+        with patch("boto3.client", return_value=mock_s3):
+            for bad in ["../../etc", "a/b", "x\\y", "..", "p\nq"]:
+                res = gw.upload_graph('{"nodes":[]}', "dev@acme.com", bad)
+                assert res["status"] == "failed", bad
+        mock_s3.put_object.assert_not_called()
+
+
+class _FakeReg:
+    """Registry double that grants/denies a single member_hash."""
+
+    def __init__(self, allow_hash=None):
+        self.allow = allow_hash
+
+    def assert_can_write(self, mh, team_id):
+        if mh != self.allow:
+            raise ForbiddenError("not permitted")
+        return MagicMock(can_teach=True)
+
+
+class TestShareGraphToTeam:
+    def test_member_can_share_routes_to_team_prefix(self):
+        gw = CloudGateway(api_key="grq_test123")
+        mh = hashlib.sha256(b"dev@acme.com").hexdigest()
+        mock_s3 = MagicMock()
+        with patch("boto3.client", return_value=mock_s3):
+            res = gw.share_graph_to_team('{"nodes":[]}', mh, "team-acme", "proj",
+                                         registry=_FakeReg(allow_hash=mh))
+        assert res["status"] == "shared"
+        assert res["team_id"] == "team-acme"
+        assert _put_keys(mock_s3) == ["graphs/team-acme/proj/graqle.json"]
+
+    def test_viewer_or_outsider_is_forbidden_and_writes_nothing(self):
+        gw = CloudGateway(api_key="grq_test123")
+        outsider = hashlib.sha256(b"evil@x.com").hexdigest()
+        mock_s3 = MagicMock()
+        with patch("boto3.client", return_value=mock_s3):
+            res = gw.share_graph_to_team('{"nodes":[]}', outsider, "team-acme",
+                                         "proj", registry=_FakeReg(allow_hash="someoneelse"))
+        assert res["status"] == "forbidden" and res["code"] == "FORBIDDEN"
+        mock_s3.put_object.assert_not_called()
+
+    def test_share_not_connected(self):
+        gw = CloudGateway()
+        res = gw.share_graph_to_team("{}", "h" * 64, "team-acme", "proj",
+                                     registry=_FakeReg(allow_hash="h" * 64))
+        assert res.get("code") == "NOT_CONNECTED"
+
+    def test_registry_error_fails_closed(self):
+        from graqle.cloud.team_registry import TeamRegistryError
+        gw = CloudGateway(api_key="grq_test123")
+
+        class _BoomReg:
+            def assert_can_write(self, mh, team_id):
+                raise TeamRegistryError("registry down")
+
+        mock_s3 = MagicMock()
+        with patch("boto3.client", return_value=mock_s3):
+            res = gw.share_graph_to_team("{}", "h" * 64, "team-acme", "proj",
+                                         registry=_BoomReg())
+        assert res["status"] == "failed"
+        mock_s3.put_object.assert_not_called()
+
+
+class TestUploadBranches:
+    def test_scorecard_is_also_uploaded(self):
+        gw = CloudGateway(api_key="grq_test123")
+        mock_s3 = MagicMock()
+        with patch("boto3.client", return_value=mock_s3):
+            res = gw.upload_graph('{"nodes":[]}', "dev@acme.com", "proj",
+                                  scorecard_data='{"score":1}', team_id="team-acme")
+        assert res["status"] == "uploaded"
+        keys = _put_keys(mock_s3)
+        assert "graphs/team-acme/proj/graqle.json" in keys
+        assert "graphs/team-acme/proj/scorecard.json" in keys
+
+    def test_upload_s3_failure_returns_failed(self):
+        gw = CloudGateway(api_key="grq_test123")
+        mock_s3 = MagicMock()
+        mock_s3.put_object.side_effect = RuntimeError("s3 boom")
+        with patch("boto3.client", return_value=mock_s3):
+            res = gw.upload_graph('{"nodes":[]}', "dev@acme.com", "proj")
+        assert res["status"] == "failed" and "s3 boom" in res["error"]
+
+
+class TestRegisterTeamWired:
+    def test_register_team_creates_via_registry(self):
+        from graqle.cloud.team_registry import TeamRegistry
+        from tests.test_cloud.test_team_registry import FakeTable
+
+        gw = CloudGateway(api_key="grq_test123")
+        reg = TeamRegistry(table_resource=FakeTable())
+        res = gw.register_team("Acme Corp", "owner@acme.com", registry=reg)
+        assert res["status"] == "registered"
+        assert res["team_id"] == "team-acme-corp"
+        # the owner is now an active member in the registry
+        from graqle.cloud.team_registry import member_hash
+        m = reg.get_membership(member_hash("owner@acme.com"), "team-acme-corp")
+        assert m is not None and m.role == "owner"
+
+    def test_register_team_registry_error_surfaces_failure(self):
+        from graqle.cloud.team_registry import TeamRegistryError
+
+        class _BoomReg:
+            def register_team(self, name, email):
+                raise TeamRegistryError("bad email")
+
+        gw = CloudGateway(api_key="grq_test123")
+        res = gw.register_team("Acme", "not-an-email", registry=_BoomReg())
+        assert res["status"] == "failed" and "bad email" in res["error"]

--- a/tests/test_cloud/test_team_registry.py
+++ b/tests/test_cloud/test_team_registry.py
@@ -1,0 +1,355 @@
+# V-TRACKB-NATIVE-002: new test file via native Write (S-010).
+"""Tests for graqle.cloud.team_registry — the Track B DDB team registry.
+
+Security contract under test (carries A1b forward):
+  * resolve_team_for_member returns a team ONLY for an ACTIVE member; an unknown
+    or forged caller_hash -> None (fail closed, no team graph).
+  * Writes require can_teach (owner/admin/member); viewer is read-only (403).
+  * Admin-only ops (add/remove member) reject non-admin callers.
+  * The owner cannot be removed.
+  * team_id is validated (slug only) before it could reach an S3 key.
+
+Runs fully OFFLINE against an in-memory fake DynamoDB Table that implements just
+the surface the registry uses (get_item/put_item/update_item/delete_item/query +
+ConditionExpression attribute_not_exists). No boto3, no AWS.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from graqle.cloud import team_registry as tr
+from graqle.cloud.team_registry import (
+    ForbiddenError,
+    MemberRecord,
+    NotFoundError,
+    TeamRegistry,
+    TeamRegistryError,
+    member_hash,
+    slug_team_id,
+)
+
+
+# --------------------------------------------------------------- fake table ----
+
+class _Cond:
+    """Raised by the fake to mimic a DynamoDB conditional-check failure."""
+
+
+class FakeConditionalCheckFailed(Exception):
+    pass
+
+
+class FakeTable:
+    """Minimal in-memory DynamoDB Table double keyed by (team_id, sk)."""
+
+    def __init__(self):
+        self.items: dict[tuple[str, str], dict] = {}
+
+    def get_item(self, Key):
+        item = self.items.get((Key["team_id"], Key["sk"]))
+        return {"Item": dict(item)} if item else {}
+
+    def put_item(self, Item, ConditionExpression=None):
+        key = (Item["team_id"], Item["sk"])
+        if ConditionExpression == "attribute_not_exists(team_id)" and key in self.items:
+            raise FakeConditionalCheckFailed("exists")
+        self.items[key] = dict(Item)
+        return {}
+
+    def update_item(self, Key, UpdateExpression, ExpressionAttributeNames,
+                    ExpressionAttributeValues):
+        key = (Key["team_id"], Key["sk"])
+        item = self.items.get(key)
+        if item is None:
+            return {}
+        # Only the status-set update is used.
+        item["status"] = ExpressionAttributeValues[":a"]
+        return {}
+
+    def delete_item(self, Key):
+        self.items.pop((Key["team_id"], Key["sk"]), None)
+        return {}
+
+    def query(self, IndexName, KeyConditionExpression, ExpressionAttributeValues):
+        mh = ExpressionAttributeValues[":m"]
+        items = [
+            dict(v) for v in self.items.values()
+            if v.get("member_hash") == mh and str(v.get("sk", "")).startswith("MEMBER#")
+        ]
+        return {"Items": items}
+
+
+# Preserve the genuine helper before any patching, for the direct unit test.
+_REAL_IS_CONDITIONAL = tr._is_conditional_failure
+
+
+# Make the fake's conditional error look like DynamoDB's to the registry helper.
+# Wraps (not replaces) the real helper so genuine DDB shapes still work.
+@pytest.fixture(autouse=True)
+def _patch_conditional(monkeypatch):
+    monkeypatch.setattr(
+        tr, "_is_conditional_failure",
+        lambda exc: isinstance(exc, FakeConditionalCheckFailed)
+        or _REAL_IS_CONDITIONAL(exc),
+    )
+    yield
+
+
+@pytest.fixture
+def reg():
+    return TeamRegistry(table_resource=FakeTable())
+
+
+OWNER = "owner@acme.com"
+MEMBER = "dev@acme.com"
+VIEWER = "watch@acme.com"
+OUTSIDER = "evil@elsewhere.com"
+
+
+# --------------------------------------------------------------- helpers -------
+
+def test_member_hash_matches_auth_convention():
+    import hashlib
+    assert member_hash("Owner@Acme.com") == hashlib.sha256(b"owner@acme.com").hexdigest()
+
+
+def test_slug_team_id_is_safe():
+    assert slug_team_id("ACME  Corp!!") == "team-acme-corp"
+    assert slug_team_id("") == "team-team"
+
+
+# --------------------------------------------------------------- lifecycle -----
+
+def test_register_team_creates_owner_member(reg):
+    rec = reg.register_team("Acme", OWNER)
+    assert rec.team_id == "team-acme"
+    m = reg.get_membership(member_hash(OWNER), "team-acme")
+    assert m is not None and m.role == "owner" and m.can_admin and m.can_teach
+
+
+def test_register_team_rejects_duplicate(reg):
+    reg.register_team("Acme", OWNER)
+    with pytest.raises(TeamRegistryError):
+        reg.register_team("Acme", OWNER)
+
+
+def test_register_team_rejects_bad_email(reg):
+    with pytest.raises(TeamRegistryError):
+        reg.register_team("Acme", "not-an-email")
+
+
+def test_get_team_and_missing(reg):
+    reg.register_team("Acme", OWNER)
+    assert reg.get_team("team-acme").team_name == "Acme"
+    with pytest.raises(NotFoundError):
+        reg.get_team("team-ghost")
+
+
+# --------------------------------------------------------------- membership ----
+
+def test_owner_can_invite_and_member_can_accept(reg):
+    reg.register_team("Acme", OWNER)
+    oh = member_hash(OWNER)
+    inv = reg.add_member(oh, "team-acme", MEMBER, role="member")
+    assert inv.status == "invited"
+    mh = member_hash(MEMBER)
+    acc = reg.accept_invite(mh, "team-acme")
+    assert acc.status == "active" and acc.can_teach
+
+
+def test_non_admin_cannot_invite(reg):
+    reg.register_team("Acme", OWNER)
+    reg.add_member(member_hash(OWNER), "team-acme", MEMBER, role="member")
+    reg.accept_invite(member_hash(MEMBER), "team-acme")
+    # an active 'member' is not an admin
+    with pytest.raises(ForbiddenError):
+        reg.add_member(member_hash(MEMBER), "team-acme", VIEWER, role="viewer")
+
+
+def test_outsider_cannot_invite(reg):
+    reg.register_team("Acme", OWNER)
+    with pytest.raises(ForbiddenError):
+        reg.add_member(member_hash(OUTSIDER), "team-acme", VIEWER)
+
+
+def test_add_member_rejects_bad_role(reg):
+    reg.register_team("Acme", OWNER)
+    with pytest.raises(TeamRegistryError):
+        reg.add_member(member_hash(OWNER), "team-acme", MEMBER, role="superuser")
+
+
+def test_add_member_rejects_duplicate(reg):
+    reg.register_team("Acme", OWNER)
+    oh = member_hash(OWNER)
+    reg.add_member(oh, "team-acme", MEMBER)
+    with pytest.raises(TeamRegistryError):
+        reg.add_member(oh, "team-acme", MEMBER)
+
+
+def test_add_member_rejects_bad_email(reg):
+    reg.register_team("Acme", OWNER)
+    with pytest.raises(TeamRegistryError):
+        reg.add_member(member_hash(OWNER), "team-acme", "nope")
+
+
+def test_accept_invite_without_invitation(reg):
+    reg.register_team("Acme", OWNER)
+    with pytest.raises(NotFoundError):
+        reg.accept_invite(member_hash(OUTSIDER), "team-acme")
+
+
+def test_remove_member(reg):
+    reg.register_team("Acme", OWNER)
+    oh = member_hash(OWNER)
+    reg.add_member(oh, "team-acme", MEMBER)
+    reg.remove_member(oh, "team-acme", member_hash(MEMBER))
+    assert reg.get_membership(member_hash(MEMBER), "team-acme") is None
+
+
+def test_cannot_remove_owner(reg):
+    reg.register_team("Acme", OWNER)
+    oh = member_hash(OWNER)
+    with pytest.raises(ForbiddenError):
+        reg.remove_member(oh, "team-acme", oh)
+
+
+def test_non_admin_cannot_remove(reg):
+    reg.register_team("Acme", OWNER)
+    with pytest.raises(ForbiddenError):
+        reg.remove_member(member_hash(OUTSIDER), "team-acme", member_hash(OWNER))
+
+
+# --------------------------------------------------- resolve + write authz ----
+
+def test_resolve_team_for_active_member(reg):
+    reg.register_team("Acme", OWNER)
+    reg.add_member(member_hash(OWNER), "team-acme", MEMBER)
+    reg.accept_invite(member_hash(MEMBER), "team-acme")
+    got = reg.resolve_team_for_member(member_hash(MEMBER))
+    assert got is not None and got.team_id == "team-acme"
+
+
+def test_resolve_returns_none_for_invited_not_active(reg):
+    reg.register_team("Acme", OWNER)
+    reg.add_member(member_hash(OWNER), "team-acme", MEMBER)  # invited, not accepted
+    assert reg.resolve_team_for_member(member_hash(MEMBER)) is None
+
+
+def test_resolve_returns_none_for_outsider(reg):
+    reg.register_team("Acme", OWNER)
+    assert reg.resolve_team_for_member(member_hash(OUTSIDER)) is None
+
+
+def test_resolve_rejects_non_hash_input(reg):
+    # A forged/garbage caller (not a sha256 hex) must never resolve a team.
+    assert reg.resolve_team_for_member("victim@example.com") is None
+    assert reg.resolve_team_for_member("") is None
+
+
+def test_resolve_fails_closed_on_query_error(monkeypatch, reg):
+    def boom(**_):
+        raise RuntimeError("ddb down")
+    monkeypatch.setattr(reg.table, "query", boom)
+    assert reg.resolve_team_for_member(member_hash(OWNER)) is None
+
+
+def test_assert_can_write_allows_member_blocks_viewer(reg):
+    reg.register_team("Acme", OWNER)
+    oh = member_hash(OWNER)
+    reg.add_member(oh, "team-acme", MEMBER, role="member")
+    reg.accept_invite(member_hash(MEMBER), "team-acme")
+    reg.add_member(oh, "team-acme", VIEWER, role="viewer")
+    reg.accept_invite(member_hash(VIEWER), "team-acme")
+
+    assert reg.assert_can_write(member_hash(MEMBER), "team-acme").can_teach
+    assert reg.assert_can_write(oh, "team-acme").can_admin
+    with pytest.raises(ForbiddenError):
+        reg.assert_can_write(member_hash(VIEWER), "team-acme")
+    with pytest.raises(ForbiddenError):
+        reg.assert_can_write(member_hash(OUTSIDER), "team-acme")
+
+
+def test_get_membership_missing_returns_none(reg):
+    reg.register_team("Acme", OWNER)
+    assert reg.get_membership(member_hash(OUTSIDER), "team-acme") is None
+
+
+def test_get_item_failure_returns_none(monkeypatch, reg):
+    reg.register_team("Acme", OWNER)
+    def boom(**_):
+        raise RuntimeError("transient")
+    monkeypatch.setattr(reg.table, "get_item", boom)
+    assert reg.get_membership(member_hash(OWNER), "team-acme") is None
+
+
+def test_register_team_non_conditional_error_propagates(monkeypatch, reg):
+    def boom(**_):
+        raise RuntimeError("unexpected ddb error")
+    monkeypatch.setattr(reg.table, "put_item", boom)
+    with pytest.raises(RuntimeError):
+        reg.register_team("Acme", OWNER)
+
+
+def test_member_record_can_teach_requires_active():
+    inactive = MemberRecord("t", "h" * 64, "member", "invited", "")
+    assert not inactive.can_teach
+    active = MemberRecord("t", "h" * 64, "member", "active", "")
+    assert active.can_teach
+
+
+def test_is_conditional_failure_recognises_ddb_shapes():
+    # Direct unit test of the genuine real-DDB helper (captured before patching).
+    fn = _REAL_IS_CONDITIONAL
+
+    class ConditionalCheckFailedException(Exception):
+        pass
+
+    class Botoish(Exception):
+        def __init__(self):
+            self.response = {"Error": {"Code": "ConditionalCheckFailedException"}}
+
+    class OtherCoded(Exception):
+        def __init__(self):
+            self.response = {"Error": {"Code": "ThrottlingException"}}
+
+    assert fn(ConditionalCheckFailedException())
+    assert fn(Botoish())
+    assert not fn(RuntimeError("other"))
+    assert not fn(OtherCoded())
+
+
+def test_valid_email_rejects_non_string():
+    assert tr._valid_email(None) is None
+    assert tr._valid_email(123) is None
+
+
+def test_register_team_rejects_unsluggable_name(monkeypatch, reg):
+    # Force slug_team_id to yield something the team_id regex rejects, to cover
+    # the defensive guard in register_team.
+    monkeypatch.setattr(tr, "slug_team_id", lambda name: "BAD_ID!!")
+    with pytest.raises(TeamRegistryError):
+        reg.register_team("whatever", OWNER)
+
+
+def test_lazy_table_build_uses_boto3(monkeypatch):
+    # Cover the lazy boto3 path without a real AWS call.
+    built = {}
+
+    class _FakeTableObj:
+        pass
+
+    class _FakeResource:
+        def Table(self, name):
+            built["name"] = name
+            return _FakeTableObj()
+
+    import sys, types
+    fake_boto3 = types.ModuleType("boto3")
+    fake_boto3.resource = lambda svc, region_name=None: _FakeResource()
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+
+    r = TeamRegistry(table_name="graqle-teams", table_resource=None)
+    t = r.table
+    assert isinstance(t, _FakeTableObj)
+    assert built["name"] == "graqle-teams"

--- a/tests/test_studio/test_auth.py
+++ b/tests/test_studio/test_auth.py
@@ -359,3 +359,82 @@ def test_proxy_trust_header_read_error_is_swallowed(monkeypatch):
         headers = _H()
 
     assert auth.verified_email_from_request(_Req2()) is None
+
+
+# ───────────────────── Track B (B2.2): team-aware owner resolution ──────────
+
+class _FakeMembership:
+    def __init__(self, team_id):
+        self.team_id = team_id
+
+
+class _FakeReg:
+    """resolve_team_for_member returns a membership for one specific hash."""
+    def __init__(self, active_hash=None, team_id="team-acme", boom=False):
+        self.active_hash = active_hash
+        self.team_id = team_id
+        self.boom = boom
+
+    def resolve_team_for_member(self, mh):
+        if self.boom:
+            raise RuntimeError("registry down")
+        if mh == self.active_hash:
+            return _FakeMembership(self.team_id)
+        return None
+
+
+def _req_scoped(rsa_key, email, scope=None):
+    headers = {"authorization": f"Bearer {_mint(rsa_key, claims=_good_claims(email))}"}
+    if scope is not None:
+        headers["x-graph-scope"] = scope
+    return _Req(headers)
+
+
+def test_owner_prefix_none_when_unauthenticated():
+    assert auth.resolve_graph_owner_prefix(_Req({})) is None
+
+
+def test_owner_prefix_is_self_hash_without_scope(rsa_key):
+    req = _req_scoped(rsa_key, "dev@acme.com")
+    assert auth.resolve_graph_owner_prefix(req) == auth.tenant_hash("dev@acme.com")
+
+
+def test_owner_prefix_self_when_scope_self(rsa_key):
+    req = _req_scoped(rsa_key, "dev@acme.com", scope="self")
+    assert auth.resolve_graph_owner_prefix(req) == auth.tenant_hash("dev@acme.com")
+
+
+def test_owner_prefix_team_for_active_member(rsa_key):
+    mh = auth.tenant_hash("dev@acme.com")
+    reg = _FakeReg(active_hash=mh, team_id="team-acme")
+    req = _req_scoped(rsa_key, "dev@acme.com", scope="team")
+    assert auth.resolve_graph_owner_prefix(req, registry=reg) == "team-acme"
+
+
+def test_owner_prefix_falls_back_to_self_when_not_a_member(rsa_key):
+    # Asked for team scope but no membership → own graph (NOT denied, NOT team).
+    reg = _FakeReg(active_hash="someoneelse")
+    req = _req_scoped(rsa_key, "dev@acme.com", scope="team")
+    assert auth.resolve_graph_owner_prefix(req, registry=reg) == auth.tenant_hash("dev@acme.com")
+
+
+def test_owner_prefix_team_scope_registry_error_falls_back_to_self(rsa_key):
+    reg = _FakeReg(boom=True)
+    req = _req_scoped(rsa_key, "dev@acme.com", scope="team")
+    assert auth.resolve_graph_owner_prefix(req, registry=reg) == auth.tenant_hash("dev@acme.com")
+
+
+def test_owner_prefix_shared_alias_scope(rsa_key):
+    mh = auth.tenant_hash("dev@acme.com")
+    reg = _FakeReg(active_hash=mh)
+    req = _req_scoped(rsa_key, "dev@acme.com", scope="SHARED")  # case-insensitive alias
+    assert auth.resolve_graph_owner_prefix(req, registry=reg) == "team-acme"
+
+
+def test_wants_team_scope_header_read_error_is_false():
+    class _H:
+        def get(self, k, default=None):
+            raise RuntimeError("boom")
+    class _R:
+        headers = _H()
+    assert auth._wants_team_scope(_R()) is False

--- a/tests/test_studio/test_team_endpoints.py
+++ b/tests/test_studio/test_team_endpoints.py
@@ -1,0 +1,148 @@
+# V-TRACKB-NATIVE-005: new test file via native Write (S-010).
+"""Tests for the Track B (B2.3) studio team endpoints.
+
+GET /api/team/membership  — what team am I in (verified identity)?
+POST /api/team/share      — publish my project graph as the shared team graph.
+
+Identity is the A1b verified email; we patch verified_email_from_request to
+simulate "a valid token resolved to this email" vs "unauthenticated".
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from graqle.studio.routes.api import router
+
+
+def _make_app():
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    app.state.studio_state = {"graph": None}
+    return app
+
+
+def _membership(team_id="team-acme", role="member", can_teach=True):
+    m = MagicMock()
+    m.team_id = team_id
+    m.role = role
+    m.can_teach = can_teach
+    return m
+
+
+# ----------------------------------------------------------- /team/membership
+
+class TestMembership:
+    def test_unauthenticated_is_401(self):
+        client = TestClient(_make_app())
+        with patch("graqle.studio.auth.verified_email_from_request", return_value=None):
+            r = client.get("/api/team/membership")
+        assert r.status_code == 401
+        assert r.json()["team"] is None
+
+    def test_member_returns_team(self):
+        client = TestClient(_make_app())
+        reg = MagicMock()
+        reg.resolve_team_for_member.return_value = _membership()
+        with patch("graqle.studio.auth.verified_email_from_request", return_value="dev@acme.com"), \
+             patch("graqle.cloud.team_registry.TeamRegistry", return_value=reg):
+            r = client.get("/api/team/membership")
+        assert r.status_code == 200
+        assert r.json()["team"]["team_id"] == "team-acme"
+        assert r.json()["team"]["can_teach"] is True
+
+    def test_non_member_returns_null_team(self):
+        client = TestClient(_make_app())
+        reg = MagicMock()
+        reg.resolve_team_for_member.return_value = None
+        with patch("graqle.studio.auth.verified_email_from_request", return_value="dev@acme.com"), \
+             patch("graqle.cloud.team_registry.TeamRegistry", return_value=reg):
+            r = client.get("/api/team/membership")
+        assert r.status_code == 200
+        assert r.json()["team"] is None
+
+    def test_registry_error_fails_closed_to_no_team(self):
+        client = TestClient(_make_app())
+        reg = MagicMock()
+        reg.resolve_team_for_member.side_effect = RuntimeError("ddb down")
+        with patch("graqle.studio.auth.verified_email_from_request", return_value="dev@acme.com"), \
+             patch("graqle.cloud.team_registry.TeamRegistry", return_value=reg):
+            r = client.get("/api/team/membership")
+        assert r.status_code == 200
+        assert r.json()["team"] is None
+
+
+# ----------------------------------------------------------------- /team/share
+
+class TestShareEndpoint:
+    def test_unauthenticated_is_401(self):
+        client = TestClient(_make_app())
+        with patch("graqle.studio.auth.verified_email_from_request", return_value=None):
+            r = client.post("/api/team/share", json={"project": "proj"})
+        assert r.status_code == 401
+
+    def test_invalid_project_is_400(self):
+        client = TestClient(_make_app())
+        with patch("graqle.studio.auth.verified_email_from_request", return_value="dev@acme.com"):
+            r = client.post("/api/team/share", json={"project": "../../etc"})
+        assert r.status_code == 400
+
+    def test_non_member_is_403(self):
+        client = TestClient(_make_app())
+        reg = MagicMock()
+        reg.resolve_team_for_member.return_value = None
+        with patch("graqle.studio.auth.verified_email_from_request", return_value="dev@acme.com"), \
+             patch("graqle.cloud.team_registry.TeamRegistry", return_value=reg):
+            r = client.post("/api/team/share", json={"project": "proj"})
+        assert r.status_code == 403
+
+    def test_member_shares_successfully(self):
+        client = TestClient(_make_app())
+        reg = MagicMock()
+        reg.resolve_team_for_member.return_value = _membership()
+        mock_s3 = MagicMock()
+        mock_s3.get_object.return_value = {"Body": MagicMock(read=lambda: b'{"nodes":[]}')}
+        gw = MagicMock()
+        gw.share_graph_to_team.return_value = {"status": "shared"}
+        with patch("graqle.studio.auth.verified_email_from_request", return_value="dev@acme.com"), \
+             patch("graqle.cloud.team_registry.TeamRegistry", return_value=reg), \
+             patch("boto3.client", return_value=mock_s3), \
+             patch("graqle.cloud.gateway.CloudGateway", return_value=gw):
+            r = client.post("/api/team/share", json={"project": "proj"})
+        assert r.status_code == 200
+        assert r.json()["status"] == "shared"
+        assert r.json()["team_id"] == "team-acme"
+        # the verified member hash was passed to the gateway (64-hex)
+        kw = gw.share_graph_to_team.call_args.kwargs
+        assert len(kw["member_hash"]) == 64 and kw["team_id"] == "team-acme"
+
+    def test_no_graph_to_share_is_404(self):
+        client = TestClient(_make_app())
+        reg = MagicMock()
+        reg.resolve_team_for_member.return_value = _membership()
+        mock_s3 = MagicMock()
+        mock_s3.get_object.side_effect = Exception("NoSuchKey")
+        with patch("graqle.studio.auth.verified_email_from_request", return_value="dev@acme.com"), \
+             patch("graqle.cloud.team_registry.TeamRegistry", return_value=reg), \
+             patch("boto3.client", return_value=mock_s3):
+            r = client.post("/api/team/share", json={"project": "proj"})
+        assert r.status_code == 404
+
+    def test_gateway_forbidden_is_403(self):
+        client = TestClient(_make_app())
+        reg = MagicMock()
+        reg.resolve_team_for_member.return_value = _membership(can_teach=False, role="viewer")
+        mock_s3 = MagicMock()
+        mock_s3.get_object.return_value = {"Body": MagicMock(read=lambda: b'{"nodes":[]}')}
+        gw = MagicMock()
+        gw.share_graph_to_team.return_value = {"status": "forbidden", "code": "FORBIDDEN"}
+        with patch("graqle.studio.auth.verified_email_from_request",
+                   return_value="watch@acme.com"), \
+             patch("graqle.cloud.team_registry.TeamRegistry", return_value=reg), \
+             patch("boto3.client", return_value=mock_s3), \
+             patch("graqle.cloud.gateway.CloudGateway", return_value=gw):
+            r = client.post("/api/team/share", json={"project": "proj"})
+        assert r.status_code == 403


### PR DESCRIPTION
## Track B — Team Graph Monetization (public cherry-pick of private #186, merged)

A user's LOCAL graph becomes shared CLOUD team infrastructure — "one developer teaches the graph, the whole team benefits." Backend + API + CLI.

- **`graqle/cloud/team_registry.py`** (new) — DynamoDB `TeamRegistry`, source of truth for `team_id → members/roles`. Fail-closed RBAC, identity = `sha256(verified email)`, cross-team isolation.
- **`gateway.upload_graph(team_id=...)` + `share_graph_to_team`** — team-aware S3 path `graphs/team-{id}/{project}` + the Share RBAC gate. `team_id=None` is byte-identical to today (0 regression). `register_team` wired to the registry.
- **`studio/auth.resolve_graph_owner_prefix`** — team-aware READ (`x-graph-scope: team` → shared graph; fails safe to self).
- **`/api/team/membership` + `/api/team/share`** studio endpoints + **`graq team share`** CLI.

**Security:** `project` and `team_id` validated at the gateway boundary; `_PROJECT_NAME_RE` rejects all-dots traversal. Carries the A1b verified-identity trust model forward. Sentinel round-2 APPROVED on private #186.

**Open-core posture:** all under `graqle/cloud/*` + `graqle/studio/*` — already excluded from the Community PyPI wheel; ships in source for the proprietary Studio/Enterprise distributions only. **126 tests green**, IP-scan clean.

**Not in this PR:** B3 Studio UI (cognigraph-studio repo) + `graqle-teams` DDB table provisioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
