### PR TITLE
fix(ci): fix YAML shell-quoting bug blocking Lambda deploy since 2026-06-09

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -90,9 +90,10 @@ jobs:
           # If any are missing, run a direct mount_studio() diagnostic to surface the real error
           # (e.g. a broken import inside the studio router chain that create_app swallowed).
           required = ['/studio/api/health', '/studio/api/intelligence', '/studio/api/governance', '/studio/api/learning']
-          missing = [r for r in required if r not in routes]
+          missing = {r for r in required if r not in routes}
           for r in required:
-              print(f'  {r}: {"OK" if r not in missing else "MISSING"}')
+              status = 'OK' if r not in missing else 'MISSING'
+              print(f'  {r}: {status}')
 
           if missing:
               print('FAIL: Required studio routes missing — running direct mount_studio() diagnostic')
@@ -162,6 +163,7 @@ jobs:
           # trust root). Without it the `import jwt` guard makes _verify_bearer
           # return None for EVERY request → the fix would over-deny and break
           # valid logins. cryptography (already below) is the RS256 backend.
+          # (Synced from public PR #191 for private/public parity.)
           pip install --target build/lambda \
             --platform manylinux2014_x86_64 --only-binary=:all: \
             --python-version 3.10 --implementation cp \


### PR DESCRIPTION
## Summary

Fixes the 6-day CI/CD deploy outage blocking R2/A2 from reaching production.

**Root cause:** `.github/workflows/deploy-lambda.yml` "Verify Studio routes register" step
embedded an f-string ternary with inner double quotes inside a `python -c "..."` shell
command. The shell terminated the `-c` argument at the first inner `"`, splitting
`{"OK" if r not in missing else "MISSING"}` into fragments — producing
`NameError: name 'MISSING' is not defined`. The check exited 1 before the route count
even printed, so the `deploy` job (which `needs: graqle-check`) was never reached.
Every push to master since 2026-06-09 (PRs #204, #207, #206) failed at this gate.

**Changes (2 lines, deploy-lambda.yml only):**
- `missing = [r for r in ...]` → `missing = {r for r in ...}` (set for O(1) lookup)  
- `print(f'  {r}: {"OK" if r not in missing else "MISSING"}')` →  
  ```python
  status = 'OK' if r not in missing else 'MISSING'
  print(f'  {r}: {status}')
  ```
  Pre-assigned variable eliminates the inner double quotes entirely.

**`graqle/server/app.py`** — already correct on `origin/master` (the silent-swallow fix
landed in prior PRs #201/#208). No changes in this PR.

---

## ADR-209 Sentinel Review Chain (full, 2026-06-17/18)

| Phase | Tool | Result |
|-------|------|--------|
| Phase 3 | `graq_preflight` | ✅ MEDIUM risk, scoped to deployment automation |
| Phase 3 | `graq_safety_check` | ✅ MEDIUM risk, no CRITICAL paths affected |
| Phase 7 | `graq_review(focus="all")` pass 1 | ⚠️ CHANGES_REQUESTED (style: list→set) → applied |
| Phase 7 | `graq_review(focus="all")` pass 2 | ✅ APPROVED 92%, 0 BLOCKERs, 0 MAJORS |
| Phase 7 | `graq_review(focus="security")` | ✅ APPROVED 95%, unanimous across 13 agents |
| Phase 7 | `graq_predict` | ✅ SKIPPED_LOW_CONFIDENCE — pattern already in KG (85% synth conf) |

All phases PASSED. Zero BLOCKERs. Zero security concerns.

---

## Test plan

- [ ] Merge this PR → CI triggers `Deploy Lambda` workflow on master push
- [ ] `graqle-check` job "Verify Studio routes register" step should now PASS (no NameError)
- [ ] `deploy` job should proceed and update `cognigraph-api` Lambda
- [ ] Smoke test in workflow: `/health` → 200, `/studio/api/health` → 200, graph viz → 200, CORS count = 1
- [ ] Post-deploy: curl `https://r3tj3qkjfu6ecxtpw7cb57jbha0qjmaw.lambda-url.eu-central-1.on.aws/studio/api/reason` with unloadable project → expect 401/404 (R2 fail-closed), not 200 default-graph

---

## Why this was hard to diagnose

`graqle/server/app.py` had an `except ImportError` that swallowed any error inside `mount_studio()` execution (not just missing optional imports). CI saw 14 base routes + 1 studio route because studio routes never mounted, but no traceback was emitted — only `logger.debug`. The YAML quoting bug then made the route-check step crash immediately (before printing route counts) on a completely unrelated `NameError`, making the CI log misleading. The app.py silent-swallow fix (observability, NOT this PR) was already merged in #201/#208.

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code) · ADR-209 Sentinel chain APPROVED
