### PR TITLE
feat(governance): P5b — wire EU AI Act latch into gate (CG-EU-AIA, v0.75.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## 0.75.0 (2026-06-09) — [EU AI Act layer: enforced compliance phase (wired)]
+
+> The EU AI Act latch (0.74.0) is now **wired into the governance gate** as an
+> enforced, **narrow-scope, off-by-default** compliance phase (CG-EU-AIA).
+> Implements ADR-222 P5b — completing the EU AI Act layer.
+
+**Added**
+
+- **CG-EU-AIA gate phase** in the MCP server. When the tamper-evident latch
+  reads `enabled`, AIA-relevant **write** tools (`graq_edit` / `graq_write` /
+  `graq_generate` / `graq_apply` + `kogni_` aliases) pass through an Article-14
+  human-oversight check:
+  - **blocking** mode + supplied confidence below the review threshold →
+    **refused** with an envelope explaining the audited-override path;
+  - **advisory** mode → recorded + advised, never blocked;
+  - a signed `eu_aia_override_justification` argument records an audited override
+    (latch stays on) and lets that one action proceed.
+- **`graqle.compliance.eu_ai_act_latch.evaluate_gate`** — a pure, unit-tested
+  decision function (the enforcement logic, testable without the server).
+
+**Scope & safety (deliberate)**
+
+- **Reads, planning, reasoning, and lifecycle tools are never gated** — only
+  AIA-relevant writes, only when the latch is on.
+- The phase is **fail-safe for usability**: if it cannot evaluate, it allows
+  (never blocks routine work); the latch itself remains fail-closed for tamper.
+- It is **light-touch by design** — a compliance *traceability* aid (Art. 12/72
+  support), not a hard wall and not a substitute for human compliance judgement.
+- **Off by default**; no new MCP tool; 0 regression.
+
+---
+
 ## 0.74.0 (2026-06-08) — [EU AI Act layer: configurable + irreversible latch (core)]
 
 > The optional **EU AI Act (Reg. (EU) 2024/1689)** governance layer gains its

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.74.0"
+__version__ = "0.75.0"

--- a/graqle/compliance/eu_ai_act_latch.py
+++ b/graqle/compliance/eu_ai_act_latch.py
@@ -456,3 +456,117 @@ class EuAiActLatch:
             )
             self._append(record)
             return self.read_state()
