### PR TITLE
feat(governance): P5a — EU AI Act configurable + irreversible-latch core (v0.74.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## 0.74.0 (2026-06-08) — [EU AI Act layer: configurable + irreversible latch (core)]
+
+> The optional **EU AI Act (Reg. (EU) 2024/1689)** governance layer gains its
+> configurable, tamper-evident **irreversible-latch core**. It is **OFF by
+> default** and, in this release, **wired to nothing** — installing 0.74.0
+> changes no runtime behaviour. A later release wires the latched state into the
+> governance gate as an enforced compliance phase. Implements ADR-222 P5a.
+
+**Added**
+
+- **`graqle.compliance.eu_ai_act_latch`** — an ed25519-signed, hash-chained,
+  append-only **one-way latch** (`.graqle/eu_ai_act_latch.jsonl`). Once a project
+  records `enabled: true`, the layer cannot be silently turned off and `mode`
+  cannot be downgraded `blocking → advisory`. Upgrades are allowed; downgrades
+  are refused (`LatchDowngradeRefused`); there is intentionally no disable path.
+  - **Tamper-evident:** content edits, chain breaks, and signing-key swaps are
+    detected; the reader **fails closed** (a tamper attempt can never disable the
+    latch). `read_state()` never raises into a caller.
+  - **Audited override:** a wrongly-blocked action may proceed once via a signed,
+    logged `override` event with a justification — this records, it does not
+    downgrade the latch.
+- **`governance.eu_ai_act`** config (`graqle.yaml`): `enabled` (default `false`),
+  `mode` (`blocking`|`advisory`), `risk_class` (`high`|`limited`|`minimal`). The
+  enforced state is the latch, not this yaml — a hand-edit cannot disable it.
+
+**Framing**
+
+- The irreversible latch is a GraQle design that **supports** the Act's
+  record-keeping / traceability expectations (Art. 12 / 72). The Act does NOT
+  itself require an un-disableable switch — it is never documented as such.
+
+---
+
 ## 0.73.0 (2026-06-08) — [Cost is observability, never a quality gate]
 
 > Governance and reasoning **quality are never cut for cost**. Every cost path

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.73.0"
+__version__ = "0.74.0"

--- a/graqle/compliance/eu_ai_act_latch.py
+++ b/graqle/compliance/eu_ai_act_latch.py
@@ -1,0 +1,458 @@
+"""EU AI Act configurable + irreversible-latch core (ADR-222 P5a).
+
+This module is the **security-critical core** of GraQle's optional EU AI Act
+(Regulation (EU) 2024/1689) governance layer. It is **OFF by default** and, as
+of P5a, is **wired to nothing** — building it changes no runtime behaviour. P5b
+wires the latched state into the governance gate as an enforced phase.
+
+What it provides
+----------------
+A **one-way latch**: once a project records ``enabled: true`` for the EU AI Act
+layer, that state cannot be silently turned off, and ``mode`` cannot be
+downgraded ``blocking -> advisory``. The latch is NOT a hand-editable yaml flag
+— it is an **ed25519-signed, hash-chained, append-only record** stored under
+``.graqle/eu_ai_act_latch.jsonl``. The gate (P5b) reads the *latched* state, not
+the raw yaml; if yaml says ``enabled: false`` but the latch says ``true``, the
+latch wins and tampering is flagged.
+
+Design (ADR-222 R-B1 / R-B4 / D-1):
+- **Tamper-evident:** each event is canonicalised (RFC 8785 ``canon``) and signed
+  with a per-project ed25519 key; each event carries ``prev_hash`` forming a
+  hash chain. A broken signature or chain => the reader fails closed.
+- **One-way:** ``upgrade`` events are allowed (``advisory -> blocking``,
+  ``enabled false -> true``); ``downgrade`` is refused.
+- **Audited override (D-1):** a wrongly-blocked action may proceed ONCE via a
+  signed, logged ``override`` event carrying a justification. This is NOT a
+  downgrade — the latch stays on; it only records that one action proceeded.
+- **No silent edits, ever.** Every state transition is a signed chained event.
+
+Honest framing (ADR-222 D-3 / research §2): the irreversible latch is a GraQle
+design that **supports** the Act's record-keeping / traceability expectations
+(Art. 12 / 72). The Act does NOT itself require an un-disableable switch — never
+document it as "required by the Act".
+
+This module performs NO blocking on its own; it records and reports state. It
+never raises into a caller's hot path beyond the explicit, typed exceptions
+below, which callers (P5b) handle as fail-closed.
+
+Known residuals — addressed when P5b wires the live (multi-instance) gate
+(graq_predict 30-day forecast, ADR-222 P5a):
+- **Cross-process concurrency:** the in-process ``threading.RLock`` serializes
+  writes within ONE process only. Concurrent writers from separate processes on
+  the SAME project dir are NOT serialized — but this cannot silently corrupt
+  state: ``_verify_chain`` detects any resulting chain break and ``read_state``
+  fails closed. P5b adds real cross-process file locking (portalocker, as in
+  ``graqle/config/resolver.py``) before the latch gates a multi-instance server.
+- **File deletion:** deleting the whole ``.graqle/eu_ai_act_latch.jsonl`` resets
+  to "absent/disabled". P5b anchors the latch's existence into the tamper-
+  evidence substrate so deletion of an enabled latch is detectable.
+- **Key-permission drift / key loss:** a lost or unreadable key only blocks
+  WRITES (new transitions); reads verify off each event's embedded public key,
+  and any read failure fails closed. P5b documents key custody/rotation.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+from graqle.governance.tamper_evidence.canonicalize import canon
+
+logger = logging.getLogger("graqle.compliance.eu_ai_act_latch")
+
+# Public, stable string literals (safe to expose — ADR CLAUDE.md "SAFE TO EXPOSE").
+Mode = Literal["blocking", "advisory"]
+RiskClass = Literal["high", "limited", "minimal"]
+EventKind = Literal["enable", "upgrade", "override"]
+
+_LATCH_FILENAME = "eu_ai_act_latch.jsonl"
+_KEY_FILENAME = "eu_ai_act_latch.key"
+_GENESIS_HASH = "0" * 64
+
+# mode ordering for the one-way ratchet: advisory < blocking (blocking is stricter)
+_MODE_RANK = {"advisory": 0, "blocking": 1}
+
+
+class LatchError(Exception):
+    """Base error for latch operations."""
+
+
+class LatchTamperError(LatchError):
+    """The latch chain is broken or a signature is invalid — fail closed."""
+
+
+class LatchDowngradeRefused(LatchError):
+    """A request would weaken the latch (disable, or blocking->advisory)."""
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _b64(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _b64d(s: str) -> bytes:
+    pad = "=" * (-len(s) % 4)
+    return base64.urlsafe_b64decode(s + pad)
+
+
+@dataclass(frozen=True)
+class LatchState:
+    """The resolved, verified latch state. ``enabled=False`` means no latch."""
+
+    enabled: bool
+    mode: Mode | None
+    risk_class: RiskClass | None
+    event_count: int
+    override_count: int
+    tampered: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "mode": self.mode,
+            "risk_class": self.risk_class,
+            "event_count": self.event_count,
+            "override_count": self.override_count,
+            "tampered": self.tampered,
+        }
+
+
+class EuAiActLatch:
+    """Append-only, ed25519-signed, hash-chained EU AI Act latch.
+
+    Construct with the project root; the latch lives under ``<root>/.graqle/``.
+    All timestamps are passed in by the caller (UTC ISO-8601) so the latch is
+    deterministic and testable — never read from the clock here.
+    """
+
+    def __init__(self, root: str | Path) -> None:
+        self._root = Path(root)
+        self._dir = self._root / ".graqle"
+        self._path = self._dir / _LATCH_FILENAME
+        self._key_path = self._dir / _KEY_FILENAME
+        # P5a Sentinel MAJOR fix: serialize concurrent write transitions
+        # (enable / record_override) so a read-modify-append race cannot corrupt
+        # the chain. In-process serialization via a re-entrant lock. Writes are
+        # deliberate, infrequent operator actions (not a hot path); cross-process
+        # concurrency on the SAME project dir is out of scope for P5a and would
+        # be detected as a chain break by _verify_chain (fail-closed) rather than
+        # silently corrupting state.
+        import threading
+
+        self._write_lock = threading.RLock()
+
+    # ── key management ────────────────────────────────────────────────
+    # The latch key is a PER-PROJECT integrity seal: it proves the recorded
+    # state was not altered after the fact. It is generated on first enable and
+    # stored locally (0600). This is NOT a licence key and is not verified
+    # against any server — it secures the local chain only.
+
+    def _load_or_create_key(self) -> Ed25519PrivateKey:
+        if self._key_path.exists():
+            raw = self._key_path.read_bytes()
+            return serialization.load_pem_private_key(raw, password=None)  # type: ignore[return-value]
+        key = Ed25519PrivateKey.generate()
+        pem = key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._atomic_write_bytes(self._key_path, pem)
+        try:
+            os.chmod(self._key_path, 0o600)
+        except OSError:
+            pass  # best-effort on platforms without POSIX perms
+        return key
+
+    def _public_key(self) -> Ed25519PublicKey:
+        return self._load_or_create_key().public_key()
+
+    # ── low-level event IO ────────────────────────────────────────────
+
+    def _read_raw_events(self) -> list[dict[str, Any]]:
+        if not self._path.exists():
+            return []
+        events: list[dict[str, Any]] = []
+        for line in self._path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            events.append(json.loads(line))
+        return events
+
+    def _atomic_write_bytes(self, path: Path, data: bytes) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=path.name + ".", suffix=".tmp")
+        try:
+            with os.fdopen(fd, "wb") as f:
+                f.write(data)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp, path)
+            tmp = ""  # replaced
+        finally:
+            if tmp and os.path.exists(tmp):
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+
+    def _signed_record(
+        self,
+        priv: Ed25519PrivateKey,
+        *,
+        kind: EventKind,
+        ts: str,
+        prev_hash: str,
+        body: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Build a canonicalised, signed, chained event record."""
+        core = {
+            "kind": kind,
+            "ts": ts,
+            "prev_hash": prev_hash,
+            "body": body,
+        }
+        message = canon(core)
+        signature = priv.sign(message)
+        leaf_hash = _sha256_hex(message)
+        pub_pem = priv.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        record = dict(core)
+        record["sig"] = _b64(signature)
+        record["hash"] = leaf_hash
+        record["pub"] = _b64(pub_pem)
+        return record
+
+    def _append(self, record: dict[str, Any]) -> None:
+        self._dir.mkdir(parents=True, exist_ok=True)
+        existing = self._path.read_bytes() if self._path.exists() else b""
+        line = (json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+        self._atomic_write_bytes(self._path, existing + line)
+
+    # ── verification ──────────────────────────────────────────────────
+
+    def _verify_chain(self, events: list[dict[str, Any]]) -> None:
+        """Verify signatures + hash chain. Raise LatchTamperError on any break.
+
+        Fail-closed: any structural problem, bad signature, or chain mismatch is
+        treated as tampering.
+        """
+        prev = _GENESIS_HASH
+        pub_pem_first: bytes | None = None
+        for idx, ev in enumerate(events):
+            try:
+                kind = ev["kind"]
+                ts = ev["ts"]
+                ev_prev = ev["prev_hash"]
+                body = ev["body"]
+                sig = _b64d(ev["sig"])
+                claimed_hash = ev["hash"]
+                pub_pem = _b64d(ev["pub"])
+            except (KeyError, ValueError, TypeError) as exc:
+                raise LatchTamperError(f"latch event {idx} malformed: {exc}") from exc
+
+            # The signing key must be stable across the chain (no key swap).
+            if pub_pem_first is None:
+                pub_pem_first = pub_pem
+            elif pub_pem != pub_pem_first:
+                raise LatchTamperError(f"latch event {idx} signing key changed (key-swap attack)")
+
+            if ev_prev != prev:
+                raise LatchTamperError(
+                    f"latch event {idx} chain break: prev_hash {ev_prev!r} != {prev!r}"
+                )
+
+            core = {"kind": kind, "ts": ts, "prev_hash": ev_prev, "body": body}
+            message = canon(core)
+            if _sha256_hex(message) != claimed_hash:
+                raise LatchTamperError(f"latch event {idx} hash mismatch (content altered)")
+
+            try:
+                pub = serialization.load_pem_public_key(pub_pem)
+                pub.verify(sig, message)  # type: ignore[union-attr]
+            except (InvalidSignature, ValueError, TypeError) as exc:
+                raise LatchTamperError(f"latch event {idx} signature invalid: {exc}") from exc
+
+            prev = claimed_hash
+
+    # ── public read API ───────────────────────────────────────────────
+
+    def read_state(self) -> LatchState:
+        """Return the verified latched state. Fails closed on tamper.
+
+        If the chain is tampered, returns a LatchState with ``tampered=True`` and,
+        crucially, ``enabled=True`` IF any enable event is present in the (now
+        untrusted) log — so a tamper attempt can NEVER be used to silently turn
+        the latch off. A clean absent latch returns ``enabled=False``.
+        """
+        # SECURITY (P5a Sentinel BLOCKER fix): read_state must NEVER raise into a
+        # caller (the P5b gate) — an uncaught exception would bypass fail-closed.
+        # ANY failure (malformed JSONL, IO error, corrupt key, unexpected bug)
+        # is treated as fail-closed: tampered=True, and enabled stays True if the
+        # raw bytes show any sign the latch was ever enabled. Tampering / I/O
+        # damage can NEVER silently disable the latch.
+        try:
+            events = self._read_raw_events()
+        except Exception as exc:  # noqa: BLE001 — fail closed on ANY read failure
+            logger.warning("EU AI Act latch unreadable (%s) — failing closed.", exc)
+            return self._fail_closed_state()
+
+        if not events:
+            return LatchState(enabled=False, mode=None, risk_class=None,
+                              event_count=0, override_count=0, tampered=False)
+        try:
+            self._verify_chain(events)
+        except LatchTamperError:
+            logger.warning("EU AI Act latch FAILED verification — failing closed (tampered).")
+            return self._fail_closed_state(events)
+        except Exception as exc:  # noqa: BLE001 — any unexpected error = fail closed
+            logger.warning("EU AI Act latch verify error (%s) — failing closed.", exc)
+            return self._fail_closed_state(events)
+        try:
+            return self._resolve(events)
+        except Exception as exc:  # noqa: BLE001 — resolve must not crash the gate
+            logger.warning("EU AI Act latch resolve error (%s) — failing closed.", exc)
+            return self._fail_closed_state(events)
+
+    def _fail_closed_state(self, events: list[dict[str, Any]] | None = None) -> LatchState:
+        """Build a fail-closed LatchState. If the (untrusted) log shows any
+        enable/upgrade, the latch STAYS enabled+blocking — tamper/damage can
+        never disable it. Best-effort raw byte probe if events couldn't parse."""
+        any_enable = False
+        override_count = 0
+        n = 0
+        try:
+            if events is not None:
+                n = len(events)
+                any_enable = any(
+                    isinstance(e, dict) and e.get("kind") in ("enable", "upgrade")
+                    for e in events
+                )
+                override_count = sum(
+                    1 for e in events if isinstance(e, dict) and e.get("kind") == "override"
+                )
+            elif self._path.exists():
+                # raw probe — even unparseable bytes mentioning an enable event
+                # keep the latch closed (conservative).
+                raw = self._path.read_bytes()
+                any_enable = b'"kind":"enable"' in raw or b'"enable"' in raw or b'"upgrade"' in raw
+        except Exception:  # noqa: BLE001 — probing must never raise either
+            any_enable = True  # most conservative: assume enabled, fail closed
+        return LatchState(
+            enabled=any_enable, mode="blocking" if any_enable else None,
+            risk_class=None, event_count=n, override_count=override_count,
+            tampered=True,
+        )
+
+    def _resolve(self, events: list[dict[str, Any]]) -> LatchState:
+        """Fold verified events into the current state (one-way ratchet)."""
+        enabled = False
+        mode: Mode | None = None
+        risk_class: RiskClass | None = None
+        override_count = 0
+        for ev in events:
+            kind = ev["kind"]
+            body = ev.get("body", {})
+            if kind in ("enable", "upgrade"):
+                enabled = True
+                new_mode = body.get("mode")
+                if new_mode in _MODE_RANK:
+                    # ratchet: only ever move to a stricter-or-equal mode
+                    if mode is None or _MODE_RANK[new_mode] >= _MODE_RANK[mode]:
+                        mode = new_mode  # type: ignore[assignment]
+                rc = body.get("risk_class")
+                if rc in ("high", "limited", "minimal"):
+                    risk_class = rc  # type: ignore[assignment]
+            elif kind == "override":
+                override_count += 1
+        return LatchState(
+            enabled=enabled, mode=mode, risk_class=risk_class,
+            event_count=len(events), override_count=override_count, tampered=False,
+        )
+
+    # ── public write API (all transitions are signed chained events) ───
+
+    def enable(self, *, mode: Mode, risk_class: RiskClass, ts: str) -> LatchState:
+        """Record an enable/upgrade event. One-way: never weakens the latch.
+
+        Allowed: first enable; advisory->blocking; risk_class change; re-assert.
+        Refused (LatchDowngradeRefused): blocking->advisory.
+        (There is intentionally no 'disable' — the latch cannot be turned off.)
+        """
+        if mode not in _MODE_RANK:
+            raise LatchError(f"invalid mode {mode!r}")
+        if risk_class not in ("high", "limited", "minimal"):
+            raise LatchError(f"invalid risk_class {risk_class!r}")
+
+        with self._write_lock:
+            current = self.read_state()
+            if current.tampered:
+                raise LatchTamperError("refusing to write over a tampered latch chain")
+            if current.enabled and current.mode is not None:
+                if _MODE_RANK[mode] < _MODE_RANK[current.mode]:
+                    raise LatchDowngradeRefused(
+                        f"refusing to downgrade EU AI Act mode "
+                        f"{current.mode!r} -> {mode!r}: the latch is one-way."
+                    )
+
+            priv = self._load_or_create_key()
+            events = self._read_raw_events()
+            prev = events[-1]["hash"] if events else _GENESIS_HASH
+            kind: EventKind = "enable" if not current.enabled else "upgrade"
+            record = self._signed_record(
+                priv, kind=kind, ts=ts, prev_hash=prev,
+                body={"mode": mode, "risk_class": risk_class},
+            )
+            self._append(record)
+            return self.read_state()
+
+    def record_override(self, *, justification: str, actor: str, action: str, ts: str) -> LatchState:
+        """Record an audited per-action override (D-1).
+
+        This does NOT turn the latch off or downgrade it — it appends a signed
+        record that ONE action proceeded past a block, with a justification, for
+        the audit trail. Requires the latch to be enabled.
+        """
+        if not justification or not justification.strip():
+            raise LatchError("override requires a non-empty justification")
+        with self._write_lock:
+            current = self.read_state()
+            if current.tampered:
+                raise LatchTamperError("refusing to write over a tampered latch chain")
+            if not current.enabled:
+                raise LatchError("cannot record an override: EU AI Act latch is not enabled")
+
+            priv = self._load_or_create_key()
+            events = self._read_raw_events()
+            prev = events[-1]["hash"] if events else _GENESIS_HASH
+            record = self._signed_record(
+                priv, kind="override", ts=ts, prev_hash=prev,
+                body={
+                    "justification": justification.strip(),
+                    "actor": actor,
+                    "action": action,
+                },
+            )
+            self._append(record)
+            return self.read_state()

--- a/graqle/config/settings.py
+++ b/graqle/config/settings.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Literal
 
 import yaml
 from pydantic import BaseModel, Field, model_validator
@@ -480,6 +480,33 @@ class NamedModelConfig(BaseModel):
     api_key: str | None = None
 
 
+class EuAiActConfig(BaseModel):
+    """EU AI Act (Reg. (EU) 2024/1689) layer config — OFF by default (ADR-222 P5).
+
+    Stored in graqle.yaml under ``governance.eu_ai_act``. This config is the
+    DECLARED intent; the ENFORCED state is the tamper-evident latch recorded in
+    ``.graqle/eu_ai_act_latch.jsonl`` (see graqle.compliance.eu_ai_act_latch).
+    The gate (P5b) reads the latched state, not this yaml, so a hand-edit back to
+    ``enabled: false`` cannot silently disable an enabled latch.
+
+    Example YAML::
+
+        governance:
+          eu_ai_act:
+            enabled: false              # off by default
+            mode: blocking              # blocking | advisory
+            risk_class: high            # high | limited | minimal
+
+    HONEST FRAMING (ADR-222 D-3): the irreversible latch is a GraQle design that
+    SUPPORTS the Act's record-keeping / traceability expectations. The Act does
+    NOT itself require an un-disableable switch.
+    """
+
+    enabled: bool = False
+    mode: Literal["blocking", "advisory"] = "blocking"
+    risk_class: Literal["high", "limited", "minimal"] = "high"
+
+
 class GovernancePolicyConfig(BaseModel):
     """Governance policy thresholds — stored in graqle.yaml under 'governance:'.
 
@@ -531,6 +558,10 @@ class GovernancePolicyConfig(BaseModel):
     # signal whether the value is calibrated. See
     # graqle.compliance.article_14_gate.
     human_review_required_threshold: float = Field(default=0.75, ge=0.0, le=1.0)
+
+    # —— ADR-222 P5: EU AI Act layer (OFF by default; enforced via tamper-evident
+    # latch, not this yaml). P5a ships config + latch core; P5b wires the gate.
+    eu_ai_act: EuAiActConfig = Field(default_factory=EuAiActConfig)
 
     @model_validator(mode="after")
     def _validate_edit_enforcement_requires_plan(self) -> "GovernancePolicyConfig":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-# V-CR-GOV-INSTALL-P4-NATIVE: native version bump (G4 config). 0.73.0 =
-# ADR-222 P4 — cost is observability, never a quality gate (both cost paths
-# made advisory + measured). 0.72.2 was the tokens-saved-baseline release.
-version = "0.73.0"
+# V-CR-GOV-INSTALL-P5A-NATIVE: native version bump (G4 config). 0.74.0 =
+# ADR-222 P5a — EU AI Act configurable + irreversible-latch core (OFF by
+# default, unwired). 0.73.0 was the cost-is-observability release.
+version = "0.74.0"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_compliance/test_eu_ai_act_latch.py
+++ b/tests/test_compliance/test_eu_ai_act_latch.py
@@ -1,0 +1,233 @@
+"""P5a (ADR-222): EU AI Act irreversible-latch core tests.
+
+The latch is the security-critical heart of the optional EU AI Act layer. These
+tests pin its hard contract:
+- one-way ratchet: enable, upgrade (advisory->blocking) OK; downgrade refused.
+- the latch can never be turned off (no disable path).
+- tamper-evident: content edit / chain break / key swap -> tampered, fail closed.
+- fail-closed: a tampered chain that ever enabled stays enabled (can't disable
+  by tampering).
+- audited override records a signed event, latch stays on.
+- config defaults OFF.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from graqle.compliance.eu_ai_act_latch import (
+    EuAiActLatch,
+    LatchDowngradeRefused,
+    LatchError,
+    LatchTamperError,
+)
+
+_T0 = "2026-06-08T00:00:00Z"
+_T1 = "2026-06-08T00:01:00Z"
+_T2 = "2026-06-08T00:02:00Z"
+
+
+def _latch(tmp_path: Path) -> EuAiActLatch:
+    return EuAiActLatch(tmp_path)
+
+
+# ── happy path / ratchet ───────────────────────────────────────────────
+
+def test_absent_latch_is_disabled(tmp_path):
+    st = _latch(tmp_path).read_state()
+    assert st.enabled is False
+    assert st.mode is None
+    assert st.tampered is False
+
+
+def test_enable_then_read(tmp_path):
+    L = _latch(tmp_path)
+    st = L.enable(mode="advisory", risk_class="limited", ts=_T0)
+    assert st.enabled is True
+    assert st.mode == "advisory"
+    assert st.risk_class == "limited"
+    # re-read from disk is identical and clean
+    st2 = L.read_state()
+    assert st2.enabled is True and st2.mode == "advisory" and st2.tampered is False
+
+
+def test_upgrade_advisory_to_blocking_allowed(tmp_path):
+    L = _latch(tmp_path)
+    L.enable(mode="advisory", risk_class="limited", ts=_T0)
+    st = L.enable(mode="blocking", risk_class="high", ts=_T1)
+    assert st.mode == "blocking"
+    assert st.risk_class == "high"
+    assert st.event_count == 2
+
+
+def test_downgrade_blocking_to_advisory_refused(tmp_path):
+    L = _latch(tmp_path)
+    L.enable(mode="blocking", risk_class="high", ts=_T0)
+    with pytest.raises(LatchDowngradeRefused):
+        L.enable(mode="advisory", risk_class="high", ts=_T1)
+    # state unchanged — still blocking
+    assert L.read_state().mode == "blocking"
+
+
+def test_no_disable_path_exists():
+    # The latch API has NO method to set enabled=False — by design.
+    assert not hasattr(EuAiActLatch, "disable")
+
+
+def test_reassert_same_mode_allowed(tmp_path):
+    L = _latch(tmp_path)
+    L.enable(mode="blocking", risk_class="high", ts=_T0)
+    st = L.enable(mode="blocking", risk_class="high", ts=_T1)  # equal mode OK
+    assert st.mode == "blocking"
+    assert st.event_count == 2
+
+
+# ── override (D-1) ─────────────────────────────────────────────────────
+
+def test_override_records_and_keeps_latch_on(tmp_path):
+    L = _latch(tmp_path)
+    L.enable(mode="blocking", risk_class="high", ts=_T0)
+    st = L.record_override(
+        justification="formatting only, no model logic", actor="harish",
+        action="edit", ts=_T1,
+    )
+    assert st.override_count == 1
+    # latch is NOT downgraded by an override
+    assert st.enabled is True and st.mode == "blocking"
+
+
+def test_override_requires_justification(tmp_path):
+    L = _latch(tmp_path)
+    L.enable(mode="blocking", risk_class="high", ts=_T0)
+    with pytest.raises(LatchError):
+        L.record_override(justification="  ", actor="x", action="y", ts=_T1)
+
+
+def test_override_requires_enabled_latch(tmp_path):
+    L = _latch(tmp_path)
+    with pytest.raises(LatchError):
+        L.record_override(justification="j", actor="x", action="y", ts=_T0)
+
+
+# ── tamper evidence / fail-closed ──────────────────────────────────────
+
+def _latch_file(tmp_path: Path) -> Path:
+    return tmp_path / ".graqle" / "eu_ai_act_latch.jsonl"
+
+
+def test_content_tamper_detected_and_fails_closed(tmp_path):
+    L = _latch(tmp_path)
+    L.enable(mode="blocking", risk_class="high", ts=_T0)
+    p = _latch_file(tmp_path)
+    ev = json.loads(p.read_text().splitlines()[0])
+    ev["body"]["mode"] = "advisory"  # attempt to weaken via raw edit
+    p.write_text(json.dumps(ev) + "\n")
+    st = L.read_state()
+    assert st.tampered is True
+    # fail closed: stays enabled + blocking, the tamper cannot weaken it
+    assert st.enabled is True
+    assert st.mode == "blocking"
+
+
+def test_chain_break_detected(tmp_path):
+    L = _latch(tmp_path)
+    L.enable(mode="advisory", risk_class="limited", ts=_T0)
+    L.enable(mode="blocking", risk_class="high", ts=_T1)
+    p = _latch_file(tmp_path)
+    lines = p.read_text().splitlines()
+    # drop the first event -> second event's prev_hash no longer matches genesis
+    p.write_text(lines[1] + "\n")
+    assert L.read_state().tampered is True
+
+
+def test_key_swap_detected(tmp_path):
+    # An attacker re-signs a forged event with a DIFFERENT key. The chain
+    # requires one stable signing key, so the swap is detected.
+    L = _latch(tmp_path)
+    L.enable(mode="blocking", risk_class="high", ts=_T0)
+    # forge a second latch (different key) and append its event
+    import shutil
+    other_dir = tmp_path / "other"
+    other = EuAiActLatch(other_dir)
+    other.enable(mode="blocking", risk_class="high", ts=_T1)
+    forged = (other_dir / ".graqle" / "eu_ai_act_latch.jsonl").read_text().splitlines()[0]
+    p = _latch_file(tmp_path)
+    p.write_text(p.read_text() + forged + "\n")
+    assert L.read_state().tampered is True
+
+
+def test_write_over_tampered_chain_refused(tmp_path):
+    L = _latch(tmp_path)
+    L.enable(mode="blocking", risk_class="high", ts=_T0)
+    p = _latch_file(tmp_path)
+    ev = json.loads(p.read_text().splitlines()[0])
+    ev["hash"] = "deadbeef" * 8
+    p.write_text(json.dumps(ev) + "\n")
+    with pytest.raises(LatchTamperError):
+        L.enable(mode="blocking", risk_class="high", ts=_T1)
+
+
+# ── fail-closed on IO / corruption (P5a Sentinel BLOCKER fix) ──────────
+
+def test_read_state_never_raises_on_malformed_jsonl(tmp_path):
+    # Realistic tamper: corrupt the JSON structure but the enable event bytes
+    # remain — read_state must NOT raise and must fail closed = stay enabled.
+    L = _latch(tmp_path)
+    L.enable(mode="blocking", risk_class="high", ts=_T0)
+    p = _latch_file(tmp_path)
+    p.write_text(p.read_text() + "{ broken json with enable marker here\n")
+    st = L.read_state()  # must not raise
+    assert st.tampered is True
+    assert st.enabled is True  # was enabled -> stays on through corruption
+
+
+def test_read_state_garbage_only_is_not_falsely_enabled(tmp_path):
+    # Pure garbage with no enable evidence must NOT be reported as enabled
+    # (you cannot fake-enable the latch by writing junk).
+    L = _latch(tmp_path)
+    (tmp_path / ".graqle").mkdir(parents=True)
+    _latch_file(tmp_path).write_text("random junk no markers\n")
+    st = L.read_state()  # must not raise
+    assert st.enabled is False
+
+
+def test_read_state_fail_closed_when_key_corrupt(tmp_path):
+    L = _latch(tmp_path)
+    L.enable(mode="blocking", risk_class="high", ts=_T0)
+    # corrupt the key file — read_state must still not raise
+    (tmp_path / ".graqle" / "eu_ai_act_latch.key").write_bytes(b"not a key")
+    st = L.read_state()
+    assert st.enabled is True  # verification still works off embedded pub; clean
+    # (the embedded pub in each event verifies the chain; private key is only for writes)
+
+
+def test_empty_file_is_clean_disabled(tmp_path):
+    L = _latch(tmp_path)
+    (tmp_path / ".graqle").mkdir(parents=True)
+    _latch_file(tmp_path).write_text("")  # empty file, never enabled
+    st = L.read_state()
+    assert st.enabled is False
+    assert st.tampered is False
+
+
+# ── config defaults ────────────────────────────────────────────────────
+
+def test_config_defaults_off():
+    from graqle.config.settings import GraqleConfig
+
+    e = GraqleConfig().governance.eu_ai_act
+    assert e.enabled is False
+    assert e.mode == "blocking"
+    assert e.risk_class == "high"
+
+
+def test_config_loads_from_yaml():
+    from graqle.config.settings import GraqleConfig
+
+    c = GraqleConfig(**{"governance": {"eu_ai_act": {
+        "enabled": True, "mode": "advisory", "risk_class": "limited"}}})
+    e = c.governance.eu_ai_act
+    assert e.enabled is True and e.mode == "advisory" and e.risk_class == "limited"


### PR DESCRIPTION
## P5a (ADR-222) — EU AI Act configurable + irreversible-latch core (v0.74.0)

The optional EU AI Act (Reg. (EU) 2024/1689) layer gains its tamper-evident **irreversible-latch core**. **OFF by default + wired to nothing** — installing 0.74.0 changes no runtime behaviour. A later increment wires the latched state into the governance gate as an enforced compliance phase.

### What it adds
- **`graqle/compliance/eu_ai_act_latch.py`** — an ed25519-signed, hash-chained, append-only **one-way latch** (`.graqle/eu_ai_act_latch.jsonl`). Once `enabled: true` is recorded, the layer cannot be silently disabled and `mode` cannot be downgraded `blocking → advisory`; upgrades allowed, downgrades refused, **no disable path**. Tamper-evident (content / chain / key-swap detected) and **fails closed** — a tamper can never disable it; `read_state()` never raises. Audited per-action override (records a signed justification, never downgrades).
- **`governance.eu_ai_act`** config (`enabled` default `false`). The gate reads the **latch**, not this yaml.

### Validation
- **19 latch tests** (enable / upgrade / downgrade-refused / override / tamper / key-swap / fail-closed-on-IO / config); **198 pass, 0 regression**.
- Sentinel: pass-1 **1 BLOCKER + 2 MAJOR** → fixed; **security APPROVED, 0 BLOCKERs** on the literal code.
- version 0.73.0 → **0.74.0**; CHANGELOG updated.

The irreversible latch **supports** the Act's record-keeping / traceability expectations (Art. 12 / 72); the Act does not itself require an un-disableable switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
