### PR TITLE
feat(governance): P4 — cost is observability, never a quality gate (v0.73.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## 0.73.0 (2026-06-08) — [Cost is observability, never a quality gate]
+
+> Governance and reasoning **quality are never cut for cost**. Every cost path
+> is now ADVISORY — it measures and surfaces spend (the cost-savings story) but
+> never halts a still-valuable reasoning or debate. The bounds are value-based
+> (convergence + max_rounds), never price-based. Implements ADR-222 P4.
+
+**Changed**
+
+- **Reasoning orchestrator:** the old hard cost-ceiling that halted multi-round
+  reasoning at N× budget is now a one-time **advisory** — reasoning continues to
+  natural convergence / `max_rounds`. The cost of continuing past the advisory
+  is **measured** and surfaced in result metadata (`cost_advisory_triggered`,
+  `cost_at_advisory_usd`, `continuation_cost_usd`).
+- **Multi-backend debate (opt-in):** `DebateCostGate.check_round` no longer
+  raises `BudgetExhaustedError` to stop a debate — it returns an advisory
+  boolean and records over-budget rounds (`over_budget` / `over_budget_rounds`);
+  the debate runs to `max_rounds`. `BudgetExhaustedError` is retained for
+  back-compat.
+
+**Added**
+
+- **Advisory per-session cost meter** in the MCP server: accumulates estimated
+  spend across a session and surfaces it (`session_cost_usd`) plus a one-time
+  over-budget `cost_advisory` note. It is **purely observational** — it never
+  blocks, skips, or alters a tool result, never raises, and rejects malformed
+  cost values (NaN / Infinity / negative / bool). Resets on `session_start`.
+
+**Principle**
+
+- Cost is a story to tell, not a lever to pull. No cost path can halt governance
+  or quality work. Runaway protection remains via `max_rounds` and the absolute
+  `max_llm_calls` ceiling — never via cost.
+
+---
+
 ## 0.72.2 (2026-06-08) — [Measured tokens-saved baseline]
 
 > Completes the authentic-savings story. 0.72.1 made the *dollar rate* real

--- a/README.md
+++ b/README.md
@@ -266,6 +266,26 @@ The EU AI Act docs are deliberately open to contribution — **corrections, tran
 
 ---
 
+## What's new in v0.73.0
+
+**Cost is observability, never a quality gate.** GraQle never cuts reasoning or
+debate quality to save money. Every cost path is now **advisory**: it measures
+and surfaces spend (the cost-savings story) but never halts still-valuable work.
+
+- **Reasoning** continues past budget to natural convergence / `max_rounds`; the
+  cost of continuing is measured (`continuation_cost_usd` in result metadata).
+- **Multi-backend debate** no longer stops on budget — it runs to `max_rounds`
+  and reports over-budget rounds instead.
+- **Advisory per-session cost meter** in the MCP server surfaces `session_cost_usd`
+  and a one-time over-budget note — purely observational, never blocks a tool,
+  and hardened against malformed cost values.
+- Runaway protection stays value-based (`max_rounds` + the absolute LLM-call
+  ceiling), never price-based.
+
+→ [Full v0.73.0 changelog](./CHANGELOG.md)
+
+---
+
 ## What's new in v0.72.0
 
 **One constitution, every AI client.** The governance rulebook now renders into

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.72.2"
+__version__ = "0.73.0"

--- a/graqle/intelligence/governance/debate_cost_gate.py
+++ b/graqle/intelligence/governance/debate_cost_gate.py
@@ -25,23 +25,35 @@ class BudgetExhaustedError(Exception):
 class DebateCostGate:
     """Thin governance wrapper around :class:`DebateCostBudget`.
 
-    Provides check-before-spend and record-after-spend semantics
-    for each debate round, raising :class:`BudgetExhaustedError`
-    when the decaying budget cannot cover the next round.
+    Provides check-before-spend and record-after-spend semantics for each
+    debate round.
+
+    ADR-222 P4 — cost is observability, NEVER a quality gate. As of P4 this
+    gate is ADVISORY: when the decaying budget cannot cover the next round it
+    does NOT halt the debate. Instead it records that the round ran over budget
+    (so the cost of continuing is MEASURED and visible via ``over_budget`` /
+    ``over_budget_rounds``) and allows the debate to continue to its natural
+    bound (rounds / convergence). A still-valuable debate is never cut for cost.
     """
 
     def __init__(self, budget: DebateCostBudget) -> None:
         self._budget = budget
+        # ADR-222 P4: advisory tracking — measure, never gate.
+        self._over_budget_rounds: int = 0
 
     # ── round lifecycle ──────────────────────────────────────────
 
-    def check_round(self, estimated_cost: float) -> None:
-        """Authorize the next round or raise :class:`BudgetExhaustedError`."""
+    def check_round(self, estimated_cost: float) -> bool:
+        """ADVISORY authorization (ADR-222 P4) — NEVER raises, NEVER halts.
+
+        Returns True when the round is within budget, False when it is over
+        budget. The debate proceeds regardless; the boolean + ``over_budget``
+        are observability so callers can surface the cost of continuing.
+        """
         if not self._budget.authorize_round(estimated_cost):
-            raise BudgetExhaustedError(
-                remaining_budget=self._budget._remaining,
-                round_number=self._budget._round,
-            )
+            self._over_budget_rounds += 1
+            return False
+        return True
 
     def record_and_decay(self, actual_cost: float) -> float:
         """Record spend for the current round and return remaining budget."""
@@ -62,5 +74,20 @@ class DebateCostGate:
 
     @property
     def exhausted(self) -> bool:
-        """Whether the budget is fully exhausted."""
+        """Whether the budget is fully exhausted.
+
+        ADR-222 P4: this is now an ADVISORY signal only — callers may surface it,
+        but it does NOT halt the debate (cost never gates quality).
+        """
         return self._budget.exhausted
+
+    @property
+    def over_budget(self) -> bool:
+        """ADR-222 P4: True if any round ran over budget (advisory/observability)."""
+        return self._over_budget_rounds > 0
+
+    @property
+    def over_budget_rounds(self) -> int:
+        """ADR-222 P4: count of rounds that ran over budget — the measured cost
+        of continuing past the advisory, never a gate."""
+        return self._over_budget_rounds

--- a/graqle/orchestration/debate.py
+++ b/graqle/orchestration/debate.py
@@ -124,13 +124,22 @@ class DebateOrchestrator:
         challenges: list[PanelistResponse] = []
 
         for round_idx in range(1, self._config.max_rounds + 1):
-            # ── budget guard ────────────────────────────────────
+            # ── budget advisory (ADR-222 P4) ────────────────────
+            # Cost is observability, NEVER a quality gate. We do NOT halt a
+            # still-running debate because it went over budget — that would cut
+            # quality for cost. check_round is advisory: it returns False when
+            # over budget (recorded for measurement) but the debate CONTINUES,
+            # bounded only by max_rounds (this loop). The cost of continuing is
+            # surfaced via cost_gate.over_budget_rounds.
             round_estimate = _COST_PER_PANELIST_USD * len(self._pool.panelist_names) * _PHASES_PER_ROUND
-            try:
-                self._cost_gate.check_round(round_estimate)
-            except BudgetExhaustedError:
-                logger.warning("Budget exhausted before round %d.", round_idx)
-                break
+            if not self._cost_gate.check_round(round_estimate):
+                logger.warning(
+                    "Debate round %d is over budget — CONTINUING (quality over "
+                    "cost; bounded by max_rounds, never by cost). Over-budget "
+                    "rounds so far: %d.",
+                    round_idx,
+                    self._cost_gate.over_budget_rounds,
+                )
 
             # ── Phase 1: Propose ────────────────────────────────
             propose_prompt = self._build_propose_prompt(query, context)

--- a/graqle/orchestration/orchestrator.py
+++ b/graqle/orchestration/orchestrator.py
@@ -155,6 +155,12 @@ class Orchestrator:
         rounds_completed = 0
         per_round_observations: list[list[str]] = []
         budget_exceeded = False
+        # ADR-222 P4: cost is measured, never gated. cost_advisory_emitted ensures
+        # the N x-budget advisory logs once; cost_at_advisory snapshots spend at the
+        # moment reasoning chose to continue, so we can MEASURE the cost of that
+        # decision (the extra spend the continuation incurred) and surface it.
+        cost_advisory_emitted = False
+        cost_at_advisory: float | None = None
 
         # CR-007 Fix 5: absolute LLM-call ceiling. Checked BEFORE each
         # round so the ceiling actually constrains rounds (post-round check
@@ -233,14 +239,26 @@ class Orchestrator:
                     )
                     budget_exceeded = True
 
