### PR TITLE
v0.79.0 — graqle.workflow.seed: seed a project graph from a goal (ADR-242-A1)

### DIFF
--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.78.0"
+__version__ = "0.79.0"

--- a/graqle/workflow/seed.py
+++ b/graqle/workflow/seed.py
@@ -1,0 +1,350 @@
+"""Seed a project knowledge graph from a build goal, profile, and source docs.
+
+A builder that generates a project from a natural-language goal starts with no
+graph: there is no codebase to scan yet, so activation has nothing to activate
+and every build cold-starts. This module produces the missing *seed* graph — a
+small but real project graph built from the inputs available before the first
+line of code exists:
+
+* the user's **goal**,
+* the **build profile** (which scaffolded components it implies),
+* any attached **source documents** (already chunked and embedded upstream).
+
+The seed is written to the project's graph file, so the *next* build loads a
+non-empty graph and its context activation has real nodes to select from. Fold
+build results back into the same graph after each build and the project's
+knowledge compounds instead of resetting.
+
+This is pure composition of the core graph API — it constructs no graph
+structures of its own:
+
+* :class:`graqle.core.graph.Graqle` (container)
+* ``Graqle.add_node_simple`` / ``add_edge_simple`` (typed nodes/edges)
+* ``Graqle.auto_connect`` (semantic edge discovery)
+
+Serialization
+-------------
+:func:`to_runner_graph_dict` emits the **flat scanner shape** —
+``{"nodes": [{"id","label","type","text","embedding",...}], "edges": [...]}`` —
+which is what a graph consumer reading raw dict keys expects (the same shape a
+repository scan produces). Note this is deliberately **not** the NetworkX
+node-link shape that :meth:`Graqle.to_json` emits (``{"nodes", "links"}`` with
+``entity_type`` rather than ``type``). Consumers that read the file as a raw
+dict — rather than via :meth:`Graqle.from_json`, which normalizes both — need
+the flat shape, so this adapter is the single serialization choke point.
+
+Example
+-------
+>>> graph_dict = seed_project_graph_dict(
+...     goal="a photographer portfolio with a contact form",
+...     profile_id="static-site",
+...     profile_components=["index.html"],
+...     project_id="portfolio",
+... )
+>>> graph_dict["nodes"][0]["type"]
+'Project'
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "build_seed_graph",
+    "seed_project_graph_dict",
+    "to_runner_graph_dict",
+]
+
+# Node type used for attached document chunks. Consumers filter on this exact
+# string when selecting embedded context, so it is part of the wire contract.
+DOCUMENT_CHUNK_TYPE = "DocumentChunk"
+
+# Node labels flow into generation prompts as project context. They are
+# attacker-influenceable data (a goal is user input), so restrict them to a safe
+# identifier charset and cap the length at the source — defence in depth on top
+# of whatever fencing the consumer applies.
+_SAFE_ID_RE = re.compile(r"[^A-Za-z0-9_.\- ]")
+
+# Size guard for chunk text held in the seed graph. This is NOT a sanitiser:
+# chunk text reaches a prompt only through the caller's own untrusted-text
+# fencing, which is the single source of truth for that concern. This cap only
+# stops a pathological chunk from bloating the graph file.
+_CHUNK_TEXT_CAP = 20_000
+
+
+def _safe(text: str, limit: int = 128) -> str:
+    """Restrict to a safe identifier charset and cap length. Never raises."""
+    return _SAFE_ID_RE.sub("", str(text or ""))[:limit].strip()
+
+
+def _infer_capabilities(goal: str, max_caps: int = 6) -> list[str]:
+    """Infer capability names from the goal by keyword match (no LLM, no cost).
+
+    Deliberately conservative: a curated intent->capability map. Anything
+    unmatched contributes nothing, so noise never invents a capability. Returns
+    a de-duplicated, order-stable list.
+    """
+    g = goal.lower()
+    catalogue: list[tuple[tuple[str, ...], str]] = [
+        (("login", "sign in", "sign-in", "auth", "account"), "authentication"),
+        (("sign up", "signup", "register", "registration"), "user-registration"),
+        (("contact", "get in touch", "enquiry", "inquiry"), "contact-form"),
+        (("cart", "checkout", "payment", "stripe", "buy", "shop", "store", "commerce"), "payments"),
+        (("blog", "post", "article", "cms", "content"), "content-management"),
+        (("dashboard", "chart", "graph", "analytics", "metric"), "analytics-dashboard"),
+        (("search", "filter", "query"), "search"),
+        (("upload", "file", "attachment", "document"), "file-upload"),
+        (("api", "endpoint", "rest", "backend"), "api"),
+        (("map", "location", "geo"), "maps"),
+        (("gallery", "portfolio", "photo", "image"), "media-gallery"),
+        (("booking", "appointment", "reservation", "schedule", "calendar"), "booking"),
+    ]
+    caps: list[str] = []
+    for keywords, cap in catalogue:
+        if any(k in g for k in keywords) and cap not in caps:
+            caps.append(cap)
+        if len(caps) >= max_caps:
+            break
+    return caps
+
+
+def build_seed_graph(
+    *,
+    goal: str,
+    profile_id: str | None = None,
+    profile_display_name: str | None = None,
+    profile_components: list[str] | None = None,
+    project_id: str = "",
+    tenant_hash: str = "",
+    source_chunks: list[dict] | None = None,
+    created_at: str = "",
+) -> Any:
+    """Compose a seed :class:`~graqle.core.graph.Graqle` from pre-build inputs.
+
+    Node model::
+
+        Project . Goal . BuildProfile . Capability . Component . DocumentChunk
+
+    Edges::
+
+        Project -HAS_GOAL->      Goal
+        Goal    -TARGETS->       Capability
+        Project -USES_PROFILE->  BuildProfile
+        BuildProfile -SCAFFOLDS-> Component
+        Project -HAS_CONTEXT->   DocumentChunk
+
+    Parameters
+    ----------
+    goal:
+        The user's build request. Becomes the ``Goal`` node and drives
+        capability inference.
+    profile_id, profile_display_name, profile_components:
+        Optional build-profile identity and the components it scaffolds.
+    project_id, tenant_hash, created_at:
+        Project identity metadata carried on the ``Project`` node.
+    source_chunks:
+        Optional ``[{"label", "text", "embedding"}]`` — already-chunked source
+        documents. Added verbatim as ``DocumentChunk`` nodes (embeddings
+        preserved) so a later build's embedding activation can rank them. This
+        function does not chunk or embed; pass already-prepared chunks.
+
+    Returns
+    -------
+    Graqle
+        Serialize with :func:`to_runner_graph_dict`.
+
+    Notes
+    -----
+    Per-chunk parsing and ``auto_connect`` are guarded: a malformed chunk or an
+    embedding-backend failure degrades the seed, never raises.
+    """
+    from graqle.core.graph import Graqle
+
+    g = Graqle()
+    new_ids: list[str] = []
+
+    project_node_id = f"project::{_safe(project_id) or 'new'}"
+    g.add_node_simple(
+        project_node_id,
+        label=_safe(project_id) or "new-project",
+        entity_type="Project",
+        description="project root",
+        properties={"tenant_hash": tenant_hash, "created_at": created_at},
+    )
+    new_ids.append(project_node_id)
+
+    goal_id = "goal::0"
+    g.add_node_simple(
+        goal_id,
+        label=_safe(goal, limit=80) or "build-goal",
+        entity_type="Goal",
+        description=str(goal or "")[:2048],
+        properties={"created_at": created_at},
+    )
+    g.add_edge_simple(project_node_id, goal_id, relation="HAS_GOAL")
+    new_ids.append(goal_id)
+
+    if profile_id:
+        profile_node_id = f"profile::{_safe(profile_id)}"
+        g.add_node_simple(
+            profile_node_id,
+            label=_safe(profile_display_name or profile_id, limit=80),
+            entity_type="BuildProfile",
+            description=f"build profile {profile_id}",
+            properties={"profile_id": _safe(profile_id)},
+        )
+        g.add_edge_simple(project_node_id, profile_node_id, relation="USES_PROFILE")
+        new_ids.append(profile_node_id)
+
+        for comp in (profile_components or []):
+            comp_label = _safe(comp, limit=80)
+            if not comp_label:
+                continue
+            comp_id = f"component::{comp_label}"
+            g.add_node_simple(
+                comp_id,
+                label=comp_label,
+                entity_type="Component",
+                description=f"scaffolded component {comp_label}",
+                properties={"layer": "generated"},
+            )
+            g.add_edge_simple(profile_node_id, comp_id, relation="SCAFFOLDS")
+            new_ids.append(comp_id)
+
+    for cap in _infer_capabilities(goal):
+        cap_id = f"capability::{cap}"
+        g.add_node_simple(
+            cap_id,
+            label=cap,
+            entity_type="Capability",
+            description=f"capability inferred from goal: {cap}",
+            properties={"status": "active", "source": "inferred"},
+        )
+        g.add_edge_simple(goal_id, cap_id, relation="TARGETS")
+        new_ids.append(cap_id)
+
+    for i, chunk in enumerate(source_chunks or []):
+        if not isinstance(chunk, dict):
+            continue
+        text = str(chunk.get("text") or "")[:_CHUNK_TEXT_CAP]
+        if not text.strip():
+            continue
+        chunk_id = f"chunk::{i}"
+        g.add_node_simple(
+            chunk_id,
+            label=_safe(chunk.get("label") or f"chunk-{i}", limit=64),
+            entity_type=DOCUMENT_CHUNK_TYPE,
+            description="attached source document chunk",
+            properties={"text": text, "embedding": chunk.get("embedding")},
+        )
+        g.add_edge_simple(project_node_id, chunk_id, relation="HAS_CONTEXT")
+        new_ids.append(chunk_id)
+
+    # Semantic auto-connect over the new nodes. Best-effort: the seed is valid
+    # without discovered edges, so a backend failure never blocks the caller.
+    try:
+        g.auto_connect(new_ids)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("seed: auto_connect skipped (%s)", type(exc).__name__)
+
+    return g
+
+
+def to_runner_graph_dict(graph: Any) -> dict:
+    """Serialize a :class:`~graqle.core.graph.Graqle` to the flat scanner shape.
+
+    The single serialization choke point for consumers that read a graph file as
+    a raw dict (``graph["nodes"]``, ``node["type"]``, ``node["embedding"]``)
+    rather than through :meth:`Graqle.from_json`.
+
+    Mapping:
+
+    ==================  ===================
+    ``CogniNode``       emitted key
+    ==================  ===================
+    ``id``              ``id``
+    ``label``           ``label``
+    ``entity_type``     ``type``
+    ``description``     ``description``
+    ``properties.text``       ``text``       (lifted to top level)
+    ``properties.embedding``  ``embedding``  (lifted to top level)
+    remaining props     ``properties``
+    ==================  ===================
+
+    Edges are emitted under ``"edges"`` (never ``"links"``) as
+    ``{"source", "target", "relation"}``.
+
+    ``text`` and ``embedding`` are lifted out of ``properties`` because that is
+    where a raw-dict consumer reads them; leaving them nested makes document
+    chunks invisible to context activation.
+    """
+    nodes_out: list[dict] = []
+    for node in graph.nodes.values():
+        props = dict(getattr(node, "properties", {}) or {})
+        node_dict: dict[str, Any] = {
+            "id": node.id,
+            "label": getattr(node, "label", node.id),
+            "type": getattr(node, "entity_type", "CONCEPT"),
+            "description": getattr(node, "description", ""),
+        }
+        if "text" in props:
+            node_dict["text"] = props["text"]
+        if props.get("embedding") is not None:
+            node_dict["embedding"] = props["embedding"]
+        extra = {k: v for k, v in props.items() if k not in ("text", "embedding")}
+        if extra:
+            node_dict["properties"] = extra
+        nodes_out.append(node_dict)
+
+    edges_out: list[dict] = []
+    for edge in graph.edges.values():
+        edges_out.append({
+            "source": edge.source_id,
+            "target": edge.target_id,
+            "relation": getattr(edge, "relationship", "RELATES_TO"),
+        })
+
+    return {"nodes": nodes_out, "edges": edges_out}
+
+
+def seed_project_graph_dict(
+    *,
+    goal: str,
+    profile_id: str | None = None,
+    profile_display_name: str | None = None,
+    profile_components: list[str] | None = None,
+    project_id: str = "",
+    tenant_hash: str = "",
+    source_chunks: list[dict] | None = None,
+    created_at: str = "",
+) -> dict:
+    """Build the seed graph and return it in the flat scanner shape.
+
+    The one-call entry point for a builder: compose the seed, serialize it, and
+    hand back a dict ready to persist as the project's graph file.
+
+    **Guaranteed non-raising.** On any internal failure it returns the empty
+    shape ``{"nodes": [], "edges": []}`` — identical to what a consumer falls
+    back to when no graph file exists — so a seed failure can never abort a
+    build. Callers should persist only when ``nodes`` is non-empty, so a
+    degraded seed is never written over a good graph.
+    """
+    try:
+        g = build_seed_graph(
+            goal=goal,
+            profile_id=profile_id,
+            profile_display_name=profile_display_name,
+            profile_components=profile_components,
+            project_id=project_id,
+            tenant_hash=tenant_hash,
+            source_chunks=source_chunks,
+            created_at=created_at,
+        )
+        return to_runner_graph_dict(g)
+    except Exception as exc:  # pragma: no cover - defensive top-level guard
+        logger.warning("seed: seed_project_graph_dict failed (%s)", type(exc).__name__)
+        return {"nodes": [], "edges": []}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,14 @@ build-backend = "hatchling.build"
 [project]
 name = "graqle"
 # V-ADR240-DELTA: native version bump (G4 config, CG-14 native-edit precedent).
-# 0.78.0 = ADR-240 D1+D2: BackendRaceChain (first-to-finish/best-of-N) +
-# CostAwareRouter (auto cost/latency selection) — dual-provider autonomy;
-# additive, backward-compatible, no IP concern. 0.77.0 = ADR-239 Stage 2
+# 0.79.0 = ADR-242-A1 CR-SEED-02: graqle.workflow.seed — seed a project graph
+# from goal + build profile + source chunks before any code exists, and the
+# flat-scanner-shape serializer for raw-dict graph consumers; additive,
+# backward-compatible, no IP concern. 0.78.0 = ADR-240 D1+D2: BackendRaceChain
+# (first-to-finish/best-of-N) + CostAwareRouter (auto cost/latency selection) —
+# dual-provider autonomy. 0.77.0 = ADR-239 Stage 2
 # (CheckpointProtocol + run_tests). 0.76.0 = ADR-225 G1 multi-tenant memory.
-version = "0.78.0"
+version = "0.79.0"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_workflow/test_seed_sdk.py
+++ b/tests/test_workflow/test_seed_sdk.py
@@ -1,0 +1,208 @@
+"""Tests for graqle.workflow.seed (CR-SEED-02, ADR-242-A1 SDK promotion).
+
+The seed builder + the flat-scanner-shape serialization adapter. The canary test
+asserts the wire contract a raw-dict graph consumer depends on: it reads the
+adapter's output using the exact key accesses such a consumer performs
+(graph["nodes"], node["type"], node["embedding"], node["text"], node["id"]),
+so a regression in the adapter fails here rather than silently producing a graph
+that activates to nothing.
+"""
+from __future__ import annotations
+
+import re
+
+from graqle.workflow.seed import (
+    DOCUMENT_CHUNK_TYPE,
+    _CHUNK_TEXT_CAP,
+    build_seed_graph,
+    seed_project_graph_dict,
+    to_runner_graph_dict,
+)
+
+
+# ── Reproduction of a raw-dict consumer's reads (the wire contract) ───────────
+
+_SAFE_LABEL_RE = re.compile(r"[^A-Za-z0-9_.\- ]")
+
+
+def _consumer_node_count(graph: dict) -> int:
+    return len(graph.get("nodes", []))
+
+
+def _consumer_context_labels(graph: dict, task: str, max_nodes: int = 12) -> list[str]:
+    """Token-overlap label selection — how a consumer builds project context."""
+    nodes = graph.get("nodes") or []
+    if not nodes:
+        return []
+    task_tokens = {t for t in re.split(r"[^a-z0-9]+", task.lower()) if len(t) > 2}
+    if not task_tokens:
+        return []
+    scored: list = []
+    for n in nodes:
+        if not isinstance(n, dict):
+            continue
+        label = str(n.get("id") or n.get("label") or n.get("name") or "")
+        label = _SAFE_LABEL_RE.sub("", label)[:128].strip()
+        if not label:
+            continue
+        node_tokens = {t for t in re.split(r"[^a-z0-9]+", label.lower()) if len(t) > 2}
+        overlap = len(task_tokens & node_tokens)
+        if overlap:
+            scored.append((overlap, label))
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [label for _, label in scored[:max_nodes]]
+
+
+def _consumer_document_chunks(graph: dict) -> list[dict]:
+    """Embedded-chunk selection — requires type AND a truthy embedding."""
+    return [
+        n for n in graph.get("nodes", [])
+        if n.get("type") == "DocumentChunk" and n.get("embedding")
+    ]
+
+
+# ── Node model ────────────────────────────────────────────────────────────────
+
+def test_seed_graph_is_non_trivial_for_bare_goal():
+    d = to_runner_graph_dict(build_seed_graph(goal="build a hello world website",
+                                              project_id="p1"))
+    assert _consumer_node_count(d) >= 1
+    types = {n["type"] for n in d["nodes"]}
+    assert "Project" in types
+    assert "Goal" in types
+
+
+def test_seed_infers_capabilities_from_goal():
+    d = to_runner_graph_dict(
+        build_seed_graph(goal="a shop with a checkout and a contact form", project_id="p1")
+    )
+    caps = {n["label"] for n in d["nodes"] if n["type"] == "Capability"}
+    assert "payments" in caps
+    assert "contact-form" in caps
+
+
+def test_seed_includes_profile_and_components():
+    d = to_runner_graph_dict(build_seed_graph(
+        goal="a portfolio site",
+        project_id="p1",
+        profile_id="static-site",
+        profile_display_name="Static Site",
+        profile_components=["index.html", "styles.css"],
+    ))
+    types = [n["type"] for n in d["nodes"]]
+    assert "BuildProfile" in types
+    assert types.count("Component") == 2
+
+
+def test_edges_carry_the_declared_relations():
+    d = to_runner_graph_dict(build_seed_graph(
+        goal="a blog", project_id="p1",
+        profile_id="static-site", profile_components=["index.html"],
+    ))
+    relations = {e["relation"] for e in d["edges"]}
+    assert "HAS_GOAL" in relations
+    assert "USES_PROFILE" in relations
+    assert "SCAFFOLDS" in relations
+
+
+# ── Wire-contract canary (the point of the adapter) ───────────────────────────
+
+def test_canary_output_reads_back_through_consumer_reads():
+    task = "build a photographer portfolio with a contact form"
+    d = seed_project_graph_dict(
+        goal=task, project_id="portfolio",
+        profile_id="static-site", profile_components=["index.html"],
+    )
+    # node_count is non-zero — the number a builder surfaces as "nodes activated".
+    assert _consumer_node_count(d) > 0
+    # Context activation selects real labels from the seed.
+    labels = _consumer_context_labels(d, task)
+    assert labels, "context activation selected nothing from the seed"
+    assert any("contact" in lbl.lower() for lbl in labels)
+
+
+def test_edges_key_is_edges_not_links():
+    d = to_runner_graph_dict(build_seed_graph(goal="a blog", project_id="p1"))
+    assert "edges" in d
+    assert "links" not in d, "must be the flat scanner shape, not nx node-link"
+    for e in d["edges"]:
+        assert set(e) >= {"source", "target", "relation"}
+
+
+def test_entity_type_is_emitted_as_type():
+    # CogniNode.entity_type must surface as "type" — a consumer never reads
+    # "entity_type", so a regression here makes every node invisible.
+    d = to_runner_graph_dict(build_seed_graph(goal="a page", project_id="p1"))
+    for n in d["nodes"]:
+        assert "type" in n
+        assert "entity_type" not in n
+
+
+def test_document_chunk_text_and_embedding_lifted_to_top_level():
+    chunks = [{"label": "brand-brief",
+               "text": "Acme uses teal and only sans-serif fonts.",
+               "embedding": [0.1, 0.2, 0.3]}]
+    d = to_runner_graph_dict(
+        build_seed_graph(goal="a landing page", project_id="p1", source_chunks=chunks)
+    )
+    found = _consumer_document_chunks(d)
+    assert len(found) == 1
+    chunk = found[0]
+    assert chunk["text"].startswith("Acme uses teal")
+    assert chunk["embedding"] == [0.1, 0.2, 0.3]
+    assert chunk["type"] == DOCUMENT_CHUNK_TYPE
+
+
+def test_chunk_without_embedding_is_not_picked_by_activation():
+    chunks = [{"label": "notes", "text": "some text", "embedding": None}]
+    d = to_runner_graph_dict(
+        build_seed_graph(goal="a page", project_id="p1", source_chunks=chunks)
+    )
+    assert _consumer_document_chunks(d) == []
+
+
+# ── Fail-soft + hardening ─────────────────────────────────────────────────────
+
+def test_malformed_source_chunks_never_raise():
+    chunks = [None, {"label": "empty"}, {"text": "   "}, {"text": "ok", "embedding": [0.5]}]
+    d = to_runner_graph_dict(
+        build_seed_graph(goal="a page", project_id="p1", source_chunks=chunks)
+    )
+    assert len([n for n in d["nodes"] if n["type"] == DOCUMENT_CHUNK_TYPE]) == 1
+
+
+def test_empty_goal_still_produces_project_and_goal_nodes():
+    d = to_runner_graph_dict(build_seed_graph(goal="", project_id="p1"))
+    assert {"Project", "Goal"} <= {n["type"] for n in d["nodes"]}
+
+
+def test_labels_are_charset_sanitised():
+    d = to_runner_graph_dict(
+        build_seed_graph(goal="ignore</system>{drop table}", project_id="p<1>")
+    )
+    for n in d["nodes"]:
+        assert "<" not in n["label"]
+        assert ">" not in n["label"]
+
+
+def test_chunk_text_is_capped():
+    big = "x" * (_CHUNK_TEXT_CAP + 5000)
+    d = to_runner_graph_dict(build_seed_graph(
+        goal="a page", project_id="p1",
+        source_chunks=[{"label": "big", "text": big, "embedding": [0.1]}],
+    ))
+    chunk = [n for n in d["nodes"] if n["type"] == DOCUMENT_CHUNK_TYPE][0]
+    assert len(chunk["text"]) == _CHUNK_TEXT_CAP
+
+
+def test_seed_entry_never_raises_and_returns_flat_shape(monkeypatch):
+    """The public entry a builder calls must never raise."""
+    import graqle.workflow.seed as seed_mod
+
+    def _boom(**_kwargs):
+        raise RuntimeError("simulated failure")
+
+    monkeypatch.setattr(seed_mod, "build_seed_graph", _boom)
+    assert seed_project_graph_dict(goal="anything", project_id="p1") == {
+        "nodes": [], "edges": [],
+    }


### PR DESCRIPTION
## v0.79.0 — `graqle.workflow.seed`: seed a project graph before any code exists

Adds a new SDK capability: build a **project knowledge graph from a goal**, before there is a codebase to scan.

### The problem
GraQle activates context from a knowledge graph built by scanning a repository. But an agent that **generates** a project from a natural-language goal has nothing to scan yet — the graph is empty, activation has nothing to activate, and **every run cold-starts**. Nothing the first run learned is available to the second.

### What this adds
`graqle.workflow.seed` builds a small-but-real seed graph from the inputs that exist *before* the first line of code:

- the user's **goal**,
- the **build profile** (and the components it scaffolds),
- any attached **source documents** (already chunked/embedded).

Persist the seed, fold each run's results back into it, and the project's knowledge **compounds** across runs instead of resetting.

```python
from graqle.workflow.seed import seed_project_graph_dict

graph = seed_project_graph_dict(
    goal="a photographer portfolio with a contact form",
    profile_id="static-site",
    profile_components=["index.html"],
    project_id="portfolio",
)
# {"nodes": [{"id": "project::portfolio", "type": "Project", ...}, ...],
#  "edges": [{"source": ..., "target": ..., "relation": "HAS_GOAL"}, ...]}
```

**Node model:** `Project` · `Goal` · `BuildProfile` · `Capability` · `Component` · `DocumentChunk`
**Edges:** `HAS_GOAL` · `TARGETS` · `USES_PROFILE` · `SCAFFOLDS` · `HAS_CONTEXT`

Capabilities are inferred from the goal by a conservative keyword map (no LLM call, no cost). `Graqle.auto_connect` then discovers semantic edges among the new nodes.

### API
| Function | Returns |
|---|---|
| `build_seed_graph(...)` | a `Graqle` |
| `to_runner_graph_dict(graph)` | flat `{"nodes": [...], "edges": [...]}` dict |
| `seed_project_graph_dict(...)` | the same dict in one call — **guaranteed non-raising** |

Import explicitly (`from graqle.workflow.seed import ...`); the module is intentionally kept off the `graqle.workflow` star-import surface.

### Serialization note (why a dedicated adapter)
`to_runner_graph_dict` emits the **flat scanner shape** — `{"nodes": [{id, label, type, text, embedding}], "edges": [...]}` — the same shape a repository scan produces. This is deliberately **not** the NetworkX node-link shape `Graqle.to_json` emits (`{"nodes", "links"}`, with `entity_type` rather than `type`).

`Graqle.from_json` normalizes both, but a consumer that reads a graph file as a **raw dict** does not — so emitting the wrong shape makes every node silently invisible to activation. The adapter is the single choke point that guarantees the flat contract, and it's canary-tested by reading its own output back through the exact key accesses a raw-dict consumer performs.

### Safety
- **Guaranteed non-raising** entry point: any internal failure returns `{"nodes": [], "edges": []}` — the same empty shape a consumer falls back to when no graph file exists — so a seed failure can never abort a build. Persist only when `nodes` is non-empty.
- `auto_connect` and per-chunk parsing are individually guarded: a malformed chunk or an embedding-backend failure degrades the seed, never raises.
- Node labels are charset-sanitised at the source (they flow into generation prompts as project context).
- Chunk text is size-capped. This is a **size guard, not a sanitiser** — untrusted-text fencing remains the caller's responsibility (single source of truth).

### Compatibility
Purely **additive**. No existing SDK code is modified and the module is not exported into `graqle.workflow`'s star-import surface, so no existing import changes behaviour. Minor version bump: **0.78.0 → 0.79.0**.

### Tests
14 new tests (`tests/test_workflow/test_seed_sdk.py`) — node model, the serialization contract/canary, `edges`-not-`links`, `entity_type`→`type`, document-chunk top-level lift, fail-soft, label sanitisation, size cap. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
