### PR TITLE
chore(release): v0.75.1 — Studio reasoning fail-closed fix (ADR-220-A R2)

### DIFF
--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.75.0"
+__version__ = "0.75.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,11 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-# V-CR-GOV-INSTALL-P5B-NATIVE: native version bump (G4 config). 0.75.0 =
-# ADR-222 P5b — EU AI Act latch wired into the gate as the enforced (narrow,
-# off-by-default) CG-EU-AIA compliance phase. 0.74.0 was the P5a latch core.
-version = "0.75.0"
+# V-CR-STUDIO-R2-NATIVE: native version bump (G4 config). 0.75.1 = ADR-220-A R2
+# — Studio /studio/api/reason + /graph/visualization fail-closed on project
+# mismatch (fixes wrong-graph "hallucination"). 0.75.0 = ADR-222 P5b EU AI Act
+# latch wired into the gate (CG-EU-AIA phase); 0.74.0 was the P5a latch core.
+version = "0.75.1"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## v0.75.1 — packages the R2 fail-closed fix for PyPI

Public mirror of private release PR #198 (merged). Cherry-pick of the version bump.

The R2 code (fail-closed on project mismatch in `/studio/api/reason` +
`/studio/api/graph/visualization`) is already on public master via #204. This bumps
the version so the wrong-graph "hallucination" backend fix ships to PyPI users.

```
graqle/__version__.py : 0.75.0 -> 0.75.1
pyproject.toml        : 0.75.0 -> 0.75.1
```

After merge: tag `v0.75.1` -> PyPI publish (OIDC) -> wheel-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)