-                # Hard ceiling — absolute safety net, never exceed this
-                if cumulative_cost >= budget_limit * hard_mult and rounds_completed >= 2:
+                # Cost is observability, NOT a governance/quality gate (ADR-222 P4).
+                # We never halt a still-converging ("brilliant") reasoning purely
+                # because it got expensive — that would cut quality for cost. The
+                # value-based bound is convergence + max_rounds (below): they stop
+                # reasoning when it stops ADDING value, not when it gets pricey.
+                # At N x budget we emit a LOUD advisory (the cost-visibility / sell
+                # story) and CONTINUE. The only true runaway guard is max_rounds.
+                if (
+                    cumulative_cost >= budget_limit * hard_mult
+                    and rounds_completed >= 2
+                    and not cost_advisory_emitted
+                ):
                     logger.warning(
-                        f"Cost hard ceiling ({hard_mult}x budget): "
-                        f"${cumulative_cost:.4f}. "
-                        f"Halting after round {rounds_completed}."
+                        f"Cost advisory ({hard_mult}x budget): "
+                        f"${cumulative_cost:.4f} at round {rounds_completed}. "
+                        f"Reasoning CONTINUES — quality over cost; bounded by "
+                        f"convergence and max_rounds, never by cost."
                     )
-                    break
+                    cost_advisory_emitted = True
+                    cost_at_advisory = cumulative_cost
 
                 # Dynamic probabilistic gate (after minimum 2 rounds)
                 if dynamic_ceiling and rounds_completed >= 2:
