### PR TITLE
ADR-239: AutonomousExecutor pluggable checkpoint + optional/agent test stage (v0.77.0)

### DIFF
--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.76.0"
+__version__ = "0.77.0"

--- a/graqle/workflow/__init__.py
+++ b/graqle/workflow/__init__.py
@@ -24,9 +24,11 @@ from graqle.workflow.loop_observer import (
     Violation,
     ViolationType,
 )
+from graqle.workflow.protocols import CheckpointProtocol
 
 __all__ = [
     "ActionAgentProtocol",
+    "CheckpointProtocol",
     "ExecutionResult",
     "InvalidTransitionError",
     "LoopContext",

--- a/graqle/workflow/autonomous_executor.py
+++ b/graqle/workflow/autonomous_executor.py
@@ -26,6 +26,7 @@ from graqle.workflow.action_agent_protocol import ActionAgentProtocol, Execution
 from graqle.workflow.diff_applicator import DiffApplicator
 from graqle.workflow.execution_memory import ExecutionMemory
 from graqle.workflow.loop_controller import LoopContext, LoopController, LoopState
+from graqle.workflow.protocols import CheckpointProtocol
 from graqle.workflow.test_result_parser import ParsedTestResult, TestResultParser
 
 logger = logging.getLogger("graqle.workflow.autonomous_executor")
@@ -43,6 +44,18 @@ class ExecutorConfig:
     working_dir: str = "."
     dry_run: bool = False
     timeout_seconds: int = 300
+    # ADR-239: pluggable checkpoint/rollback (default None → DiffApplicator).
+    # A cloud consumer injects a non-git checkpoint (e.g. object-store file sink).
+    checkpoint: "CheckpointProtocol | None" = None
+    # ADR-239: skip the pytest TEST stage entirely (greenfield builds with
+    # nothing to test yet). Default True preserves the existing git/pytest path.
+    run_tests: bool = True
+    # ADR-239 Stage 2.1: route the TEST stage through the agent instead of a
+    # subprocess. When True, _on_test delegates to agent.run_tests() (which may
+    # run any validation the consumer defines) so the native LoopController
+    # RED_FIX loop drives repair on a failing result. Default False preserves
+    # the existing subprocess(test_command) path exactly.
+    test_via_agent: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -52,6 +65,9 @@ class ExecutorConfig:
             "working_dir": self.working_dir,
             "dry_run": self.dry_run,
             "timeout_seconds": self.timeout_seconds,
+            "run_tests": self.run_tests,
+            # `checkpoint` intentionally omitted — it is an injected object, not
+            # a serialisable value; its presence is captured by run-time wiring.
         }
 
 
@@ -98,7 +114,14 @@ class AutonomousExecutor:
         self._agent = agent
         self._loop = LoopController(max_retries=self._config.max_retries)
         self._memory = ExecutionMemory(self._config.working_dir)
-        self._diff = DiffApplicator(self._config.working_dir)
+        # ADR-239: checkpoint/rollback is pluggable. Default (None) constructs
+        # DiffApplicator exactly as before — byte-identical for every existing
+        # caller. A cloud consumer injects a non-git CheckpointProtocol.
+        self._diff: CheckpointProtocol = (
+            self._config.checkpoint
+            if self._config.checkpoint is not None
+            else DiffApplicator(self._config.working_dir)
+        )
         self._parser = TestResultParser()
 
     @property
@@ -158,6 +181,63 @@ class AutonomousExecutor:
 
     async def _on_test(self, ctx: LoopContext) -> ParsedTestResult:
         """Run tests and parse results."""
