### PR TITLE
feat(governance): P2 — constitution for every client incl Codex (AGENTS.md), v0.72.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## 0.72.0 (2026-06-07) — [Constitution for every client: OpenAI Codex (AGENTS.md)]
+
+> The governance constitution now renders into **every supported AI client**,
+> not just Claude Code. `graq init` writes the same single-source rulebook into
+> the right instruction file per client — including **OpenAI Codex** via
+> `AGENTS.md`, which had no instruction file before. Implements ADR-222 P2.
+
+**Added**
+
+- **OpenAI Codex is now a first-class `graq init` client.** `codex` is a
+  supported IDE; `graq init` renders the full constitution into **`AGENTS.md`**
+  (Codex's project instruction file) and registers the MCP server in `.mcp.json`.
+- **Auto-detection:** a project containing `AGENTS.md` is detected as `codex`
+  (checked before the generic Claude fallback; Cursor/Windsurf markers still
+  take precedence when present).
+
+**Notes**
+
+- Cursor (`.cursorrules`) and Windsurf (`.windsurfrules`) already rendered the
+  constitution; P2 completes the set so all of Claude Code, Codex, Cursor, and
+  Windsurf get the identical rulebook from one source.
+- Writing is **append-under-marker and idempotent**: an existing `AGENTS.md` is
+  never clobbered, and re-running `graq init` does not duplicate the section.
+
+---
+
 ## 0.71.0 (2026-06-07) — [Governance constitution: a governed first run]
 
 > `graq init` now sets up a **governed development experience out of the box**.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,9 @@ tools only (every change is checked), a defined *investigate → plan → review
 apply → learn* workflow, built-in token-cost rules, and the project's known
 pitfalls baked in. One rulebook — shipped as
 [`graqle/data/constitution/`](./graqle/data/constitution/) — renders for every
-client, so editing it once keeps Claude Code, Cursor, and VS Code in sync.
+client (Claude Code → `CLAUDE.md`, OpenAI Codex → `AGENTS.md`, Cursor →
+`.cursorrules`, Windsurf → `.windsurfrules`), so editing it once keeps them all
+in sync.
 
 `gate-install` then routes every native write/edit/bash through GraQle's governance gates and adds a `permissions` backstop to `.claude/settings.json`. Plans required for risky changes. Trade-secret scanning on git commits. Path-traversal hardening on subprocess capture. CG-01 through CG-20 — all on, all auditable.
 
@@ -264,21 +266,19 @@ The EU AI Act docs are deliberately open to contribution — **corrections, tran
 
 ---
 
-## What's new in v0.71.0
+## What's new in v0.72.0
 
-**A governed first run.** `graq init` now sets up a governed development
-experience out of the box. The full GraQle rulebook — the **constitution** —
-ships as a single source of truth and is rendered into your AI tool's instruction
-file, so a brand-new user pair-programs with a disciplined senior engineer from
-the first command instead of a generic assistant.
+**One constitution, every AI client.** The governance rulebook now renders into
+every supported client from a single source — including **OpenAI Codex** via
+`AGENTS.md`, which previously had no instruction file. Run `graq init` and your
+AI tool pair-programs with a disciplined senior engineer from the first command,
+whichever tool you use.
 
-- **The constitution** ([`graqle/data/constitution/`](./graqle/data/constitution/)) — governed-tools-only rules, the 9-phase workflow, the full MCP tool inventory, token-cost rules, learned-behaviour workarounds, and a configurable (off-by-default) EU AI Act section. Modular Markdown fragments; edit once, every client stays in sync.
-- **`graq init`** assembles and renders it into `CLAUDE.md`, with a fail-safe fallback so init never breaks on a stripped wheel.
+- **The constitution** ([`graqle/data/constitution/`](./graqle/data/constitution/)) — governed-tools-only rules, the 9-phase workflow, the full MCP tool inventory, token-cost rules, learned-behaviour workarounds, and a configurable (off-by-default) EU AI Act section. Modular Markdown; edit once, every client stays in sync.
+- **Per-client rendering:** Claude Code → `CLAUDE.md`, **OpenAI Codex → `AGENTS.md`** (new), Cursor → `.cursorrules`, Windsurf → `.windsurfrules`. Append-under-marker and idempotent — an existing file is never clobbered.
 - **`graq gate-install`** adds a non-destructive `permissions` backstop to `.claude/settings.json` (deny native write/exec, allow the governed `graq_*` tools) behind the existing PreToolUse hook.
 
-> `AGENTS.md` (Codex) and `.cursorrules` / `.windsurfrules` rendering follow in the next release.
-
-→ [Full v0.71.0 changelog](./CHANGELOG.md)
+→ [Full v0.72.0 changelog](./CHANGELOG.md)
 
 ---
 

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.71.0"
+__version__ = "0.72.0"

--- a/graqle/cli/commands/init.py
+++ b/graqle/cli/commands/init.py
@@ -1209,6 +1209,7 @@ def _build_graqle_yaml(
 SUPPORTED_IDES = {
     "auto": "Auto-detect from project files",
     "claude": "Claude Code (.mcp.json + CLAUDE.md)",
+    "codex": "OpenAI Codex (.mcp.json + AGENTS.md)",
     "cursor": "Cursor (.cursor/mcp.json + .cursorrules)",
     "vscode": "VS Code (.vscode/mcp.json + .github/copilot-instructions.md)",
     "windsurf": "Windsurf (.mcp.json + .windsurfrules)",
@@ -1224,6 +1225,11 @@ def _detect_ide(root: Path) -> str:
         return "vscode"
     if (root / ".windsurfrules").exists():
         return "windsurf"
+    # Codex reads AGENTS.md as its instruction file. Detect it before the
+    # generic CLAUDE.md/.mcp.json fallback so an AGENTS.md project renders the
+    # constitution into the right file.
+    if (root / "AGENTS.md").exists():
+        return "codex"
     if (root / "CLAUDE.md").exists() or (root / ".mcp.json").exists():
         return "claude"
     # Default to claude for backward compat, but show as generic-compatible
@@ -1330,6 +1336,9 @@ def _get_instructions_path(root: Path, ide: str) -> Path:
         return root / ".github" / "copilot-instructions.md"
     elif ide == "windsurf":
         return root / ".windsurfrules"
+    elif ide == "codex":
+        # OpenAI Codex reads AGENTS.md as its project instruction file.
+        return root / "AGENTS.md"
     else:
         # claude or generic
         return root / "CLAUDE.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.71.0"
+version = "0.72.0"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_cli/test_multi_client_constitution.py
+++ b/tests/test_cli/test_multi_client_constitution.py
@@ -1,0 +1,68 @@
+"""P2 (ADR-222): the constitution renders into every supported client's
+instruction file, and OpenAI Codex (AGENTS.md) is a first-class client.
+
+Covers:
+- `codex` is registered in SUPPORTED_IDES.
+- `_get_instructions_path` maps each client to the correct file.
+- `_detect_ide` recognises an AGENTS.md project as `codex`.
+- `_write_claude_md` renders the FULL constitution (not the fallback) into
+  every client's instruction file (claude/codex/cursor/windsurf).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from graqle.cli.commands import init as init_mod
+from graqle.cli.commands.init import (
+    SUPPORTED_IDES,
+    _detect_ide,
+    _get_instructions_path,
+    _write_claude_md,
+)
+
+CLIENTS = [
+    ("claude", "CLAUDE.md"),
+    ("codex", "AGENTS.md"),
+    ("cursor", ".cursorrules"),
+    ("windsurf", ".windsurfrules"),
+]
+
+
+def test_codex_is_supported() -> None:
+    assert "codex" in SUPPORTED_IDES
+    assert "AGENTS.md" in SUPPORTED_IDES["codex"]
+
+
+@pytest.mark.parametrize("ide,filename", CLIENTS)
+def test_instructions_path_mapping(ide: str, filename: str) -> None:
+    p = _get_instructions_path(Path("/proj"), ide)
+    assert p.name == filename
+
+
+def test_detect_codex_from_agents_md(tmp_path: Path) -> None:
+    (tmp_path / "AGENTS.md").write_text("# existing", encoding="utf-8")
+    assert _detect_ide(tmp_path) == "codex"
+
+
+def test_detect_prefers_cursor_over_codex(tmp_path: Path) -> None:
+    # Cursor markers take precedence (checked first); AGENTS.md alone -> codex.
+    (tmp_path / ".cursorrules").write_text("x", encoding="utf-8")
+    (tmp_path / "AGENTS.md").write_text("x", encoding="utf-8")
+    assert _detect_ide(tmp_path) == "cursor"
+
+
+@pytest.mark.parametrize("ide,filename", CLIENTS)
+def test_full_constitution_rendered_per_client(ide: str, filename: str, tmp_path: Path) -> None:
+    written = _write_claude_md(tmp_path, ide)
+    assert written is True
+    target = _get_instructions_path(tmp_path, ide)
+    assert target.name == filename
+    text = target.read_text(encoding="utf-8")
+    # Full constitution, not the abridged fallback.
+    assert text != init_mod._FALLBACK_INSTRUCTIONS
+    assert len(text) > 8000
+    for marker in ("senior developer", "tool inventory", "Governed workflows", "eu_ai_act:"):
+        assert marker in text, f"{ide}: missing constitution section {marker!r}"


### PR DESCRIPTION
## P2 (ADR-222) — Constitution for every AI client, incl. OpenAI Codex (v0.72.0)

`graq init` now renders the governance constitution into **every** supported client from the single source.

| Client | File | |
|--------|------|---|
| Claude Code | `CLAUDE.md` | P1 |
| **OpenAI Codex** | **`AGENTS.md`** | **NEW** |
| Cursor | `.cursorrules` | already |
| Windsurf | `.windsurfrules` | already |

### Changes
- Additive +9 lines in `init.py`: `SUPPORTED_IDES` gains `codex`; `_detect_ide` detects `AGENTS.md`; `_get_instructions_path` maps `codex → AGENTS.md`. Codex MCP registration reuses `root/.mcp.json`.
- Append-under-marker + idempotent (existing `AGENTS.md` never clobbered).
- version 0.71.0 → **0.72.0**; CHANGELOG + README updated.

### Validation
- **87 tests pass, 0 regression** (11 new, parametrized across all 4 clients).
- Sentinel security pass **APPROVED, 0 BLOCKERs**; predict top-risk (append/overwrite) verified mitigated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
