### PR TITLE
fix: make studio mount failure observable in CI (unblocks deploy of R2/A2)

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -71,10 +71,12 @@ jobs:
           "
 
       - name: Verify Studio routes register
+        env:
+          AWS_LAMBDA_FUNCTION_NAME: test  # scoped to this step — triggers /tmp path in create_app
         run: |
           python -c "
-          import os
-          os.environ['AWS_LAMBDA_FUNCTION_NAME'] = 'test'  # Trigger /tmp path
+          import os, sys, logging, traceback
+          logging.basicConfig(level=logging.WARNING, format='%(levelname)s %(name)s: %(message)s')
 
           from graqle.server.app import create_app
           app = create_app(graph_path='nonexistent.json', config_path='nonexistent.yaml')
@@ -84,13 +86,27 @@ jobs:
           print(f'Total routes: {len(routes)}')
           print(f'Studio routes: {len(studio_routes)}')
 
+          # Validate required studio routes are registered.
+          # If any are missing, run a direct mount_studio() diagnostic to surface the real error
+          # (e.g. a broken import inside the studio router chain that create_app swallowed).
           required = ['/studio/api/health', '/studio/api/intelligence', '/studio/api/governance', '/studio/api/learning']
+          missing = [r for r in required if r not in routes]
           for r in required:
-              found = any(r in route for route in routes)
-              status = 'OK' if found else 'MISSING'
-              print(f'  {r}: {status}')
-              if not found:
-                  import sys; sys.exit(1)
+              print(f'  {r}: {"OK" if r not in missing else "MISSING"}')
+
+          if missing:
+              print('FAIL: Required studio routes missing — running direct mount_studio() diagnostic')
+              try:
+                  from fastapi import FastAPI
+                  from graqle.studio.app import mount_studio
+                  _diag_app = FastAPI()
+                  mount_studio(_diag_app, {'metrics': None, 'studio_available': False})
+                  print('Direct mount_studio() succeeded — route count discrepancy is in create_app() context')
+              except Exception as _exc:
+                  print(f'Direct mount_studio() FAILED with {type(_exc).__name__}: {_exc}')
+                  traceback.print_exc()
+                  print('Fix: add the missing dependency above to the pip install line in this workflow')
+              sys.exit(1)
           "
 
       - name: Graqle governance gate (graq verify)

--- a/graqle/server/app.py
+++ b/graqle/server/app.py
@@ -655,20 +655,40 @@ def create_app(
         yield "data: [DONE]\n\n"
 
     # Mount Studio dashboard (optional — only if studio package is available)
+    mount_studio = None  # remains None if graqle[studio] is not installed
     try:
         from graqle.studio.app import mount_studio
-
-        # Load metrics engine
-        metrics = None
-        try:
-            from graqle.metrics.engine import MetricsEngine
-            metrics = MetricsEngine()
-        except Exception:
-            pass
-
-        state["metrics"] = metrics
-        mount_studio(app, state)
     except ImportError:
         logger.debug("Studio not available (install graqle[studio] for dashboard)")
+
+    state["studio_available"] = False
+    state["metrics"] = None  # default; overwritten if studio is available and metrics engine loads
+    if mount_studio is not None:
+        # Load metrics engine
+        try:
+            from graqle.metrics.engine import MetricsEngine
+            state["metrics"] = MetricsEngine()
+        except Exception as exc:
+            logger.warning(
+                "MetricsEngine unavailable — metrics will be disabled: %s",
+                exc,
+                exc_info=True,
+            )
+        try:
+            mount_studio(app, state)
+            state["studio_available"] = True
+        except (AttributeError, RuntimeError) as exc:
+            # AttributeError: missing attribute on state/app during mount
+            # RuntimeError: StaticFiles directory missing or similar config failure
+            # ImportError is intentionally NOT caught here: if it occurs inside mount_studio()
+            # after the top-level import succeeded, it indicates a broken dependency graph
+            # and should propagate so the root cause is immediately visible.
+            # Other exceptions (TypeError, NameError, etc.) are programming errors
+            # and should also propagate.
+            logger.warning(
+                "Studio mount failed — studio routes will be unavailable: %s",
+                exc,
+                exc_info=True,
+            )
 
     return app


### PR DESCRIPTION
$(cat <<'EOF'