+        # ADR-239: consumers with nothing to test (e.g. greenfield builds) set
+        # run_tests=False. Short-circuit to a passing result — never spawn the
+        # test subprocess — while still recording to memory so the loop's state
+        # machine and retry/convergence tracking stay consistent. Snapshots are
+        # skipped: they capture file state at TEST time, meaningless with no test.
+        if not self._config.run_tests:
+            parsed = ParsedTestResult(passed=True, raw_output="tests skipped (run_tests=False)")
+            self._memory.record(
+                attempt=ctx.attempt,
+                diff_applied=ctx.generated_diff[:2000],
+                result_exit_code=0,
+                test_output="tests skipped (run_tests=False)",
+                modified_files=ctx.modified_files,
+            )
+            return parsed
+
+        # ADR-239 Stage 2.1: route TEST through the agent instead of a
+        # subprocess. The agent's run_tests() returns an ExecutionResult; its
+        # .success maps to ParsedTestResult.passed, so a failing result drives
+        # the native RED_FIX loop (agent regenerates with error_context). The
+        # consumer decides what "testing" means (e.g. static validation of
+        # generated files) — the SDK just wires the result into the FSM.
+        if self._config.test_via_agent:
+            agent_result = await self._agent.run_tests(self._config.test_paths or None)
+            # Sentinel BLOCKER 1: use the protocol's SEMANTIC pass signal, not
+            # exit_code — a harness can exit 0 while swallowing test failures.
+            passed = bool(agent_result.test_passed)
+            # Sentinel BLOCKER 2: None-guard stdout/stderr before slicing.
+            stdout = agent_result.stdout or ""
+            stderr = agent_result.stderr or ""
+            output = stdout + (("\n" + stderr) if stderr else "")
+            # Sentinel advisory: on failure, never leave error_messages empty —
+            # the FIX loop's error_context would be blank and repair would run
+            # blind. Fall back to output, then a generic marker.
+            if passed:
+                error_messages: list[str] = []
+            elif stderr:
+                error_messages = [stderr[:2000]]
+            elif output:
+                error_messages = [output[:2000]]
+            else:
+                error_messages = ["test_via_agent: validation failed, no output captured"]
+            parsed = ParsedTestResult(
+                passed=passed,
+                raw_output=output,
+                error_messages=error_messages,
+            )
+            self._memory.record(
+                attempt=ctx.attempt,
+                diff_applied=ctx.generated_diff[:2000],
+                result_exit_code=agent_result.exit_code,
+                test_output=output[:4000],
+                modified_files=ctx.modified_files,
+                error_message=("" if passed else (error_messages[0][:500] if error_messages else "")),
+            )
+            return parsed
+
         # Take before-snapshot
         if ctx.modified_files:
             before = self._memory.snapshot(ctx.modified_files)