+
+
+# ── gate decision helper (ADR-222 P5b) ─────────────────────────────────
+# Pure function so the enforcement logic is unit-testable without the MCP
+# server. The gate (graqle/plugins/mcp_dev_server.py) calls this and acts on
+# the returned decision. Cost/quality are NEVER gated here — only AIA-relevant
+# writes, only when the latch is enabled, and always with the audited override
+# escape valve (D-1).
+
+# AIA-relevant write tools — the ONLY tools the EU AI Act phase may gate. Reads,
+# planning, reasoning, lifecycle, learn, etc. are NEVER gated (narrow scope).
+AIA_GATED_TOOLS: frozenset[str] = frozenset({
+    "graq_edit", "kogni_edit",
+    "graq_write", "kogni_write",
+    "graq_generate", "kogni_generate",
+    "graq_apply", "kogni_apply",
+})
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    """Result of the EU AI Act gate evaluation for one tool call."""
+
+    action: Literal["allow", "block", "advise"]
+    reason: str = ""
+    envelope: dict[str, Any] | None = None  # refusal envelope when action=="block"
+    advisory: str | None = None             # advisory note when action=="advise"
+
+
+def evaluate_gate(
+    *,
+    state: LatchState,
+    tool_name: str,
+    confidence: float | None,
+    threshold: float,
+    override_justification: str | None = None,
+) -> GateDecision:
+    """Decide whether an AIA-relevant write proceeds under the latch.
+
+    Narrow scope + fail-safe-for-usability rules (ADR-222 P5b / research):
+    - Latch not enabled, or tool not AIA-relevant -> ``allow`` (no-op).
+    - Latch enabled but a (non-empty) override justification is present ->
+      ``allow`` (the caller will have recorded the signed override).
+    - ``advisory`` mode -> ``advise`` (warn + caller records), never block.
+    - ``blocking`` mode + confidence below threshold -> ``block`` with a refusal
+      envelope that explains how to override.
+    - ``blocking`` mode + confidence >= threshold (or unknown) -> ``allow``.
+
+    This never gates non-write tools and never blocks for cost/quality — only
+    the Article-14 oversight signal on an AIA-relevant write.
+
+    HONEST SCOPE (what this is / is NOT, per graq_predict P5b forecast): this is
+    a deliberately LIGHT-TOUCH phase. It blocks ONLY when (a) the latch is
+    enabled+blocking, (b) the tool is an AIA-relevant write, AND (c) an explicit
+    confidence below threshold is supplied — and even then a signed override
+    proceeds. In practice it RECORDS and ADVISES far more than it blocks. It is a
+    compliance *traceability* aid (Art. 12/72 support), NOT a hard wall, and NOT
+    a substitute for human compliance judgement. Native (non-graq_) tools bypass
+    it entirely — the client-side wall + constitution address that, not this
+    phase. Treat blocks as a prompt for human oversight, not a guarantee.
+    """
+    if not state.enabled or tool_name not in AIA_GATED_TOOLS:
+        return GateDecision(action="allow")
+
+    # An audited per-action override was supplied -> let this one through.
+    if override_justification and override_justification.strip():
+        return GateDecision(
+            action="allow",
+            reason="eu_ai_act_override_recorded",
+        )
+
+    mode = state.mode or "blocking"  # tampered/unknown -> treat as strictest
+
+    if mode == "advisory":
+        return GateDecision(
+            action="advise",
+            advisory=(
+                f"EU AI Act ({state.risk_class or 'high'}-risk, advisory): "
+                f"Article-14 human-oversight applies to '{tool_name}'. "
+                "Recorded; not blocked."
+            ),
+        )
+
+    # blocking mode — only refuse when oversight confidence is below threshold.
+    if confidence is not None and confidence < threshold:
+        envelope = {
+            "error": "CG-EU-AIA_OVERSIGHT",
+            "tool": tool_name,
+            "message": (
+                f"EU AI Act blocking mode ({state.risk_class or 'high'}-risk): "
+                f"'{tool_name}' needs human oversight (Article 14) — confidence "
+                f"{confidence:.2f} is below the {threshold:.2f} review threshold."
+            ),
+            "remediation": (
+                "Re-run the same tool with an 'eu_aia_override_justification' "
+                "argument to proceed with a signed, audited override. This does "
+                "NOT disable the EU AI Act latch — it records that one action "
+                "proceeded under human oversight."
+            ),
+            "eu_ai_act": {
+                "mode": mode,
+                "risk_class": state.risk_class,
+                "confidence": confidence,
+                "threshold": threshold,
+                "tampered": state.tampered,
+            },
+        }
+        return GateDecision(
+            action="block",
+            reason="article_14_oversight_below_threshold",
+            envelope=envelope,
+        )
+
+    return GateDecision(action="allow")

--- a/graqle/plugins/mcp_dev_server.py
+++ b/graqle/plugins/mcp_dev_server.py
@@ -4318,6 +4318,91 @@ class KogniDevServer:
         ],
     }
 
