### PR TITLE
fix(ci): WS-F Sentinel hotfix - case-insensitive allowlist + 12 tests for ip_content_scan

### DIFF
--- a/scripts/ci/ip_content_scan.py
+++ b/scripts/ci/ip_content_scan.py
@@ -40,7 +40,7 @@ FILENAME_DENY = [
 FILENAME_ALLOWLIST: frozenset[str] = frozenset([
     "trade_secret_wheel_gate.py",
     "trade-secret-wheel-gate.yml",
-])
+])  # entries must be lowercase; check normalises via .lower() to match FILENAME_DENY re.IGNORECASE semantics
 
 
 # Layer 2: content patterns. Scanned against the first 100 lines of any
@@ -104,7 +104,7 @@ def iter_paths(nul_file: Path) -> list[str]:
 def check_filename(path: str) -> list[str]:
     """Return list of FILENAME_DENY pattern descriptions that match this path."""
     name = Path(path).name
-    if name in FILENAME_ALLOWLIST:
+    if name.lower() in FILENAME_ALLOWLIST:
         return []
     return [pat.pattern for pat in FILENAME_DENY if pat.search(name)]
 

--- a/tests/test_packaging/test_ip_content_scan.py
+++ b/tests/test_packaging/test_ip_content_scan.py
@@ -1,0 +1,81 @@
+"""Tests for scripts/ci/ip_content_scan.py — filename allowlist and deny logic.
+
+Sentinel review (graq_review focus=all, 2026-06-25) required explicit coverage
+of the FILENAME_ALLOWLIST bypass path added in the WS-F CI fix (PR #216).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load ip_content_scan without sys.path mutation to avoid xdist isolation issues.
+_SCANNER_PATH = Path(__file__).parent.parent.parent / "scripts" / "ci" / "ip_content_scan.py"
+_spec = importlib.util.spec_from_file_location("ip_content_scan", _SCANNER_PATH)
+assert _spec and _spec.loader, f"Cannot load ip_content_scan from {_SCANNER_PATH}"
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+
+check_filename = _mod.check_filename
+FILENAME_ALLOWLIST = _mod.FILENAME_ALLOWLIST
+
+
+class TestFilenameAllowlist:
+    """check_filename() allowlist short-circuit — the security-relevant bypass path."""
+
+    def test_allowlisted_basename_returns_empty(self) -> None:
+        assert check_filename("trade_secret_wheel_gate.py") == []
+
+    def test_allowlisted_yaml_basename_returns_empty(self) -> None:
+        assert check_filename("trade-secret-wheel-gate.yml") == []
+
+    def test_allowlisted_basename_in_subdirectory_returns_empty(self) -> None:
+        """Allowlist check uses Path.name (basename only) — subdirs don't matter."""
+        assert check_filename("scripts/ci/trade_secret_wheel_gate.py") == []
+
+    def test_allowlisted_basename_case_insensitive(self) -> None:
+        """Allowlist check is case-insensitive to match FILENAME_DENY re.IGNORECASE semantics."""
+        assert check_filename("Trade_Secret_Wheel_Gate.py") == []
+        assert check_filename("TRADE_SECRET_WHEEL_GATE.PY") == []
+        assert check_filename("trade-secret-wheel-gate.YML") == []
+
+    def test_non_allowlisted_trade_secret_filename_is_blocked(self) -> None:
+        """A *different* file whose name contains 'trade_secret' is NOT allowlisted."""
+        hits = check_filename("trade_secret_analysis.md")
+        assert any(r"trade[-_]secret" in h for h in hits), (
+            f"Expected trade_secret deny pattern to fire, got: {hits}"
+        )
+
+    def test_non_allowlisted_trade_secret_filename_mixed_case_blocked(self) -> None:
+        """Mixed-case trade-secret filename not in allowlist must still be blocked."""
+        hits = check_filename("Trade_Secret_Analysis.MD")
+        assert len(hits) > 0, (
+            "Mixed-case trade_secret filename should be blocked by FILENAME_DENY (re.IGNORECASE)"
+        )
+
+    def test_ordinary_filename_passes(self) -> None:
+        assert check_filename("graqle/governance/gate.py") == []
+
+    def test_allowlist_entries_are_lowercase(self) -> None:
+        """All FILENAME_ALLOWLIST entries are lowercase — invariant for the .lower() check."""
+        for entry in FILENAME_ALLOWLIST:
+            assert entry == entry.lower(), f"Allowlist entry not lowercase: {entry!r}"
+
+    def test_ts_numbered_filename_is_blocked(self) -> None:
+        hits = check_filename("ts-1-weight-values.md")
+        assert any(r"ts[-_]\d" in h for h in hits), f"Expected ts-N deny pattern, got: {hits}"
+
+    def test_patent_draft_filename_is_blocked(self) -> None:
+        hits = check_filename("patent-draft-claims.md")
+        assert any("patent" in h for h in hits), f"Expected patent deny pattern, got: {hits}"
+
+    def test_empty_string_does_not_raise(self) -> None:
+        """Degenerate: empty path string must return empty list, not raise."""
+        assert check_filename("") == []
+
+    def test_root_slash_does_not_raise(self) -> None:
+        """Degenerate: bare '/' must return empty list, not raise."""
+        assert check_filename("/") == []


### PR DESCRIPTION
## Summary

Post-merge Sentinel hotfix for PR #216 (WS-F trade-secret wheel gate).

`graq_review(focus=all)` pass 1 on the merged diff found:
- **MAJOR**: `FILENAME_ALLOWLIST` check used `name in ALLOWLIST` (case-sensitive) while all `FILENAME_DENY` patterns use `re.IGNORECASE`. A mixed-case variant like `Trade_Secret_Wheel_Gate.py` would bypass the allowlist and fall through to deny-pattern matching unexpectedly.
- **MINOR**: Missing test coverage for the allowlist bypass path.

## Changes

- `scripts/ci/ip_content_scan.py` — `name in FILENAME_ALLOWLIST` → `name.lower() in FILENAME_ALLOWLIST`. Comment updated.
- `tests/test_packaging/test_ip_content_scan.py` (**new**) — 12 tests: allowlisted basenames, case-insensitive variants, non-allowlisted trade_secret still blocked, mixed-case blocked filename caught, degenerate inputs, lowercase invariant. Loaded via `importlib` (no `sys.path` mutation).

## Sentinel verdict

- `graq_review(focus=all)` pass 1 — CHANGES_REQUESTED (MAJOR: case-sensitivity gap)
- `graq_review(focus=all)` pass 2 — CHANGES_REQUESTED (clarified deny-list already uses IGNORECASE; test gaps addressed)
- `graq_review(focus=security)` pass 3 — **APPROVED** 0 BLOCKERs, 93% confidence

## Test plan

- [x] 12/12 new tests pass locally
- [x] Sentinel security review APPROVED (0 BLOCKERs)
- [ ] CI green on this PR
- [ ] Harish merges private PR then cherry-pick to public

🤖 Generated with [Claude Code](https://claude.com/claude-code)