@@ -408,6 +426,16 @@ class Orchestrator:
             "cumulative_cost_usd": round(cumulative_cost, 6),
             "governance_stats": dict(self._gov_stats),
         }
+        # ADR-222 P4: when reasoning chose to continue past the cost advisory
+        # (a "brilliant decision" still converging), MEASURE the cost of that
+        # decision — the extra spend the continuation incurred beyond the
+        # advisory point — and surface it. Cost is reported, never gated.
+        if cost_at_advisory is not None:
+            metadata["cost_advisory_triggered"] = True
+            metadata["cost_at_advisory_usd"] = round(cost_at_advisory, 6)
+            metadata["continuation_cost_usd"] = round(
+                max(0.0, cumulative_cost - cost_at_advisory), 6
+            )
         if observer_report:
             metadata["observer_report"] = observer_report.to_dict()
             metadata["observer_summary"] = observer_report.to_summary()

--- a/graqle/plugins/mcp_dev_server.py
+++ b/graqle/plugins/mcp_dev_server.py
@@ -3403,6 +3403,12 @@ class KogniDevServer:
         # CG-01/02: Protocol enforcement state
         self._session_started: bool = False  # Set True by graq_lifecycle(session_start)
         self._plan_active: bool = False      # Set True by graq_plan
+        # ADR-222 P4: per-session ADVISORY cost meter. Pure observability — it
+        # NEVER blocks, skips, or alters any tool or governance phase. It only
+        # accumulates estimated spend and surfaces a warning once over budget,
+        # so the cost-savings story is visible without ever gating quality.
+        self._session_cost_usd: float = 0.0
+        self._cost_advisory_emitted: bool = False
         # Per-MCP-session gate bypasses for VS Code extension.
         # Set by the initialize handler when clientInfo.name == "graqle-vscode".
         # Fail-closed default: bypasses are False. Each KogniDevServer instance
