### PR TITLE
feat(metrics): authentic, model-aware Cost Saved (single dated pricing source)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## 0.72.1 (2026-06-08) — [Authentic, model-aware "Cost Saved" metric]
+
+> The dashboard's **Cost Saved** figure is now a defensible number: real tokens
+> valued at the **real per-model price**, from a single dated source of truth —
+> not a hardcoded, model-agnostic flat rate.
+
+**Added**
+
+- **`graqle/pricing.py`** — the single source of truth for token pricing.
+  A dated per-model `$/1M` table (`PRICING_AS_OF`; Opus 4.x $5/$25, Sonnet
+  $3/$15, Haiku $1/$5), `cost_saved(tokens, model)` valued at the model's
+  **input** rate, a fail-safe `DEFAULT_MODEL` (Sonnet) for unknown ids, and
+  `pricing_basis()` so the UI can render the figure honestly (model + as-of date).
+
+**Changed**
+
+- **Eliminated three conflicting hardcoded cost rates** ($3/1M dashboard partial,
+  $15/1M `metrics.html`, $0.015/1K engine+dashboard). All now read
+  `pricing.cost_saved` via `MetricsEngine.get_summary()['cost_saved_usd']`.
+- **Cost is now model-aware.** `MetricsEngine.set_cost_model()` records the model
+  behind a saving (wired from reasoning), so the figure reflects the model the
+  user actually ran. At 88.2M tokens saved: $264.60 (Sonnet) / $441.00 (Opus 4.8)
+  / $88.20 (Haiku).
+
+---
+
 ## 0.72.0 (2026-06-07) — [Constitution for every client: OpenAI Codex (AGENTS.md)]
 
 > The governance constitution now renders into **every supported AI client**,

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.72.0"
+__version__ = "0.72.1"

--- a/graqle/core/graph.py
+++ b/graqle/core/graph.py
@@ -2127,6 +2127,18 @@ class Graqle:
             if not engine._session_active:
                 engine.start_session()
 
+            # Authentic cost valuation: record the model that produced this
+            # result so cost_saved is valued at the REAL per-model input price
+            # (graqle.pricing). The model id lives in result.metadata (set by the
+            # reasoning backend); fall back to the configured default model.
+            _model = None
+            if isinstance(result.metadata, dict):
+                _model = result.metadata.get("model") or result.metadata.get("backend_model")
+            if not _model:
+                _cfg = getattr(self, "config", None)
+                _model = getattr(_cfg, "default_model", None) if _cfg else None
+            engine.set_cost_model(_model)
+
             # Record the query — estimate result tokens from answer length
             result_tokens = len(result.answer) // 4  # ~4 chars per token
             engine.record_query(query, result_tokens)

--- a/graqle/metrics/dashboard.py
+++ b/graqle/metrics/dashboard.py
@@ -14,9 +14,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from graqle import pricing
 from graqle.metrics.engine import MetricsEngine