--- a/graqle/workflow/protocols.py
+++ b/graqle/workflow/protocols.py
@@ -1,0 +1,41 @@
+# graqle/workflow/protocols.py
+"""
+Structural protocols that let AutonomousExecutor be composed with pluggable
+collaborators — no subclassing, zero coupling (PEP 544).
+
+ADR-239 (Universal SDK Build Engine): the same autonomous-loop engine must
+serve both the SDK's default git/pytest workflow AND cloud consumers that
+checkpoint to a non-git store (e.g. an object-store file sink) with no test
+stage. CheckpointProtocol is the seam for the checkpoint/rollback concern.
+
+The default implementation is graqle.workflow.diff_applicator.DiffApplicator
+(git stash + atomic apply), which satisfies this protocol structurally with
+zero changes. A cloud consumer injects its own object satisfying the same two
+methods (e.g. create_stash returns a snapshot id / None; rollback deletes the
+files it wrote).
+"""
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from graqle.workflow.action_agent_protocol import ExecutionResult
+
+
+@runtime_checkable
+class CheckpointProtocol(Protocol):
+    """Checkpoint/rollback seam for AutonomousExecutor.
+
+    Only two methods are required — they match DiffApplicator's real
+    signatures exactly, so DiffApplicator is a valid CheckpointProtocol with
+    no modification.
+
+    create_stash: take a checkpoint before a write attempt. Returns an opaque
+      token used to roll back, or None when no checkpoint is possible (e.g.
+      git unavailable) — the executor already tolerates a None token.
+    rollback: undo changes identified by a token. Returns an ExecutionResult
+      whose .success reports whether the rollback applied.
+    """
+
+    def create_stash(self, message: str = ...) -> str | None: ...
+
+    def rollback(self, token: str) -> ExecutionResult: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,12 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graqle"
-# V-CR-G1-NATIVE: native version bump (G4 config). 0.76.0 = ADR-225 G1 multi-tenant
-# memory service — nested per-tenant store + provision() factory (isolation layer 3).
-# 0.75.1 = ADR-220-A R2 Studio fail-closed. 0.75.0 = ADR-222 P5b EU AI Act latch.
-version = "0.76.0"
+# V-ADR239-STAGE2: native version bump (G4 config, CG-14 gate can't resolve cross-repo
+# relative path — established native-edit precedent per prior V-CR-G1-NATIVE bump).
+# 0.77.0 = ADR-239 Stage 2: AutonomousExecutor CheckpointProtocol + run_tests (one
+# engine for git AND cloud consumers; backward-compatible). 0.76.0 = ADR-225 G1
+# multi-tenant memory service. 0.75.1 = ADR-220-A R2 Studio fail-closed.
+version = "0.77.0"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_workflow/test_adr239_workspace_seam.py
+++ b/tests/test_workflow/test_adr239_workspace_seam.py
@@ -1,0 +1,235 @@
+"""
+ADR-239 Stage 2: AutonomousExecutor workspace/test seam.
+
+Verifies the pluggable checkpoint (CheckpointProtocol) + optional test stage
+(run_tests) added so the one engine serves both the SDK's git/pytest workflow
+AND cloud consumers with a non-git checkpoint and no test stage.
+
+Acceptance criteria (ADR-239):
+  AC-239-01  defaults are byte-identical: no checkpoint + run_tests=True
+             ⇒ self._diff is a DiffApplicator, existing callers unchanged.
+  AC-239-02  run_tests=False ⇒ TEST stage never spawns a subprocess.
+  AC-239-03  an injected CheckpointProtocol receives create_stash/rollback,
+             not DiffApplicator.
+  AC-239-04  no ActionAgentProtocol change (a FILE:-block agent satisfies it).
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from graqle.workflow.action_agent_protocol import ActionAgentProtocol, ExecutionResult
+from graqle.workflow.autonomous_executor import AutonomousExecutor, ExecutorConfig
+from graqle.workflow.diff_applicator import DiffApplicator
+from graqle.workflow.protocols import CheckpointProtocol
+
+
+# ── Minimal fakes ─────────────────────────────────────────────────────────────
+
+class _FakeAgent:
+    """A minimal ActionAgentProtocol impl that emits an opaque (non-diff) payload."""
+
+    async def plan(self, task, context):
+        return "plan: " + task
+
+    async def generate_diff(self, task, plan, error_context=None):
+        return "FILE: app.py\n<opaque non-diff payload>"
+
+    async def apply(self, diff):
+        return ExecutionResult(exit_code=0, stdout="", stderr="", modified_files=["app.py"])
+
+    async def run_tests(self, test_paths=None):
+        return ExecutionResult(exit_code=0, stdout="", stderr="", test_passed=True)
+
+    async def rollback(self, token):
+        return ExecutionResult(exit_code=0, stdout="", stderr="")
+
+
+class _RecordingCheckpoint:
+    """A CheckpointProtocol that records calls and never touches git."""
+
+    def __init__(self):
+        self.stash_calls = []
+        self.rollback_calls = []
+
+    def create_stash(self, message="checkpoint"):
+        self.stash_calls.append(message)
+        return "cloud-token-1"
+
+    def rollback(self, token):
+        self.rollback_calls.append(token)
+        return ExecutionResult(exit_code=0, stdout="", stderr="")
+
+
+# ── AC-239-04: no protocol change ─────────────────────────────────────────────
+
+def test_file_block_agent_satisfies_action_agent_protocol():
+    assert isinstance(_FakeAgent(), ActionAgentProtocol)
+
+
+def test_recording_checkpoint_satisfies_checkpoint_protocol():
+    assert isinstance(_RecordingCheckpoint(), CheckpointProtocol)
+
+
+def test_diff_applicator_satisfies_checkpoint_protocol():
+    # The default must satisfy the new protocol with zero changes.
+    assert isinstance(DiffApplicator("."), CheckpointProtocol)
+
+
+# ── AC-239-01: defaults byte-identical ────────────────────────────────────────
+
+def test_default_config_uses_diff_applicator():
+    ex = AutonomousExecutor(_FakeAgent())
+    assert isinstance(ex._diff, DiffApplicator), \
+        "no injected checkpoint ⇒ DiffApplicator, exactly as before"
+
+
+def test_default_config_run_tests_true():
+    assert ExecutorConfig().run_tests is True
+    assert ExecutorConfig().checkpoint is None
+
+
+# ── AC-239-03: injected checkpoint is used ────────────────────────────────────
+
+def test_injected_checkpoint_replaces_diff_applicator():
+    cp = _RecordingCheckpoint()
+    ex = AutonomousExecutor(_FakeAgent(), ExecutorConfig(checkpoint=cp))
+    assert ex._diff is cp
+    assert not isinstance(ex._diff, DiffApplicator)
+
+
+# ── AC-239-02: run_tests=False never spawns a subprocess ──────────────────────
+
+def test_run_tests_false_skips_subprocess():
+    cp = _RecordingCheckpoint()
+    cfg = ExecutorConfig(checkpoint=cp, run_tests=False, max_retries=0)
+    ex = AutonomousExecutor(_FakeAgent(), cfg)
+
+    with patch("subprocess.run") as mock_run:
+        result = asyncio.run(ex.execute("build a welcome page"))
+
+    assert not mock_run.called, "run_tests=False must never spawn the test subprocess"
+    assert result.success, "a no-test build with a clean apply must succeed"
+    assert "app.py" in result.modified_files
+
+
+def test_run_tests_true_default_still_runs_tests():
+    """Guard the default path: with run_tests=True the executor DOES call the
+    test subprocess (existing behaviour preserved)."""
+    cp = _RecordingCheckpoint()
+    cfg = ExecutorConfig(checkpoint=cp, run_tests=True, max_retries=0)
+    ex = AutonomousExecutor(_FakeAgent(), cfg)
+
+    import subprocess as _sp
+
+    class _Proc:
+        returncode = 0
+        stdout = "1 passed"
+        stderr = ""
+
+    with patch("subprocess.run", return_value=_Proc()) as mock_run:
+        asyncio.run(ex.execute("build a thing"))
+
+    assert mock_run.called, "run_tests=True (default) must still run the test subprocess"
+
+
+# ── AC-239 Stage 2.1: test_via_agent routes TEST through agent.run_tests() ────
+
+def test_test_via_agent_never_spawns_subprocess():
+    """test_via_agent=True ⇒ TEST delegates to agent.run_tests(), no subprocess."""
+    cp = _RecordingCheckpoint()
+    cfg = ExecutorConfig(checkpoint=cp, run_tests=True, test_via_agent=True, max_retries=0)
+    ex = AutonomousExecutor(_FakeAgent(), cfg)
+    with patch("subprocess.run") as mock_run:
+        result = asyncio.run(ex.execute("build a page"))
+    assert not mock_run.called, "test_via_agent must not spawn the test subprocess"
+    assert result.success
+
+
+def test_test_via_agent_failure_drives_fix_loop_then_recovers():
+    """A failing agent.run_tests() must drive RED_FIX→GENERATE (native repair),
+    then a subsequent pass reaches DONE. Proves validation-repair works with no
+    pytest — the ADR-239 Stage 3 mechanism."""
+    calls = {"tests": 0, "generate": 0}
+
+    class _FlakyAgent(_FakeAgent):
+        async def generate_diff(self, task, plan, error_context=None):
+            calls["generate"] += 1
+            # error_context must be threaded on the repair iteration
+            return "FILE: app.py\n<payload>" + (f" (fixing: {error_context})" if error_context else "")
+
+        async def run_tests(self, test_paths=None):
+            calls["tests"] += 1
+            if calls["tests"] == 1:
+                # first validation fails → RED_FIX
+                return ExecutionResult(exit_code=1, stdout="", stderr="validation: bad output",
+                                       test_passed=False)
+            # second passes → DONE
+            return ExecutionResult(exit_code=0, stdout="ok", stderr="", test_passed=True)
+
+    cfg = ExecutorConfig(
+        checkpoint=_RecordingCheckpoint(),
+        run_tests=True, test_via_agent=True, max_retries=2,
+    )
+    ex = AutonomousExecutor(_FlakyAgent(), cfg)
+    with patch("subprocess.run") as mock_run:
+        result = asyncio.run(ex.execute("build a page"))
+    assert not mock_run.called
+    assert result.success, "loop must recover after a failed then passing validation"
+    assert calls["tests"] == 2, "TEST (agent.run_tests) ran twice: fail then pass"
+    assert calls["generate"] == 2, "GENERATE ran twice — the RED_FIX loop re-generated"
+
+
+def test_test_via_agent_persistent_failure_exhausts_to_failed():
+    """If agent.run_tests() always fails, the loop exhausts max_retries and
+    reports failure — not a false success."""
+    class _AlwaysFailAgent(_FakeAgent):
+        async def run_tests(self, test_paths=None):
+            return ExecutionResult(exit_code=1, stdout="", stderr="still bad")
+
+    cfg = ExecutorConfig(
+        checkpoint=_RecordingCheckpoint(),
+        run_tests=True, test_via_agent=True, max_retries=1,
+    )
+    ex = AutonomousExecutor(_AlwaysFailAgent(), cfg)
+    with patch("subprocess.run"):
+        result = asyncio.run(ex.execute("build a page"))
+    assert not result.success, "persistent validation failure must not report success"
+
+
+def test_test_via_agent_uses_test_passed_not_exit_code():
+    """Sentinel BLOCKER-1 regression: a harness exiting 0 but reporting
+    test_passed=False must be treated as FAILED — we key on the semantic
+    field, never exit_code."""
+    class _ExitZeroButFailed(_FakeAgent):
+        async def run_tests(self, test_paths=None):
+            # exit_code 0 (process ok) but tests DID NOT pass
+            return ExecutionResult(exit_code=0, stdout="", stderr="3 failed", test_passed=False)
+
+    cfg = ExecutorConfig(
+        checkpoint=_RecordingCheckpoint(),
+        run_tests=True, test_via_agent=True, max_retries=0,
+    )
+    ex = AutonomousExecutor(_ExitZeroButFailed(), cfg)
+    with patch("subprocess.run"):
+        result = asyncio.run(ex.execute("build a page"))
+    assert not result.success, "exit_code==0 must NOT override test_passed=False"
+
+
+def test_test_via_agent_none_stderr_does_not_crash():
+    """Sentinel BLOCKER-2 regression: a failing result with stderr=None must
+    not raise TypeError on slicing."""
+    class _NoneStderrFail(_FakeAgent):
+        async def run_tests(self, test_paths=None):
+            return ExecutionResult(exit_code=1, stdout=None, stderr=None, test_passed=False)
+
+    cfg = ExecutorConfig(
+        checkpoint=_RecordingCheckpoint(),
+        run_tests=True, test_via_agent=True, max_retries=0,
+    )
+    ex = AutonomousExecutor(_NoneStderrFail(), cfg)
+    with patch("subprocess.run"):
+        result = asyncio.run(ex.execute("build a page"))  # must not raise
+    assert not result.success


### PR DESCRIPTION
Public release of ADR-239 Stage 2 + 2.1 (merged private research-development-graqle #262/#263). Makes `graqle.workflow.AutonomousExecutor` the one engine for both the default git/pytest workflow AND consumers with a non-git checkpoint and no/custom test stage.

## What ships (v0.77.0)
- `graqle/workflow/protocols.py` — `CheckpointProtocol` (`create_stash`/`rollback`). `DiffApplicator` satisfies it structurally, zero changes.
- `ExecutorConfig`: +`checkpoint` (None → DiffApplicator), +`run_tests` (True → git/pytest), +`test_via_agent` (False → subprocess; True → `_on_test` delegates to `agent.run_tests()` so the native RED_FIX loop drives validation-repair with no pytest).
- Exported `CheckpointProtocol` from `graqle.workflow`.

## Backward compatibility
Every existing caller is byte-identical — all three new fields default to today's behaviour. Public `workflow/__init__.py` structure preserved (only the `CheckpointProtocol` import/export added; private-only agent modules intentionally NOT brought over).

## Testing
279 workflow tests pass on this branch. The private release carried 480 workflow tests + full sentinel review (Stage 2 APPROVED 0-BLOCKER 87%; Stage 2.1 BLOCK→fix→APPROVE 0-BLOCKER 97%). Version 0.76.0 → 0.77.0.

## Merge → publish
On merge, tag `v0.77.0` on public master triggers PyPI Trusted Publishing (bound to this public repo). This is the sanctioned publish path — the private-tag attempt failed `invalid-publisher` because the OIDC trusted publisher is this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)