@@ -4312,12 +4318,69 @@ class KogniDevServer:
         ],
     }
 
+    def _accumulate_cost_advisory(self, payload: dict) -> None:
+        """ADR-222 P4: advisory per-session cost meter. Observability only.
+
+        Accumulates any estimated spend the tool reported (``cost_usd`` /
+        ``estimated_cost_usd`` / ``total_cost_usd``) into the per-session total
+        and, the first time the session crosses ``cost.budget_per_query``,
+        attaches a one-time ``cost_advisory`` note to the payload.
+
+        Hard contract: this NEVER blocks, skips, or alters a tool result beyond
+        adding observability fields, and NEVER raises — cost is a story to tell,
+        never a governance or quality gate (see ADR-222 P4).
+        """
+        try:
+            import math
+
+            spent = 0.0
+            for key in ("cost_usd", "estimated_cost_usd", "total_cost_usd"):
+                val = payload.get(key)
+                # Reject bool (a subclass of int) and non-finite floats
+                # (NaN/Infinity) so a malformed/hostile tool result cannot
+                # poison the meter. NaN would silently disable the advisory;
+                # Infinity would pin it permanently over budget.
+                if (
+                    isinstance(val, (int, float))
+                    and not isinstance(val, bool)
+                    and math.isfinite(val)
+                    and val >= 0
+                ):
+                    spent += float(val)
+            if spent > 0:
+                self._session_cost_usd += spent
+
+            payload["session_cost_usd"] = round(self._session_cost_usd, 6)
+
+            cost_cfg = getattr(getattr(self, "_config", None), "cost", None)
+            budget = getattr(cost_cfg, "budget_per_query", None)
+            if (
+                isinstance(budget, (int, float))
+                and budget > 0
+                and self._session_cost_usd >= budget
+                and not self._cost_advisory_emitted
+            ):
+                self._cost_advisory_emitted = True
+                payload["cost_advisory"] = (
+                    f"Session spend ${self._session_cost_usd:.4f} has crossed the "
+                    f"${float(budget):.4f} budget. This is ADVISORY only — GraQle "
+                    f"never halts governance or quality work on cost."
+                )
+        except Exception as exc:  # never let the meter affect a tool result
+            logger.debug("_accumulate_cost_advisory: skipped: %s", exc)
+
     def _inject_tool_hints(self, tool_name: str, raw_response: str) -> str:
         """Inject tool_hints into handler response. Purely additive."""
         try:
             payload = json.loads(raw_response)
             if not isinstance(payload, dict):
                 return raw_response
+
+            # ADR-222 P4: advisory cost meter — purely observational, NEVER gates.
+            # Accumulate any estimated spend this tool reported and, once the
+            # session crosses budget, attach a one-time advisory note. This only
+            # ADDS a field; it never blocks, skips, or alters the tool result.
+            self._accumulate_cost_advisory(payload)
 
             # Normalize kogni_* aliases to graq_* for hint lookup
             lookup = tool_name.replace("kogni_", "graq_", 1) if tool_name.startswith("kogni_") else tool_name
@@ -7854,6 +7917,9 @@ class KogniDevServer:
 
         if event == "session_start":
             self._session_started = True  # CG-01: mark session as active
+            # ADR-222 P4: reset the per-session advisory cost meter.
+            self._session_cost_usd = 0.0
+            self._cost_advisory_emitted = False
             # Return graph stats + backend status + recent lessons
             if graph is not None:
                 stats = graph.stats

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-# V-SAVINGS-BASELINE-NATIVE-003: native version bump (G4 config). 0.72.2 =
-# measured tokens-saved baseline (graqle/metrics/baseline.py). 0.72.1 was the
-# authentic per-model $-rate; this completes the authenticity story.
-version = "0.72.2"
+# V-CR-GOV-INSTALL-P4-NATIVE: native version bump (G4 config). 0.73.0 =
+# ADR-222 P4 — cost is observability, never a quality gate (both cost paths
+# made advisory + measured). 0.72.2 was the tokens-saved-baseline release.
+version = "0.73.0"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_backends/test_error_scenarios.py
+++ b/tests/test_backends/test_error_scenarios.py
@@ -280,12 +280,19 @@ async def test_no_budget_exceeded_normal_run(sample_graph):
 
 
 @pytest.mark.asyncio
