### PR TITLE
compliance: establish EUR-Lex baseline (closes 4 drift issues)

### DIFF
--- a/.graqle/eur-lex-baseline.json
+++ b/.graqle/eur-lex-baseline.json
@@ -1,0 +1,30 @@
+{
+  "entries": [
+    {
+      "byte_size": 532455,
+      "fetched_at_iso": "2026-06-08T19:47:18Z",
+      "sha256": "32af4e79f6b4f803df8bd80ff7315c826c2bd033fb2232b64dd4cad347b4a114",
+      "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32019L0790"
+    },
+    {
+      "byte_size": 1530536,
+      "fetched_at_iso": "2026-06-08T19:47:18Z",
+      "sha256": "b6cbac82b1e3889b1f0bcd298b6307805ec7b82fe6e3acb671c73d0f3e7c0215",
+      "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=OJ:L_202401689"
+    },
+    {
+      "byte_size": 1264454,
+      "fetched_at_iso": "2026-06-08T19:47:18Z",
+      "sha256": "5356bcd9799e8faa9575683fe3ecb045482a017e472fca85fd62702224cf7128",
+      "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ%3AL_202401689"
+    },
+    {
+      "byte_size": 2583319,
+      "fetched_at_iso": "2026-06-08T19:47:18Z",
+      "sha256": "bba630444b3278e881066774002a1d7824308934f49ccfa203e65be43692f55e",
+      "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=OJ:L_202401689"
+    }
+  ],
+  "generated_at_iso": "2026-06-08T19:47:22Z",
+  "schema_version": "1.0"
+}


### PR DESCRIPTION
## compliance: establish EUR-Lex baseline

Resolves the recurring **"EUR-Lex drift detected"** issues.

### Root cause
The weekly drift guard (`.github/workflows/eur-lex-weekly.yml` + `graqle/compliance/eur_lex_guard.py`) compares the 4 authoritative EU-law URLs referenced under `docs/compliance/eu-ai-act/` against a committed baseline at `.graqle/eur-lex-baseline.json`. That baseline never existed in the repo, so every weekly run reported all 4 URLs as `missing_from_baseline` and filed a fresh issue.

### Fix
- Ran the documented one-time `refresh_baseline`: fetched + SHA-256-hashed the 4 URLs (AI Act OJ text x3 + Copyright Directive 2019/790), wrote `.graqle/eur-lex-baseline.json` (force-added past the `.graqle/` gitignore, as the workflow remediation prescribes).
- Drift check now: `missing_from_baseline=0`, `has_drift=False`.

### Safety
Baseline holds only public URLs + hashes + byte sizes + timestamps — no page bodies, no secrets.

Closes #197
Closes #182
Closes #171
Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)
