### PR TITLE
feat(studio): wire reasoning context-dimension filter (ADR-220-A A2)

### DIFF
--- a/graqle/studio/routes/api.py
+++ b/graqle/studio/routes/api.py
@@ -133,6 +133,112 @@ async def _load_project_graph(request: Request, project: str):
 _PROJECT_NAME_RE = re.compile(r"\A(?=.*[A-Za-z0-9])[A-Za-z0-9._\- ]{1,128}\Z")
 
 
+# A2 (ADR-220-A): context-dimension scope filter for reasoning. The Studio UI
+# sends a `dimensions` list (the Architecture / API Surface / Data Model / Testing
+# / Configuration / Security chips). After activation we narrow the node set to the
+# selected dimension(s) so reasoning is scoped, not whole-graph.
+#
+# The entity_type sets below are grounded in the LIVE KG type distribution
+# (graq_inspect stats), NOT assumed names: the graph uses APIEndpoint (not
+# "Route"/"Endpoint"), DatabaseModel (not "DataModel"/"Schema"), Config + EnvVar,
+# TestFile, PythonModule/JavaScriptModule/JSModule/ReactComponent/Dependency.
+# Function/Class are generic (24k/5k nodes) so they are matched ONLY via path/label
+# heuristics, never by type alone — otherwise every dimension would match them.
+#
+# Matching is OR across {type, path-substring, label-substring}. The filter NEVER
+# empties the set: if it would yield zero nodes (e.g. a sparse graph), the original
+# node_ids are returned so reasoning still runs (degrade to unscoped, not to error).
+_DIMENSION_FILTERS: dict[str, dict[str, Any]] = {
+    "architecture": {
+        "types": {"PythonModule", "JavaScriptModule", "JSModule",
+                  "ReactComponent", "Dependency", "Directory"},
+        "path": ("__init__", "setup.py", "requirements", "package.json"),
+        "label": (),
+    },
+    "api": {
+        "types": {"APIEndpoint"},
+        "path": ("/route", "/api/", "/views", "/handler", "/endpoint", "controller"),
+        "label": ("route", "endpoint", "handler", "api"),
+    },
+    "data-model": {
+        "types": {"DatabaseModel"},
+        "path": ("/model", "/schema", "/orm", "/entit", "/migrations"),
+        "label": ("model", "schema", "entity"),
+    },
+    "testing": {
+        "types": {"TestFile"},
+        "path": ("/test", "test_", "_test", "/spec", ".spec.", "conftest"),
+        "label": ("test", "spec"),
+    },
+    "config": {
+        "types": {"Config", "EnvVar"},
+        "path": ("/config", "settings", ".env", "/flags", ".yaml", ".yml", ".toml", ".ini"),
+        "label": ("config", "setting", "flag", "env"),
+    },
+    "security": {
+        # No exclusive type in this graph — security is purely heuristic.
+        "types": set(),
+        "path": ("/auth", "security", "permission", "secret", "token", "/rbac",
+                 "/crypto", "license", "credential"),
+        "label": ("auth", "permission", "secret", "token", "security", "rbac",
+                  "credential", "encrypt", "vuln"),
+    },
+}
+
+
+def _filter_nodes_by_dimension(
+    graph: Any, node_ids: list[str], dimensions: Any
+) -> list[str]:
+    """Narrow ``node_ids`` to the user-selected context dimension(s).
+
+    Returns ``node_ids`` unchanged when ``dimensions`` is missing, not a list, the
+    list is empty, or it contains ``"all"`` (the broadest scope). Unknown dimension
+    ids are ignored. Never returns an empty list: if the filter matches nothing,
+    the original (unscoped) set is returned so reasoning still has nodes to work
+    with — scoping is a relevance hint, not a hard gate (ADR-220-A A2).
+    """
+    if not isinstance(dimensions, list) or not dimensions:
+        return node_ids
+    dims = [d for d in dimensions if isinstance(d, str)]
+    if "all" in dims:
+        return node_ids
+    specs = [_DIMENSION_FILTERS[d] for d in dims if d in _DIMENSION_FILTERS]
+    if not specs:
+        return node_ids
+
+    matched: list[str] = []
+    for nid in node_ids:
+        node = graph.nodes.get(nid)
+        if node is None:
+            continue
+        etype = getattr(node, "entity_type", "") or ""
+        # node id is a path-like string in this KG (e.g. "pkg/mod.py::func");
+        # also consult any explicit path/file_path property and the label.
+        props = getattr(node, "properties", {}) or {}
+        path = str(props.get("path") or props.get("file_path") or nid).lower()
+        label = str(getattr(node, "label", "") or "").lower()
+        for spec in specs:
+            if (
+                etype in spec["types"]
+                or any(s in path for s in spec["path"])
+                or any(s in label for s in spec["label"])
+            ):
+                matched.append(nid)
+                break
+
+    if not matched:
+        # Scoping matched nothing (e.g. sparse graph) — degrade to unscoped so
+        # reasoning still runs, but log it so a misconfigured filter is visible.
+        # Log COUNTS only, never the raw user-controlled dim strings (avoids
+        # log-injection / probe-pattern disclosure — graq_review security MINOR).
+        logger.debug(
+            "A2: dimension filter matched 0/%d nodes for %d dim(s) — using full set",
+            len(node_ids), len(dims),
+        )
+        return node_ids
+    return matched
+
+
 async def _resolve_graph_for_request(request: Request):
     """Resolve the appropriate Graqle graph for an HTTP request (SF-07, v0.57.4).
 
@@ -833,6 +939,12 @@ async def reason_stream(request: Request):
     strategy = body.get("strategy")
     ring_fence = body.get("ring_fence", "read-only")  # Default: graph protected
     project = body.get("project")  # User's selected project
+    # A2: optional context-scope filter (user-controlled). Bound the input here so
+    # a hostile caller can't send a huge list and force O(nodes x dims x substrings)
+    # work (DoS guard, graq_review MAJOR). Studio only ever sends <=7 short ids.
+    dimensions = body.get("dimensions")
+    if isinstance(dimensions, list):
+        dimensions = [d for d in dimensions[:20] if isinstance(d, str) and len(d) <= 64]
 
     state = request.app.state.studio_state
 
@@ -883,6 +995,10 @@ async def reason_stream(request: Request):
             activation_start = time.time()
             node_ids = graph._activate_subgraph(query, strategy)
             node_ids = [nid for nid in node_ids if nid in graph.nodes]
+            # A2 (ADR-220-A): narrow the activated set to the user-selected
+            # context dimension(s) BEFORE the fast-mode cap, so the cap keeps the
+            # most relevant scoped nodes. No-op when dimensions is absent/['all'].
+            node_ids = _filter_nodes_by_dimension(graph, node_ids, dimensions)
             # Fast mode: cap activated nodes for speed (no shared state mutation)
             if fast_max_nodes and len(node_ids) > fast_max_nodes:
                 node_ids = node_ids[:fast_max_nodes]

--- a/tests/test_studio/test_dimension_filter.py
+++ b/tests/test_studio/test_dimension_filter.py
@@ -1,0 +1,147 @@
+"""A2 (ADR-220-A) tests: the reasoning context-dimension scope filter.
+
+`_filter_nodes_by_dimension` narrows the activated node set to the user-selected
+Studio dimension chip(s). Entity-type sets are grounded in the live KG type
+distribution (APIEndpoint, DatabaseModel, Config/EnvVar, TestFile, PythonModule…).
+The filter must: honour 'all'/absent as no-op, match by type OR path OR label, and
+NEVER return an empty list (degrade to unscoped rather than starve reasoning).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from graqle.studio.routes.api import _filter_nodes_by_dimension
+
+
+class _FakeGraph:
+    """A graph whose nodes carry id, entity_type, label, and optional path prop."""
+
+    def __init__(self, nodes: dict[str, SimpleNamespace]):
+        self.nodes = nodes
+
+
+def _node(entity_type="Function", label="", path=None):
+    props = {"path": path} if path else {}
+    return SimpleNamespace(entity_type=entity_type, label=label, properties=props)
+
+
+def _graph():
+    return _FakeGraph({
+        "pkg/api/users.py::list_users": _node("APIEndpoint", "list_users", "pkg/api/users.py"),
+        "pkg/models/user.py::User": _node("DatabaseModel", "User", "pkg/models/user.py"),
+        "tests/test_user.py::test_create": _node("TestFile", "test_create", "tests/test_user.py"),
+        "pkg/settings.py::DEBUG": _node("Config", "DEBUG", "pkg/settings.py"),
+        "pkg/core/graph.py": _node("PythonModule", "graph", "pkg/core/graph.py"),
+        "pkg/auth/login.py::authenticate": _node("Function", "authenticate", "pkg/auth/login.py"),
+        "pkg/util/math.py::add": _node("Function", "add", "pkg/util/math.py"),
+    })
+
+
+ALL_IDS = [
+    "pkg/api/users.py::list_users",
+    "pkg/models/user.py::User",
+    "tests/test_user.py::test_create",
+    "pkg/settings.py::DEBUG",
+    "pkg/core/graph.py",
+    "pkg/auth/login.py::authenticate",
+    "pkg/util/math.py::add",
+]
+
+
+# ----------------------------- no-op cases --------------------------------- #
+
+def test_none_dimensions_is_noop():
+    assert _filter_nodes_by_dimension(_graph(), ALL_IDS, None) == ALL_IDS
+
+
+def test_empty_list_is_noop():
+    assert _filter_nodes_by_dimension(_graph(), ALL_IDS, []) == ALL_IDS
+
+
+def test_all_dimension_is_noop():
+    assert _filter_nodes_by_dimension(_graph(), ALL_IDS, ["all"]) == ALL_IDS
+    assert _filter_nodes_by_dimension(_graph(), ALL_IDS, ["architecture", "all"]) == ALL_IDS
+
+
+def test_unknown_dimension_is_noop():
+    assert _filter_nodes_by_dimension(_graph(), ALL_IDS, ["nonsense"]) == ALL_IDS
+
+
+def test_non_list_is_noop():
+    assert _filter_nodes_by_dimension(_graph(), ALL_IDS, "security") == ALL_IDS
+
+
+# ----------------------------- scoping cases ------------------------------- #
+
+def test_api_dimension_selects_endpoint():
+    out = _filter_nodes_by_dimension(_graph(), ALL_IDS, ["api"])
+    assert "pkg/api/users.py::list_users" in out
+    assert "pkg/util/math.py::add" not in out
+    assert "pkg/models/user.py::User" not in out
+
+
+def test_data_model_dimension_selects_databasemodel():
+    out = _filter_nodes_by_dimension(_graph(), ALL_IDS, ["data-model"])
+    assert out == ["pkg/models/user.py::User"]
+
+
+def test_testing_dimension_selects_testfile():
+    out = _filter_nodes_by_dimension(_graph(), ALL_IDS, ["testing"])
+    assert "tests/test_user.py::test_create" in out
+    assert "pkg/util/math.py::add" not in out
+
+
+def test_config_dimension_selects_config():
+    out = _filter_nodes_by_dimension(_graph(), ALL_IDS, ["config"])
+    assert "pkg/settings.py::DEBUG" in out
+
+
+def test_architecture_dimension_selects_module():
+    out = _filter_nodes_by_dimension(_graph(), ALL_IDS, ["architecture"])
+    assert "pkg/core/graph.py" in out
+
+
+def test_security_dimension_is_heuristic_on_path_label():
+    # No exclusive type — 'authenticate' in pkg/auth/login.py matches via path+label.
+    out = _filter_nodes_by_dimension(_graph(), ALL_IDS, ["security"])
+    assert "pkg/auth/login.py::authenticate" in out
+    assert "pkg/util/math.py::add" not in out
+
+
+def test_multiple_dimensions_union():
+    out = _filter_nodes_by_dimension(_graph(), ALL_IDS, ["api", "testing"])
+    assert "pkg/api/users.py::list_users" in out
+    assert "tests/test_user.py::test_create" in out
+    assert "pkg/util/math.py::add" not in out
+
+
+# ----------------------------- never-empty guard --------------------------- #
+
+def test_never_returns_empty_falls_back_to_unscoped():
+    # A graph with only a generic util fn; 'data-model' matches nothing -> must
+    # return the original list, not [].
+    g = _FakeGraph({"pkg/util/math.py::add": _node("Function", "add", "pkg/util/math.py")})
+    ids = ["pkg/util/math.py::add"]
+    assert _filter_nodes_by_dimension(g, ids, ["data-model"]) == ids
+
+
+def test_huge_dimension_list_does_not_crash():
+    # Defence-in-depth: even if a large list reaches the helper (the route caps it
+    # to 20), the helper must handle it without error. Unknown ids => no-op.
+    out = _filter_nodes_by_dimension(_graph(), ALL_IDS, [f"junk{i}" for i in range(5000)])
+    assert out == ALL_IDS
+
+
+def test_non_string_elements_ignored():
+    out = _filter_nodes_by_dimension(_graph(), ALL_IDS, [123, None, "api"])
+    assert "pkg/api/users.py::list_users" in out
+    assert "pkg/util/math.py::add" not in out
+
+
+def test_missing_node_is_skipped_not_crash():
+    g = _graph()
+    ids = ALL_IDS + ["does/not/exist::ghost"]
+    out = _filter_nodes_by_dimension(g, ids, ["api"])
+    assert "does/not/exist::ghost" not in out
+    assert "pkg/api/users.py::list_users" in out


### PR DESCRIPTION
## A2 (ADR-220-A): make the Live Reasoning context chips real

Public mirror of private PR #200 (MERGED). Cherry-pick of the same commit.

The Architecture / API Surface / Data Model / Testing / Configuration / Security
chips were sent in the reason request body but `reason_stream` never read them.
This wires them: after `_activate_subgraph`, `node_ids` are narrowed to the
selected dimension(s) via `_filter_nodes_by_dimension` before the fast-mode cap.

`_DIMENSION_FILTERS` entity_type sets are grounded in the live KG (APIEndpoint,
DatabaseModel, Config/EnvVar, TestFile, PythonModule/JS/ReactComponent/Dependency);
Function/Class matched only by path/label heuristics. `'all'`/absent/unknown =
no-op; filter never empties the set.

Hardening (Sentinel): user-controlled `dimensions` capped to 20×64 (DoS guard);
fallback log emits counts only (log-injection guard).

16 unit tests; full test_studio suite green. Private-first per ABSOLUTE RULE #0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)