-async def test_dynamic_ceiling_respects_hard_limit(sample_graph):
-    """Dynamic ceiling never exceeds hard_ceiling_multiplier * budget."""
+async def test_cost_never_halts_reasoning(sample_graph):
+    """ADR-222 P4: cost is observability, NEVER a quality gate.
+
+    With P(continue)=1.0 and no decay, the ONLY thing that could stop reasoning
+    early is a cost cut. That cost cut was removed (the old hard_ceiling break is
+    now a loud ADVISORY that continues). So reasoning must run to max_rounds (or
+    natural convergence) and NEVER be halted on cost. When the budget is crossed,
+    the cost of the continuation decision is MEASURED and surfaced in metadata.
+    """
     backend = CountingBackend(fail_count=0, name_str="costed-mock")
     sample_graph.set_default_backend(backend)
 
-    # Tiny budget, dynamic ceiling ON, hard limit at 3x
+    # Tiny budget so the advisory triggers immediately; always-continue settings.
     config = GraqleConfig(cost=CostConfig(
         budget_per_query=0.0000001,
         dynamic_ceiling=True,
@@ -302,14 +309,18 @@ async def test_dynamic_ceiling_respects_hard_limit(sample_graph):
     orchestrator = Orchestrator()
     result = await orchestrator.run(
         graph=sample_graph,
-        query="test dynamic ceiling hard limit",
+        query="test cost never halts reasoning",
         active_node_ids=node_ids,
         max_rounds=10,
     )
 
-    # Even with P=1.0 (always continue), must stop at hard ceiling
-    assert result.rounds_completed < 10
+    # Cost must NOT have cut reasoning short: bounded only by max_rounds /
+    # convergence, never by cost.
     assert result.metadata["budget_exceeded"] is True
+    # The continuation past the cost advisory is measured, not gated.
+    if result.metadata.get("cost_advisory_triggered"):
+        assert "continuation_cost_usd" in result.metadata
+        assert result.metadata["continuation_cost_usd"] >= 0.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_debate/test_debate_governance.py
+++ b/tests/test_debate/test_debate_governance.py
@@ -119,18 +119,28 @@ class TestDebateCostBudget:
 class TestDebateCostGate:
 
     def test_check_round_passes(self):
+        # ADR-222 P4: within budget -> True, no raise, not over budget.
         gate = DebateCostGate(DebateCostBudget(initial_budget=1.0, decay_factor=_TEST_DECAY))
-        gate.check_round(0.1)  # should not raise
+        assert gate.check_round(0.1) is True
+        assert gate.over_budget is False
+        assert gate.over_budget_rounds == 0
 
-    def test_check_round_raises_when_exhausted(self):
+    def test_check_round_advisory_when_exhausted(self):
+        # ADR-222 P4: cost NEVER halts a debate. Over budget -> returns False,
+        # does NOT raise, and records the over-budget round for measurement.
         gate = DebateCostGate(DebateCostBudget(initial_budget=0.0, decay_factor=_TEST_DECAY))
-        with pytest.raises(BudgetExhaustedError):
-            gate.check_round(0.1)
+        assert gate.check_round(0.1) is False  # advisory, never raises
+        assert gate.over_budget is True
+        assert gate.over_budget_rounds == 1
 
-    def test_check_round_raises_when_over_budget(self):
+    def test_check_round_advisory_when_over_budget(self):
+        # ADR-222 P4: estimate exceeds remaining -> advisory False, no raise.
         gate = DebateCostGate(DebateCostBudget(initial_budget=0.05, decay_factor=_TEST_DECAY))
-        with pytest.raises(BudgetExhaustedError):
-            gate.check_round(0.1)
+        assert gate.check_round(0.1) is False
+        assert gate.over_budget is True
+        # repeated over-budget rounds keep accruing (measured, never gated)
+        assert gate.check_round(0.1) is False
+        assert gate.over_budget_rounds == 2
 
     def test_record_and_decay_returns_remaining(self):
         gate = DebateCostGate(DebateCostBudget(initial_budget=1.0, decay_factor=_TEST_DECAY))
@@ -157,11 +167,12 @@ class TestDebateCostGate:
         assert gate.exhausted is True
 
     def test_budget_exhausted_error_fields(self):
-        gate = DebateCostGate(DebateCostBudget(initial_budget=0.0, decay_factor=_TEST_DECAY))
-        with pytest.raises(BudgetExhaustedError) as exc_info:
-            gate.check_round(0.01)
-        assert exc_info.value.remaining_budget == pytest.approx(0.0)
-        assert exc_info.value.round_number == 0
+        # ADR-222 P4: check_round no longer raises (cost is advisory). The
+        # BudgetExhaustedError class is retained for back-compat (re-exported via
+        # semaphore.py); verify its fields directly when constructed.
+        err = BudgetExhaustedError(remaining_budget=0.0, round_number=0)
+        assert err.remaining_budget == pytest.approx(0.0)
+        assert err.round_number == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_debate/test_debate_orchestrator.py
+++ b/tests/test_debate/test_debate_orchestrator.py
@@ -141,10 +141,13 @@ class TestDebateOrchestrator:
         assert trace.rounds_completed == 5
 
     @pytest.mark.asyncio
-    async def test_budget_exhaustion_stops(self):
+    async def test_budget_does_not_halt_debate(self):
+        # ADR-222 P4: cost is advisory, NEVER a quality gate. Even with a tiny
+        # budget the debate is NOT cut short on cost — it runs to max_rounds
+        # (the value-based bound). Over-budget rounds are measured, not gated.
         orch = _make_orchestrator(max_rounds=10, budget=0.001)
         trace = await orch.run("test")
-        assert trace.rounds_completed < 10
+        assert trace.rounds_completed == 10  # cost did not halt it
 
     @pytest.mark.asyncio
     async def test_confidence_parsed_from_responses(self):

--- a/tests/test_plugins/test_p4_cost_advisory.py
+++ b/tests/test_plugins/test_p4_cost_advisory.py
@@ -1,0 +1,103 @@
+"""P4 (ADR-222): the cost meter is ADVISORY ONLY — cost is a story to tell,
+never a governance or quality gate.
+
+These tests pin the hard contract:
+- `_accumulate_cost_advisory` accumulates per-session spend and surfaces it.
+- It attaches a one-time advisory note once over budget.
+- It NEVER raises, NEVER removes/blocks payload data, and NEVER returns a
+  block/error — it only ADDS observability fields.
+- `session_start` resets the meter.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from graqle.plugins.mcp_dev_server import KogniDevServer
+
+
+def _server() -> KogniDevServer:
+    """A server instance with the cost-meter state, without full init I/O."""
+    srv = KogniDevServer.__new__(KogniDevServer)
+    srv._session_cost_usd = 0.0
+    srv._cost_advisory_emitted = False
+    # minimal config carrying a cost budget
+    srv._config = types.SimpleNamespace(
+        cost=types.SimpleNamespace(budget_per_query=0.15)
+    )
+    return srv
+
+
+def test_accumulates_cost_across_calls() -> None:
+    srv = _server()
+    p1 = {"answer": "x", "cost_usd": 0.05}
+    srv._accumulate_cost_advisory(p1)
+    assert p1["session_cost_usd"] == 0.05
+    p2 = {"answer": "y", "estimated_cost_usd": 0.04}
+    srv._accumulate_cost_advisory(p2)
+    assert p2["session_cost_usd"] == pytest.approx(0.09)
+
+
+def test_advisory_attached_once_over_budget() -> None:
+    srv = _server()
+    p1 = {"cost_usd": 0.10}
+    srv._accumulate_cost_advisory(p1)
+    assert "cost_advisory" not in p1  # under budget
+    p2 = {"cost_usd": 0.10}  # now 0.20 >= 0.15 budget
+    srv._accumulate_cost_advisory(p2)
+    assert "cost_advisory" in p2
+    assert "ADVISORY only" in p2["cost_advisory"]
+    # one-time: a later call does NOT re-attach
+    p3 = {"cost_usd": 0.10}
+    srv._accumulate_cost_advisory(p3)
+    assert "cost_advisory" not in p3
+
+
+def test_never_blocks_or_removes_payload() -> None:
+    srv = _server()
+    payload = {"answer": "important", "data": [1, 2, 3], "cost_usd": 0.99}
+    srv._accumulate_cost_advisory(payload)
+    # original content untouched; no error/block injected
+    assert payload["answer"] == "important"
+    assert payload["data"] == [1, 2, 3]
+    assert "error" not in payload
+    assert "blocked" not in payload
+    # only additive observability fields
+    assert "session_cost_usd" in payload
+
+
+def test_never_raises_on_malformed_input() -> None:
+    srv = _server()
+    # weird/missing cost fields must not raise
+    for bad in ({}, {"cost_usd": "nan-ish"}, {"cost_usd": None}, {"total_cost_usd": []}):
+        srv._accumulate_cost_advisory(bad)  # must not raise
+    # no budget config at all -> still safe
+    srv._config = types.SimpleNamespace(cost=None)
+    srv._accumulate_cost_advisory({"cost_usd": 999.0})  # no raise, no advisory crash
+
+
+def test_rejects_non_finite_and_negative_cost() -> None:
+    # Security: NaN/Infinity/negative/bool must NOT poison the meter (would
+    # silently disable or permanently pin the advisory). They are ignored.
+    srv = _server()
+    srv._accumulate_cost_advisory({"cost_usd": float("nan")})
+    assert srv._session_cost_usd == 0.0
+    srv._accumulate_cost_advisory({"cost_usd": float("inf")})
+    assert srv._session_cost_usd == 0.0
+    srv._accumulate_cost_advisory({"cost_usd": -5.0})
+    assert srv._session_cost_usd == 0.0
+    srv._accumulate_cost_advisory({"cost_usd": True})  # bool is not a cost
+    assert srv._session_cost_usd == 0.0
+    # a real value still accumulates after the poison attempts
+    srv._accumulate_cost_advisory({"cost_usd": 0.03})
+    assert srv._session_cost_usd == pytest.approx(0.03)
+
+
+def test_zero_or_no_cost_is_safe() -> None:
+    srv = _server()
+    p = {"answer": "free op"}  # no cost fields
+    srv._accumulate_cost_advisory(p)
+    assert p["session_cost_usd"] == 0.0
+    assert "cost_advisory" not in p


### PR DESCRIPTION
## P4 (ADR-222) — Cost is observability, never a quality gate (v0.73.0)

GraQle never cuts reasoning or debate quality to save money. Every cost path is now ADVISORY — it measures + surfaces spend but never halts still-valuable work.

### Changes
- **Reasoning orchestrator:** hard cost-ceiling break → one-time advisory + CONTINUE; measures `continuation_cost_usd` in metadata.
- **Multi-backend debate (opt-in):** `DebateCostGate.check_round` → advisory bool, never raises; `over_budget_rounds` for measurement; debate runs to `max_rounds`. `BudgetExhaustedError` retained for back-compat.
- **NEW advisory per-session cost meter** in the MCP server (`session_cost_usd` + one-time over-budget note): purely additive, never blocks/raises, rejects NaN/Inf/negative/bool; resets on `session_start`.

Runaway protection stays value-based (`max_rounds` + the absolute LLM-call ceiling), never price-based.

### Validation
- **145 tests pass** (new `test_p4_cost_advisory.py`; every old halt-on-cost test updated to the advisory contract).
- Sentinel: review 95%; **security APPROVED, 0 BLOCKERs** (fixed a NaN/Inf injection in the meter); `graq_predict` surfaced the 2nd (debate) cost-gate, now also advisory.
- version 0.72.2 → **0.73.0**; CHANGELOG + README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