-
-_COST_PER_1K_TOKENS = 0.015  # $/1K input tokens (mid-tier LLM)
 
 
 def generate_dashboard(
@@ -194,10 +193,18 @@ def generate_dashboard(
     # Cost impact estimate
     # ------------------------------------------------------------------
     sections.append("## Cost Impact Estimate\n")
-    estimated_savings = (tokens_saved / 1000) * _COST_PER_1K_TOKENS
+    # Authentic: value tokens saved at the REAL per-model INPUT price (single
+    # source of truth, graqle.pricing) — not a hardcoded flat rate. The basis
+    # (model + as-of date) is shown so the figure is auditable.
+    cost_model = getattr(metrics, "_cost_model", None) or pricing.DEFAULT_MODEL
+    estimated_savings = pricing.cost_saved(tokens_saved, cost_model)
+    basis = pricing.pricing_basis(cost_model)
     sections.append("| Parameter | Value |")
     sections.append("|-----------|-------|")
-    sections.append(f"| Token cost rate | ${_COST_PER_1K_TOKENS}/1K input tokens |")
+    sections.append(
+        f"| Priced at | {basis['model']} input "
+        f"(${basis['input_per_1m']}/1M, as of {basis['as_of']}) |"
+    )
     sections.append(f"| Total tokens saved | {tokens_saved:,} |")
     sections.append(f"| **Estimated savings** | **${estimated_savings:,.2f}** |")
 

--- a/graqle/metrics/engine.py
+++ b/graqle/metrics/engine.py
@@ -82,6 +82,20 @@ class MetricsEngine:
         self._s3_email: str | None = None
         self._s3_project: str | None = None
 
+        # The model that produced the savings (for authentic per-model cost
+        # valuation via graqle.pricing). None → graqle.pricing.DEFAULT_MODEL.
+        # Set from the reasoning backend's model id when a query is recorded.
+        self._cost_model: str | None = None
+
+    def set_cost_model(self, model: str | None) -> None:
+        """Record the model behind the savings, for authentic cost valuation.
+
+        Idempotent and cheap; the most-recently-seen non-empty model wins. The
+        dashboard / ROI report value tokens saved at THIS model's input price.
+        """
+        if isinstance(model, str) and model.strip():
+            self._cost_model = model.strip()
+
     # ------------------------------------------------------------------
     # Recording methods
     # ------------------------------------------------------------------
@@ -270,10 +284,17 @@ class MetricsEngine:
 
     def get_summary(self) -> dict[str, Any]:
         """Return a summary dict of all tracked metrics."""
+        from graqle import pricing
+
+        _cost_model = self._cost_model or pricing.DEFAULT_MODEL
         return {
             "context_loads": self.context_loads,
             "queries": self.queries,
             "tokens_saved": self.tokens_saved,
+            # Authentic, model-aware cost of the tokens saved (single source of
+            # truth, graqle.pricing) + the basis so the UI can render it honestly.
+            "cost_saved_usd": round(pricing.cost_saved(self.tokens_saved, _cost_model), 2),
+            "cost_basis": pricing.pricing_basis(_cost_model),
             "mistakes_prevented": self.mistakes_prevented,
             "lessons_applied": self.lessons_applied,
             "safety_checks": self.safety_checks,
@@ -284,16 +305,22 @@ class MetricsEngine:
             "graph_stats": self.graph_stats,
             "graph_stats_current": self.graph_stats_current,
             "caller_stats": getattr(self, "caller_stats", {}),
+            # The model behind the savings, for authentic per-model cost valuation
+            # (graqle.pricing). None → the dashboard uses pricing.DEFAULT_MODEL.
+            "cost_model": self._cost_model,
         }
 
     def get_roi_report(self) -> str:
         """Generate a human-readable ROI report.
 
-        The report estimates cost savings using a rate of $0.015 per 1 000
-        input tokens (a typical mid-tier LLM pricing).
+        Cost savings are valued at the REAL per-model input price via
+        :mod:`graqle.pricing` (single source of truth) — not a hardcoded rate.
         """
-        cost_per_1k = 0.015
-        estimated_savings_usd = (self.tokens_saved / 1000) * cost_per_1k
+        from graqle import pricing
+
+        cost_model = self._cost_model or pricing.DEFAULT_MODEL
+        estimated_savings_usd = pricing.cost_saved(self.tokens_saved, cost_model)
+        basis = pricing.pricing_basis(cost_model)
         avg_tokens_saved_per_load = (
             self.tokens_saved // self.context_loads
             if self.context_loads
@@ -331,7 +358,8 @@ class MetricsEngine:
             f"  Block rate:           {self.safety_blocks / max(self.safety_checks, 1):.0%}",
             "",
             "  --- Estimated Cost Impact ---",
-            "  Token cost rate:      $0.015 / 1K input tokens",
+            f"  Priced at:            {basis['model']} input "
+            f"(${basis['input_per_1m']}/1M, as of {basis['as_of']})",
             f"  Estimated savings:    ${estimated_savings_usd:,.2f}",
             "",
             "=" * 60,
@@ -359,6 +387,9 @@ class MetricsEngine:
             "graph_stats": self.graph_stats,
             "graph_stats_current": self.graph_stats_current,
             "caller_stats": getattr(self, "caller_stats", {}),
+            # The model behind the savings, for authentic per-model cost valuation
+            # (graqle.pricing). None → the dashboard uses pricing.DEFAULT_MODEL.
+            "cost_model": self._cost_model,
         }
         payload = json.dumps(data, indent=2, ensure_ascii=False)
         try:

--- a/graqle/pricing.py
+++ b/graqle/pricing.py
@@ -1,0 +1,145 @@
+# V-AUTH-SAVINGS-NATIVE-001: new file via native Write (S-010).
+"""Single source of truth for LLM token pricing and cost-savings math.
+
+WHY THIS EXISTS
+---------------
+The dashboard's "Cost Saved" figure is a key marketing claim, so it must be an
+AUTHENTIC, defensible number — real tokens valued at the REAL per-model price, not
+a hardcoded flat rate. Before this module there were THREE conflicting hardcoded
+rates in the codebase ($3/1M in the live dashboard partial, $15/1M in two others)
+and the cost was model-agnostic. This module replaces all of them with one dated,
+per-model price table and one cost function.
+
+PRICING IS SOURCED AND DATED
+----------------------------
+``MODEL_PRICING`` lists published Anthropic per-million-token prices with an
+``as_of`` date. When prices change, update the table and the date — never edit a
+rate inline anywhere else. ``cost_for_tokens`` and ``cost_saved`` look prices up
+here. A model id not in the table falls back to ``DEFAULT_MODEL`` pricing (logged),
+so an unknown model degrades to a documented assumption rather than a wrong number.
+
+The dashboard should surface the model + ``PRICING_AS_OF`` so the figure is
+auditable ("$X saved, valued at <model> input pricing as of <date>").
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger("graqle.pricing")
+
+# Date the prices below were last verified against Anthropic's published pricing.
+# Bump this whenever MODEL_PRICING changes.
+PRICING_AS_OF = "2026-05-26"
+
+
+@dataclass(frozen=True)
+class ModelPrice:
+    """Published price for one model, in USD per 1,000,000 tokens."""
+
+    input_per_1m: float
+    output_per_1m: float
+
+    @property
+    def input_per_token(self) -> float:
+        return self.input_per_1m / 1_000_000.0
+
+    @property
+    def output_per_token(self) -> float:
+        return self.output_per_1m / 1_000_000.0
+
+
+# Published Anthropic pricing, $/1M tokens (input, output). Verified PRICING_AS_OF.
+# Keys are EXACT model ids (the same strings passed to the API). Keep this list as
+# the ONLY place rates live.
+MODEL_PRICING: dict[str, ModelPrice] = {
+    # Opus 4.x — $5 in / $25 out per 1M
+    "claude-opus-4-8": ModelPrice(5.00, 25.00),
+    "claude-opus-4-7": ModelPrice(5.00, 25.00),
+    "claude-opus-4-6": ModelPrice(5.00, 25.00),
+    "claude-opus-4-5": ModelPrice(5.00, 25.00),
+    # Sonnet 4.x — $3 in / $15 out per 1M
+    "claude-sonnet-4-6": ModelPrice(3.00, 15.00),
+    "claude-sonnet-4-5": ModelPrice(3.00, 15.00),
+    # Haiku 4.x — $1 in / $5 out per 1M
+    "claude-haiku-4-5": ModelPrice(1.00, 5.00),
+}
+
+# When the model behind a saving is unknown, value it at this model's price. We
+# pick the DEFAULT MODEL Graqle reasons with (Sonnet) so the headline number is
+# conservative and defensible rather than inflated.
+DEFAULT_MODEL = "claude-sonnet-4-6"
+
+
+def _normalise_model(model: str | None) -> str:
+    """Map a possibly-suffixed/blank model id to a key in MODEL_PRICING.
+
+    Accepts exact ids, an empty/None value (→ DEFAULT_MODEL), and tolerates a
+    trailing date/speed suffix (e.g. ``claude-haiku-4-5-20251001`` or
+    ``claude-opus-4-6-fast``) by longest-prefix match against known ids.
+    """
+    if not model or not isinstance(model, str):
+        return DEFAULT_MODEL
+    m = model.strip()
+    if m in MODEL_PRICING:
+        return m
+    # Longest known id that is a prefix of the supplied id wins (handles date /
+    # `-fast` suffixes without guessing a price for a truly unknown family).
+    candidates = [k for k in MODEL_PRICING if m.startswith(k)]
+    if candidates:
+        return max(candidates, key=len)
+    logger.info("pricing: unknown model %r, valuing at %s", model, DEFAULT_MODEL)
+    return DEFAULT_MODEL
+
+
+def price_for(model: str | None) -> ModelPrice:
+    """Return the :class:`ModelPrice` for a model id (DEFAULT_MODEL if unknown)."""
+    return MODEL_PRICING[_normalise_model(model)]
+
+
+def cost_for_tokens(
+    model: str | None,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+) -> float:
+    """USD cost of ``input_tokens``/``output_tokens`` at ``model``'s real price."""
+    p = price_for(model)
+    return (max(input_tokens, 0) * p.input_per_token) + (
+        max(output_tokens, 0) * p.output_per_token
+    )
+
+
+def cost_saved(tokens_saved: int, model: str | None = None) -> float:
+    """USD value of ``tokens_saved`` context tokens at ``model``'s INPUT price.
+
+    Tokens saved are tokens NOT sent to the model as input (the graph returned a
+    focused context instead of a naive full load), so they are valued at the
+    *input* rate — never the output rate. ``model`` defaults to DEFAULT_MODEL.
+    This is the one function the dashboard / CLI / reports must call.
+    """
+    return max(tokens_saved, 0) * price_for(model).input_per_token
+
+
+def pricing_basis(model: str | None = None) -> dict[str, object]:
+    """A small dict for the UI to render the basis of a cost figure honestly."""
+    key = _normalise_model(model)
+    p = MODEL_PRICING[key]
+    return {
+        "model": key,
+        "input_per_1m": p.input_per_1m,
+        "output_per_1m": p.output_per_1m,
+        "as_of": PRICING_AS_OF,
+    }
+
+
+__all__ = [
+    "PRICING_AS_OF",
+    "DEFAULT_MODEL",
+    "MODEL_PRICING",
+    "ModelPrice",
+    "price_for",
+    "cost_for_tokens",
+    "cost_saved",
+    "pricing_basis",
+]

--- a/graqle/studio/routes/api.py
+++ b/graqle/studio/routes/api.py
@@ -939,7 +939,13 @@ async def partial_metrics_cards(request: Request):
     tokens_saved = m.get("tokens_saved", 0)
     queries = m.get("queries", 0)
     context_loads = m.get("context_loads", 0)
-    savings_usd = tokens_saved * 0.000003  # ~$3 per 1M tokens (Claude Sonnet input pricing)
+    # Authentic: the summary already computes cost at the REAL per-model INPUT
+    # price (single source of truth, graqle.pricing) and exposes cost_saved_usd.
+    # Fall back to a fresh computation only if an older summary lacks the field.
+    savings_usd = m.get("cost_saved_usd")
+    if savings_usd is None:
+        from graqle import pricing
+        savings_usd = pricing.cost_saved(tokens_saved, m.get("cost_model"))
 
     return f"""
     <div class="grid-4">

--- a/graqle/studio/templates/metrics.html
+++ b/graqle/studio/templates/metrics.html
@@ -29,7 +29,10 @@
         </div>
         <div class="metric-row">
             <span>Estimated Cost Saved</span>
-            <strong x-text="'$' + ((data.tokens_saved || 0) * 0.000015).toFixed(2)"></strong>
+            <!-- Authentic: the backend computes this at the REAL per-model input
+                 price (graqle.pricing, single source of truth) and returns it as
+                 cost_saved_usd. Do NOT recompute with a hardcoded rate here. -->
+            <strong x-text="'$' + (data.cost_saved_usd != null ? data.cost_saved_usd : 0).toFixed(2)"></strong>
         </div>
     </div>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-version = "0.72.0"
+# V-AUTH-SAVINGS-NATIVE-003: native version bump (G4 config). #195 ships v0.72.0;
+# this PR (authentic Cost Saved) takes the next patch so it has its own release.
+version = "0.72.1"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_metrics/test_pricing.py
+++ b/tests/test_metrics/test_pricing.py
@@ -1,0 +1,121 @@
+# V-AUTH-SAVINGS-NATIVE-002: new test file via native Write (S-010).
+"""Tests for graqle.pricing — the authentic cost-savings source of truth."""
+
+from __future__ import annotations
+
+import pytest
+
+from graqle import pricing
+
+
+def test_known_model_prices_match_published_rates():
+    assert pricing.price_for("claude-opus-4-8").input_per_1m == 5.00
+    assert pricing.price_for("claude-opus-4-8").output_per_1m == 25.00
+    assert pricing.price_for("claude-sonnet-4-6").input_per_1m == 3.00
+    assert pricing.price_for("claude-sonnet-4-6").output_per_1m == 15.00
+    assert pricing.price_for("claude-haiku-4-5").input_per_1m == 1.00
+    assert pricing.price_for("claude-haiku-4-5").output_per_1m == 5.00
+
+
+def test_per_token_derives_from_per_million():
+    p = pricing.price_for("claude-opus-4-8")
+    assert p.input_per_token == pytest.approx(5.00 / 1_000_000)
+    assert p.output_per_token == pytest.approx(25.00 / 1_000_000)
+
+
+def test_unknown_model_falls_back_to_default_not_error():
+    # An unknown family must NOT raise and must value at DEFAULT_MODEL (Sonnet).
+    p = pricing.price_for("some-future-model-x")
+    assert p.input_per_1m == pricing.price_for(pricing.DEFAULT_MODEL).input_per_1m
+
+
+def test_none_and_blank_model_use_default():
+    assert pricing.price_for(None).input_per_1m == pricing.price_for(pricing.DEFAULT_MODEL).input_per_1m
+    assert pricing.price_for("").input_per_1m == pricing.price_for(pricing.DEFAULT_MODEL).input_per_1m
+
+
+def test_date_and_speed_suffixes_match_by_prefix():
+    # Real ids sometimes carry a date or speed suffix — value them correctly.
+    assert pricing.price_for("claude-haiku-4-5-20251001").input_per_1m == 1.00
+    assert pricing.price_for("claude-opus-4-6-fast").input_per_1m == 5.00
+
+
+def test_cost_saved_uses_input_price_of_the_real_model():
+    # 88.2M input tokens saved, valued at each model's INPUT rate.
+    saved = 88_200_000
+    assert pricing.cost_saved(saved, "claude-sonnet-4-6") == pytest.approx(264.60, abs=0.01)
+    assert pricing.cost_saved(saved, "claude-opus-4-8") == pytest.approx(441.00, abs=0.01)
+    assert pricing.cost_saved(saved, "claude-haiku-4-5") == pytest.approx(88.20, abs=0.01)
+
+
+def test_cost_saved_default_model_is_sonnet():
+    saved = 1_000_000
+    assert pricing.cost_saved(saved) == pytest.approx(3.00, abs=1e-6)
+
+
+def test_cost_saved_never_negative():
+    assert pricing.cost_saved(-5, "claude-opus-4-8") == 0.0
+
+
+def test_cost_for_tokens_input_and_output():
+    # 1M input + 1M output on Opus = $5 + $25.
+    assert pricing.cost_for_tokens("claude-opus-4-8", 1_000_000, 1_000_000) == pytest.approx(30.00)
+    # negatives clamp to 0
+    assert pricing.cost_for_tokens("claude-opus-4-8", -10, -10) == 0.0
+
+
+def test_pricing_basis_is_renderable_and_dated():
+    basis = pricing.pricing_basis("claude-opus-4-8")
+    assert basis["model"] == "claude-opus-4-8"
+    assert basis["input_per_1m"] == 5.00
+    assert basis["output_per_1m"] == 25.00
+    assert basis["as_of"] == pricing.PRICING_AS_OF
+
+
+def test_pricing_as_of_is_set():
+    assert isinstance(pricing.PRICING_AS_OF, str) and pricing.PRICING_AS_OF
+
+
+# ---- engine wiring: authentic per-model cost in the summary ----
+
+def test_summary_exposes_authentic_cost_saved(tmp_path):
+    from graqle.metrics.engine import MetricsEngine
+
+    eng = MetricsEngine(metrics_dir=tmp_path)
+    eng.tokens_saved = 88_200_000
+
+    # default (no model recorded) → Sonnet rate
+    s = eng.get_summary()
+    assert s["cost_saved_usd"] == pytest.approx(264.60, abs=0.01)
+    assert s["cost_basis"]["model"] == pricing.DEFAULT_MODEL
+    assert s["cost_model"] is None
+
+    # record the real model → cost reflects it
+    eng.set_cost_model("claude-opus-4-8")
+    s2 = eng.get_summary()
+    assert s2["cost_saved_usd"] == pytest.approx(441.00, abs=0.01)
+    assert s2["cost_basis"]["model"] == "claude-opus-4-8"
+    assert s2["cost_model"] == "claude-opus-4-8"
+
+
+def test_set_cost_model_ignores_blank(tmp_path):
+    from graqle.metrics.engine import MetricsEngine
+
+    eng = MetricsEngine(metrics_dir=tmp_path)
+    eng.set_cost_model("claude-opus-4-8")
+    eng.set_cost_model("")     # ignored
+    eng.set_cost_model(None)   # ignored
+    eng.set_cost_model("   ")  # ignored
+    assert eng._cost_model == "claude-opus-4-8"
+
+
+def test_roi_report_shows_model_basis_not_hardcoded_rate(tmp_path):
+    from graqle.metrics.engine import MetricsEngine
+
+    eng = MetricsEngine(metrics_dir=tmp_path)
+    eng.tokens_saved = 10_000_000
+    eng.set_cost_model("claude-opus-4-8")
+    report = eng.get_roi_report()
+    assert "claude-opus-4-8 input" in report
+    assert pricing.PRICING_AS_OF in report
+    assert "$0.015" not in report  # the old hardcoded rate must be gone


### PR DESCRIPTION
## Authentic, model-aware "Cost Saved" (public cherry-pick of private #187, merged)

Replaces the dashboard's hardcoded, model-agnostic "Cost Saved" rate with a defensible, model-aware one.

- **New `graqle/pricing.py`** — single dated source of truth: per-model `$/1M` table (**as of 2026-05-26**: Opus 4.x `$5/$25`, Sonnet `$3/$15`, Haiku `$1/$5`), `cost_saved(tokens, model)` at the **input** rate, `DEFAULT_MODEL` (Sonnet) fallback, prefix-match for date/`-fast` suffixes.
- Replaced **all three** hardcoded rates (`$3/1M` dashboard partial, `$15/1M` metrics.html, `$0.015/1K` engine+dashboard) → all read `pricing.cost_saved`.
- `get_summary` exposes `cost_saved_usd` + `cost_basis`; `engine.set_cost_model` wired from `core/graph.py` reasoning; UI shows model + as-of.

**Honest impact** at 88.2M tokens saved: **$264.60 (Sonnet) · $441.00 (Opus 4.8) · $88.20 (Haiku)** — one computation path, sourced + dated.

14 tests (`pricing.py` 100%), 208 green. Follow-up: the tokens-saved baseline is still flat (`_DEFAULT_TOKENS_WITHOUT=2000`) — calibrating it is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
