### PR TITLE
chore(release): bump version to 0.76.0 (G1 ADR-225 multi-tenant memory)

### DIFF
--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.75.1"
+__version__ = "0.76.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,10 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-# V-CR-STUDIO-R2-NATIVE: native version bump (G4 config). 0.75.1 = ADR-220-A R2
-# — Studio /studio/api/reason + /graph/visualization fail-closed on project
-# mismatch (fixes wrong-graph "hallucination"). 0.75.0 = ADR-222 P5b EU AI Act
-# latch wired into the gate (CG-EU-AIA phase); 0.74.0 was the P5a latch core.
-version = "0.75.1"
+# V-CR-G1-NATIVE: native version bump (G4 config). 0.76.0 = ADR-225 G1 multi-tenant
+# memory service — nested per-tenant store + provision() factory (isolation layer 3).
+# 0.75.1 = ADR-220-A R2 Studio fail-closed. 0.75.0 = ADR-222 P5b EU AI Act latch.
+version = "0.76.0"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## chore(release): bump version to 0.76.0 (G1 ADR-225 multi-tenant memory)

**Cherry-pick of:** `7c99d233` from private PR #204 (merged, approved by Harish Kumar)

Ships ADR-225 G1 multi-tenant memory service — nested per-tenant store + `provision()` factory.
383 tests pass, 0 regressions. On-prem invariant preserved.

See private PR #203 and #204 for full sentinel chain details.

🤖 Generated with [Claude Code](https://claude.com/claude-code) under GraQle ADR-231 mandate.