+    def _eu_ai_act_gate(self, name: str, arguments: dict):
+        """CG-EU-AIA (ADR-222 P5b): evaluate the EU AI Act phase for a write tool.
+
+        Returns None when the phase is inert (config disabled / latch disabled /
+        any failure -> never blocks legitimate work). Otherwise returns a tuple
+        ``(action, payload)`` where action is "block" (payload = refusal
+        envelope), "override" (a signed override was recorded; allow), or
+        "advise"/"allow" (payload unused). FAIL-SAFE FOR USABILITY: any error in
+        the EU AI Act phase logs and returns None (allow) — the latch's own
+        read_state is internally fail-closed, but a phase that cannot evaluate
+        must never block routine work. Hard blocking only happens on an explicit,
+        verified blocking decision.
+        """
+        try:
+            cfg = getattr(getattr(self, "_config", None), "governance", None)
+            eu_cfg = getattr(cfg, "eu_ai_act", None)
+            if eu_cfg is None or not getattr(eu_cfg, "enabled", False):
+                return None  # config switch off -> phase inert
+
+            from graqle.compliance.eu_ai_act_latch import EuAiActLatch, evaluate_gate
+
+            # Latch lives under the server's OWN project root (not any
+            # caller-supplied path). Normalize to an absolute real path defensively
+            # (Sentinel: avoid any relative/symlink ambiguity in the latch dir).
+            import os as _os  # CG-01: os is not module-scoped here — import locally
+            root = getattr(self, "_project_root", None) or _os.getcwd()
+            root = _os.path.realpath(str(root))
+            latch = EuAiActLatch(root)
+            state = latch.read_state()  # internally fail-closed, never raises
+            if not state.enabled:
+                return None  # no latch recorded -> phase inert
+
+            override = None
+            if isinstance(arguments, dict):
+                override = arguments.get("eu_aia_override_justification")
+
+            # confidence: prefer an explicit arg; else None (unknown -> allow in
+            # blocking mode, since we cannot assert it is BELOW threshold).
+            confidence = None
+            if isinstance(arguments, dict):
+                c = arguments.get("confidence")
+                # finite, non-bool, in-range [0,1] only; anything else -> unknown
+                # (None) which never blocks (Sentinel MINOR: explicit bounds).
+                import math as _math
+                if (
+                    isinstance(c, (int, float))
+                    and not isinstance(c, bool)
+                    and _math.isfinite(c)
+                    and 0.0 <= float(c) <= 1.0
+                ):
+                    confidence = float(c)
+
+            threshold = float(getattr(cfg, "human_review_required_threshold", 0.75))
+
+            decision = evaluate_gate(
+                state=state, tool_name=name, confidence=confidence,
+                threshold=threshold, override_justification=override,
+            )
+
+            if decision.action == "block":
+                return ("block", decision.envelope)
+            if decision.action == "allow" and override and override.strip():
+                # A signed, audited override was supplied — record it (D-1).
+                from datetime import datetime, timezone
+                ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+                try:
+                    # actor="mcp-client": the MCP protocol does not carry an
+                    # authenticated end-user identity at this layer, so the
+                    # override records the client role + the justification text
+                    # (which SHOULD name the human reviewer). A future increment
+                    # binds a verified identity when the transport provides one.
+                    latch.record_override(
+                        justification=override, actor="mcp-client",
+                        action=name, ts=ts,
+                    )
+                except Exception as exc:  # noqa: BLE001 — override logging must not block
+                    logger.warning("CG-EU-AIA override record failed (%s) — allowing", exc)
+                return ("override", None)
+            if decision.action == "advise":
+                return ("advise", None)
+            return None
+        except Exception as exc:  # noqa: BLE001 — the phase must NEVER crash the gate
+            logger.warning("CG-EU-AIA phase error (%s) — allowing (fail-safe-for-usability)", exc)
+            return None
+
     def _accumulate_cost_advisory(self, payload: dict) -> None:
         """ADR-222 P4: advisory per-session cost meter. Observability only.
 
@@ -4509,6 +4594,25 @@ class KogniDevServer:
                             "remediation": "graq_edit",
                         })
                         return self._inject_tool_hints(name, err)
+
+            # CG-EU-AIA (ADR-222 P5b): EU AI Act enforced compliance phase.
+            # NARROW SCOPE — only AIA-relevant write tools, only when the
+            # tamper-evident latch reads enabled. Reads/plan/reason/lifecycle are
+            # never gated. blocking+below-threshold -> refuse with an override
+            # path; advisory -> attach a note, never block. A signed
+            # eu_aia_override_justification lets one action through (latch stays
+            # on). The latch read is fail-closed and can never crash the gate.
+            from graqle.compliance.eu_ai_act_latch import AIA_GATED_TOOLS as _AIA_TOOLS
+            if name in _AIA_TOOLS:
+                _aia_decision = self._eu_ai_act_gate(name, arguments)
+                if _aia_decision is not None:
+                    action, payload = _aia_decision
+                    if action == "block":
+                        logger.warning("CG-EU-AIA BLOCKED: '%s' below oversight threshold", name)
+                        return self._inject_tool_hints(name, json.dumps(payload))
+                    if action == "override":
+                        logger.info("CG-EU-AIA override recorded for '%s'", name)
+                    # "advise" / "override" / "allow" fall through to dispatch.
 
         # CG-17: Memory-path write gate (v0.52.0 / G1).
         # Force graq_memory for any write/edit to ~/.claude/projects/*/memory/*.md.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-# V-CR-GOV-INSTALL-P5A-NATIVE: native version bump (G4 config). 0.74.0 =
-# ADR-222 P5a — EU AI Act configurable + irreversible-latch core (OFF by
-# default, unwired). 0.73.0 was the cost-is-observability release.
-version = "0.74.0"
+# V-CR-GOV-INSTALL-P5B-NATIVE: native version bump (G4 config). 0.75.0 =
+# ADR-222 P5b — EU AI Act latch wired into the gate as the enforced (narrow,
+# off-by-default) CG-EU-AIA compliance phase. 0.74.0 was the P5a latch core.
+version = "0.75.0"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_compliance/test_eu_ai_act_gate.py
+++ b/tests/test_compliance/test_eu_ai_act_gate.py
@@ -1,0 +1,173 @@
+"""P5b (ADR-222): EU AI Act gate enforcement (CG-EU-AIA) tests.
+
+Two layers:
+1. `evaluate_gate` — the pure decision function (narrow scope, fail-safe).
+2. `KogniDevServer._eu_ai_act_gate` — the gate-side wiring (off by default,
+   latch-driven, fail-safe-for-usability).
+
+Hard contract: cost/quality are never gated; only AIA-relevant WRITES, only when
+the latch is enabled; reads never gated; the audited override always available;
+any phase error -> allow (never block routine work).
+"""
+
+from __future__ import annotations
+
+import types
+from pathlib import Path
+
+import pytest
+
+from graqle.compliance.eu_ai_act_latch import (
+    AIA_GATED_TOOLS,
+    EuAiActLatch,
+    LatchState,
+    evaluate_gate,
+)
+
+_T0 = "2026-06-09T00:00:00Z"
+
+
+def _state(enabled, mode=None, risk="high") -> LatchState:
+    return LatchState(
+        enabled=enabled, mode=mode, risk_class=risk if enabled else None,
+        event_count=1 if enabled else 0, override_count=0,
+    )
+
+
+# ── pure decision function ─────────────────────────────────────────────
+
+def test_disabled_latch_allows_everything():
+    d = evaluate_gate(state=_state(False), tool_name="graq_edit",
+                      confidence=0.0, threshold=0.75)
+    assert d.action == "allow"
+
+
+def test_read_tool_never_gated_even_when_enabled():
+    # narrow scope: only AIA_GATED_TOOLS are evaluated
+    for tool in ("graq_reason", "graq_inspect", "graq_plan", "graq_context"):
+        d = evaluate_gate(state=_state(True, "blocking"), tool_name=tool,
+                          confidence=0.0, threshold=0.75)
+        assert d.action == "allow", tool
+
+
+def test_blocking_below_threshold_blocks_write():
+    d = evaluate_gate(state=_state(True, "blocking"), tool_name="graq_edit",
+                      confidence=0.40, threshold=0.75)
+    assert d.action == "block"
+    assert d.envelope["error"] == "CG-EU-AIA_OVERSIGHT"
+    assert "override" in d.envelope["remediation"].lower()
+
+
+def test_blocking_above_threshold_allows_write():
+    d = evaluate_gate(state=_state(True, "blocking"), tool_name="graq_edit",
+                      confidence=0.95, threshold=0.75)
+    assert d.action == "allow"
+
+
+def test_blocking_unknown_confidence_allows():
+    # cannot assert below-threshold -> allow (never block on missing signal)
+    d = evaluate_gate(state=_state(True, "blocking"), tool_name="graq_edit",
+                      confidence=None, threshold=0.75)
+    assert d.action == "allow"
+
+
+def test_override_justification_allows_blocked_write():
+    d = evaluate_gate(state=_state(True, "blocking"), tool_name="graq_edit",
+                      confidence=0.10, threshold=0.75,
+                      override_justification="reviewed by harish")
+    assert d.action == "allow"
+
+
+def test_advisory_mode_advises_never_blocks():
+    d = evaluate_gate(state=_state(True, "advisory", risk="limited"),
+                      tool_name="graq_write", confidence=0.0, threshold=0.75)
+    assert d.action == "advise"
+    assert d.advisory and "advisory" in d.advisory.lower()
+
+
+def test_tampered_unknown_mode_treated_as_blocking():
+    # mode None on an enabled latch -> strictest (blocking)
+    st = LatchState(enabled=True, mode=None, risk_class="high",
+                    event_count=1, override_count=0, tampered=True)
+    d = evaluate_gate(state=st, tool_name="graq_edit", confidence=0.1, threshold=0.75)
+    assert d.action == "block"
+
+
+def test_gated_tools_are_writes_only():
+    assert "graq_edit" in AIA_GATED_TOOLS
+    assert "graq_write" in AIA_GATED_TOOLS
+    assert "graq_generate" in AIA_GATED_TOOLS
+    assert "graq_reason" not in AIA_GATED_TOOLS
+    assert "graq_read" not in AIA_GATED_TOOLS
+
+
+# ── gate-side wiring (_eu_ai_act_gate) ─────────────────────────────────
+
+def _server_with_latch(tmp_path: Path, *, enabled_cfg: bool, threshold=0.75):
+    from graqle.plugins.mcp_dev_server import KogniDevServer
+
+    srv = KogniDevServer.__new__(KogniDevServer)
+    srv._project_root = str(tmp_path)
+    gov = types.SimpleNamespace(
+        eu_ai_act=types.SimpleNamespace(enabled=enabled_cfg, mode="blocking", risk_class="high"),
+        human_review_required_threshold=threshold,
+    )
+    srv._config = types.SimpleNamespace(governance=gov)
+    return srv
+
+
+def test_gate_inert_when_config_off(tmp_path):
+    # config flag off -> phase inert even if a latch file somehow exists
+    srv = _server_with_latch(tmp_path, enabled_cfg=False)
+    assert srv._eu_ai_act_gate("graq_edit", {"confidence": 0.1}) is None
+
+
+def test_gate_inert_when_no_latch(tmp_path):
+    # config on but no latch recorded -> inert
+    srv = _server_with_latch(tmp_path, enabled_cfg=True)
+    assert srv._eu_ai_act_gate("graq_edit", {"confidence": 0.1}) is None
+
+
+def test_gate_blocks_when_latch_enabled_blocking_low_conf(tmp_path):
+    EuAiActLatch(tmp_path).enable(mode="blocking", risk_class="high", ts=_T0)
+    srv = _server_with_latch(tmp_path, enabled_cfg=True)
+    res = srv._eu_ai_act_gate("graq_edit", {"confidence": 0.30})
+    assert res is not None
+    action, payload = res
+    assert action == "block"
+    assert payload["error"] == "CG-EU-AIA_OVERSIGHT"
+
+
+def test_gate_override_records_and_allows(tmp_path):
+    EuAiActLatch(tmp_path).enable(mode="blocking", risk_class="high", ts=_T0)
+    srv = _server_with_latch(tmp_path, enabled_cfg=True)
+    res = srv._eu_ai_act_gate(
+        "graq_edit", {"confidence": 0.30, "eu_aia_override_justification": "human reviewed"},
+    )
+    assert res is not None
+    assert res[0] == "override"
+    # the override is recorded in the latch chain (audit trail)
+    assert EuAiActLatch(tmp_path).read_state().override_count == 1
+
+
+def test_gate_allows_high_confidence(tmp_path):
+    EuAiActLatch(tmp_path).enable(mode="blocking", risk_class="high", ts=_T0)
+    srv = _server_with_latch(tmp_path, enabled_cfg=True)
+    assert srv._eu_ai_act_gate("graq_edit", {"confidence": 0.95}) is None
+
+
+def test_gate_ignores_out_of_range_confidence(tmp_path):
+    # NaN / >1 / <0 confidence -> treated as unknown -> never blocks (Sentinel MINOR)
+    EuAiActLatch(tmp_path).enable(mode="blocking", risk_class="high", ts=_T0)
+    srv = _server_with_latch(tmp_path, enabled_cfg=True)
+    for bad in (float("nan"), 1.5, -0.2, float("inf")):
+        assert srv._eu_ai_act_gate("graq_edit", {"confidence": bad}) is None, bad
+
+
+def test_gate_fail_safe_on_error(tmp_path):
+    # a broken config must NOT crash or block — fail safe for usability
+    from graqle.plugins.mcp_dev_server import KogniDevServer
+    srv = KogniDevServer.__new__(KogniDevServer)
+    srv._project_root = str(tmp_path)
+    srv._config = types.SimpleNamespace(governance="not-a-namespace")  # broken
+    assert srv._eu_ai_act_gate("graq_edit", {"confidence": 0.1}) is None


### PR DESCRIPTION
## P5b (ADR-222) — EU AI Act latch wired into the gate (CG-EU-AIA, v0.75.0)

Completes the EU AI Act layer: the tamper-evident latch (0.74.0) is now **enforced** via a **narrow-scope, off-by-default** gate phase.

### What it does
When the latch reads `enabled`, AIA-relevant **write** tools (`graq_edit`/`write`/`generate`/`apply` + `kogni_`) pass an Article-14 oversight check:
- **blocking** + supplied `confidence` below threshold → **refused** with an audited-override path;
- **advisory** → recorded + advised, never blocked;
- a signed `eu_aia_override_justification` arg → records an audited override (latch stays on) + lets that one action proceed.

`evaluate_gate` is a pure, unit-tested decision function (logic testable without the server).

### Scope & safety (deliberate)
- **Reads / plan / reason / lifecycle are NEVER gated** — only AIA-relevant writes, only when the latch is on.
- **Fail-safe for usability:** if it cannot evaluate, it allows (never blocks routine work); the latch itself stays fail-closed for tamper.
- **Light-touch by design** — a traceability aid (Art. 12/72 support), not a hard wall, not a substitute for human compliance judgement. Native (non-graq_) tools bypass it; the client wall covers that.
- **Off by default; no new MCP tool; 0 regression.**

### Validation
- **35 P5 tests + 134 dev-server + config = 214 pass, 0 regression.**
- Sentinel: review **APPROVED 95% (0 BLOCKERs)**; security — path-MAJOR fixed (realpath; not attacker-controlled), confidence-MINOR fixed (finite + [0,1]), `actor=mcp-client` documented; `graq_predict` captured (light-touch intentional; native-bypass out of scope).
- version 0.74.0 → **0.75.0**; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
