### PR TITLE
Tier-derived node limits + warn-only usage meter

### DIFF
--- a/graqle/cli/commands/scan.py
+++ b/graqle/cli/commands/scan.py
@@ -1900,14 +1900,10 @@ def _show_cloud_onboarding_nudge(graph_data: dict, graqle_dir: Path) -> None:
             title="[dim]One-time tip[/dim]",
             border_style="dim",
         ))
-    elif creds.plan == "free" and node_count > 400:
-        # Free user near the 500-node limit — show upgrade CTA
-        pct = int(node_count / 500 * 100)
-        console.print(
-            f"\n[dim]You're at [yellow]{pct}%[/yellow] of the Free plan node limit "
-            f"({node_count:,}/500). Team plan: unlimited nodes + Neptune cloud sync. "
-            "[cyan]graqle.com/pricing[/cyan][/dim]"
-        )
+    # NOTE (CR-LIC-01): the legacy free-plan node-limit CTA that lived here was
+    # superseded by _record_usage_meter — one meter, one message, one CTA.
+    # Keeping two thresholds with two different upgrade paths (cloud plan vs
+    # licence) double-messaged users at the exact conversion moment.
 
     try:
         graqle_dir.mkdir(parents=True, exist_ok=True)

--- a/graqle/cli/commands/scan.py
+++ b/graqle/cli/commands/scan.py
@@ -1916,6 +1916,46 @@ def _show_cloud_onboarding_nudge(graph_data: dict, graqle_dir: Path) -> None:
         pass
 
 
+def _record_usage_meter(graph_data: dict, graqle_dir: Path) -> None:
+    """Record scan size against tier-derived limits — warn-only (CR-LIC-01).
+
+    Prints one line at WARN/AT_CAP (suppressed in non-TTY). Never raises:
+    metering failure must never break a scan. Enforcement is CR-LIC-03.
+    """
+    try:
+        from graqle.licensing.limits import resolve_limits
+        from graqle.licensing.manager import _get_manager
+        from graqle.licensing.meter import MeterStatus, UsageMeter
+
+        limits = resolve_limits(_get_manager().license)
+        reading = UsageMeter(graqle_dir).record(
+            len(graph_data.get("nodes", [])), limits
+        )
+
+        import sys
+
+        if not sys.stdout.isatty():
+            return
+        if reading.status is MeterStatus.WARN:
+            console.print(
+                f"\n[yellow]Graph at {reading.node_count:,}/{reading.max_nodes:,} "
+                f"nodes ({reading.percent_used}%) on the current plan.[/yellow] "
+                "[dim]Register free for more headroom: "
+                "[cyan]https://graqle.com/signup[/cyan][/dim]"
+            )
+        elif reading.status is MeterStatus.AT_CAP:
+            console.print(
+                f"\n[yellow]Graph reached the current plan's node cap "
+                f"({reading.node_count:,}/{reading.max_nodes:,}).[/yellow] "
+                "[dim]Nothing is blocked or deleted. Plans: "
+                "[cyan]https://graqle.com/pricing[/cyan][/dim]"
+            )
+    except Exception as exc:
+        import logging
+
+        logging.getLogger("graqle.cli.scan").debug("usage meter skipped: %s", exc)
+
+
 # ---------------------------------------------------------------------------
 # Summary Formatting
 # ---------------------------------------------------------------------------
@@ -2186,7 +2226,8 @@ def _scan_repo_impl(
         except Exception:
             pass
 
-    # Cloud onboarding nudge — show once if user isn't connected to cloud yet
+    # Usage meter (CR-LIC-01) — warn-only high-water mark, then onboarding nudge
+    _record_usage_meter(data, Path(".graqle"))
     _show_cloud_onboarding_nudge(data, Path(".graqle"))
 
 

--- a/graqle/licensing/limits.py
+++ b/graqle/licensing/limits.py
@@ -1,0 +1,130 @@
+"""Tier-derived node limits — CR-LIC-01 (ADR-244 composite-trigger monetisation).
+
+Resolves the *effective* node cap for the current install without any change to
+the ``graqle-license-v2`` wire format:
+
+* **No licence key at all** → anonymous install → ``ANONYMOUS_MAX_NODES``.
+* **Licence with tier FREE** → registered free user → ``TIER_MAX_NODES[FREE]``.
+* **PRO / TEAM / ENTERPRISE** → uncapped (``None``).
+* **Per-licence override** — a signed ``features`` entry of the form
+  ``max_nodes:<int>`` wins over the tier default. Because ``features`` is part
+  of the signed payload in BOTH the legacy HMAC v1 and ed25519 v2 formats, the
+  override inherits the licence signature; no new claim field is needed and no
+  previously issued licence is invalidated.
+
+Deliberately duck-typed: accepts any object exposing ``tier`` and ``features``
+(``manager.License`` today, the v2 payload dataclass tomorrow).
+
+This module only *resolves* limits. Recording usage against them lives in
+:mod:`graqle.licensing.meter`; enforcement is a later CR (CR-LIC-03) and is
+gated behind ``GRAQLE_ENFORCE_CAPS``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from graqle.licensing.manager import LicenseTier
+
+__all__ = [
+    "ANONYMOUS_MAX_NODES",
+    "TIER_MAX_NODES",
+    "WARN_RATIO",
+    "EffectiveLimits",
+    "resolve_limits",
+]
+
+# Anonymous (keyless) installs. Calibrated against the 2026-07 graph census:
+# a fresh scan of a normal project lands in the hundreds of nodes, so a normal
+# project fits; crossing the cap correlates with large repos or sustained use.
+ANONYMOUS_MAX_NODES = 500
+
+# Tier defaults. ``None`` means uncapped (fair-use).
+TIER_MAX_NODES: dict[LicenseTier, int | None] = {
+    LicenseTier.FREE: 1_000,
+    LicenseTier.PRO: None,
+    LicenseTier.TEAM: None,
+    LicenseTier.ENTERPRISE: None,
+}
+
+# Fraction of the cap at which the meter starts warning.
+WARN_RATIO = 0.8
+
+_OVERRIDE_PREFIX = "max_nodes:"
+
+
+@dataclass(frozen=True)
+class EffectiveLimits:
+    """The resolved node cap plus where it came from (for messaging/telemetry)."""
+
+    max_nodes: int | None
+    source: str  # "anonymous" | "tier:<name>" | "override"
+
+    @property
+    def unlimited(self) -> bool:
+        return self.max_nodes is None
+
+    def warn_threshold(self) -> int | None:
+        """Node count at which warnings begin, or ``None`` when uncapped."""
+        if self.max_nodes is None:
+            return None
+        return int(self.max_nodes * WARN_RATIO)
+
+
+def _override_from_features(features) -> int | None:
+    """Extract a signed ``max_nodes:<int>`` override from a features iterable.
+
+    Malformed entries are ignored (a bad override must never grant more OR
+    less than the tier default by accident — it simply doesn't apply). When
+    several overrides are present the largest wins, so a re-issued upgrade key
+    can only improve on a stale one.
+    """
+    best: int | None = None
+    for entry in features or ():
+        if not isinstance(entry, str) or not entry.startswith(_OVERRIDE_PREFIX):
+            continue
+        raw = entry[len(_OVERRIDE_PREFIX):]
+        try:
+            value = int(raw)
+        except ValueError:
+            continue
+        if value <= 0:
+            continue
+        if best is None or value > best:
+            best = value
+    return best
+
+
+def _normalise_tier(tier) -> LicenseTier | None:
+    if isinstance(tier, LicenseTier):
+        return tier
+    if isinstance(tier, str):
+        try:
+            return LicenseTier(tier)
+        except ValueError:
+            return None
+    return None
+
+
+def resolve_limits(license=None) -> EffectiveLimits:
+    """Resolve the effective node limits for ``license`` (``None`` = anonymous).
+
+    Unknown/unrecognised tiers resolve to the FREE cap rather than uncapped —
+    a garbled licence must never be more permissive than a valid one.
+    """
+    if license is None:
+        return EffectiveLimits(max_nodes=ANONYMOUS_MAX_NODES, source="anonymous")
+
+    override = _override_from_features(getattr(license, "features", None))
+    if override is not None:
+        return EffectiveLimits(max_nodes=override, source="override")
+
+    tier = _normalise_tier(getattr(license, "tier", None))
+    if tier is None:
+        return EffectiveLimits(
+            max_nodes=TIER_MAX_NODES[LicenseTier.FREE], source="tier:unknown"
+        )
+    return EffectiveLimits(
+        max_nodes=TIER_MAX_NODES.get(tier, TIER_MAX_NODES[LicenseTier.FREE]),
+        source=f"tier:{tier.value}",
+    )

--- a/graqle/licensing/manager.py
+++ b/graqle/licensing/manager.py
@@ -92,9 +92,15 @@ TIER_FEATURES: dict[LicenseTier, set[str]] = {
         "auto_grow_hook",
         "metrics_dashboard",
     },
-    # PRO tier is now reserved for future team-adjacent features.
-    # All solo developer features have been moved to FREE (v0.7.5).
-    LicenseTier.PRO: set(),
+    # PRO tier (ADR-244 composite triggers): the professional governance
+    # surface. Feature constants only in CR-LIC-01 — no gating call sites yet;
+    # enforcement lands in CR-LIC-03.
+    LicenseTier.PRO: {
+        "governance_suite",  # preflight, impact, review, predict, release_gate
+        "ci_mode",  # headless/CI execution
+        "multi_backend_debate",  # R15 debate + task routing
+        "unlimited_learn",  # lessons beyond the free-tier cap
+    },
     LicenseTier.TEAM: {
         "shared_kg_sync",
         "multi_instance_coordination",

--- a/graqle/licensing/meter.py
+++ b/graqle/licensing/meter.py
@@ -103,6 +103,19 @@ class UsageMeter:
         except OSError as exc:
             logger.debug("meter persistence skipped: %s", exc)
 
+    def _ensure_gitignore(self) -> None:
+        """Self-ignore the meter file so it never lands in shared-repo diffs.
+
+        Only creates ``.gitignore`` when the directory has none — an existing
+        file (user-managed) is never touched.
+        """
+        try:
+            gi = self._path.parent / ".gitignore"
+            if not gi.exists():
+                gi.write_text("meter.json\n", encoding="utf-8")
+        except OSError as exc:
+            logger.debug("meter gitignore skipped: %s", exc)
+
     # -- public API --------------------------------------------------------
 
     @property
@@ -121,16 +134,22 @@ class UsageMeter:
         except (TypeError, ValueError):
             count = 0
 
-        hwm = max(self.high_water_mark, count)
-        self._store(
-            {
-                "schema_version": _SCHEMA_VERSION,
-                "high_water_mark": hwm,
-                "last_node_count": count,
-                "limit_source": limits.source,
-                "updated_at": datetime.now(timezone.utc).isoformat(),
-            }
-        )
+        prev_hwm = self.high_water_mark
+        hwm = max(prev_hwm, count)
+        # Write only when the high-water mark advances (or on first record):
+        # a scan that changes nothing must not dirty a committed working tree
+        # (shared-repo diff churn — CR-LIC-01 pre-merge debate, point 3).
+        if hwm > prev_hwm or not self._path.exists():
+            self._store(
+                {
+                    "schema_version": _SCHEMA_VERSION,
+                    "high_water_mark": hwm,
+                    "last_node_count": count,
+                    "limit_source": limits.source,
+                    "updated_at": datetime.now(timezone.utc).isoformat(),
+                }
+            )
+            self._ensure_gitignore()
 
         if limits.unlimited:
             status = MeterStatus.OK

--- a/graqle/licensing/meter.py
+++ b/graqle/licensing/meter.py
@@ -1,0 +1,151 @@
+"""Warn-only usage meter — CR-LIC-01 (ADR-244).
+
+Persists a per-project **high-water mark** of graph node count in
+``.graqle/meter.json`` and reports where the current count sits relative to the
+resolved :class:`~graqle.licensing.limits.EffectiveLimits`.
+
+Design constraints (constitutional for this CR):
+
+* **Never blocks, never raises out of** :meth:`UsageMeter.record` — this CR is
+  telemetry + messaging only. Enforcement arrives in CR-LIC-03 behind the
+  ``GRAQLE_ENFORCE_CAPS`` environment flag (reserved here, intentionally
+  unread).
+* **High-water mark, not current count** — deleting nodes or re-scanning a
+  pruned tree does not lower the recorded peak, so the meter cannot be gamed
+  by shrink-then-grow cycles.
+* **Corruption-tolerant** — a damaged meter file is treated as empty and
+  rewritten; a read-only filesystem degrades to in-memory readings. In the
+  warn-only phase, metering failure must never break a scan.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+
+from graqle.licensing.limits import EffectiveLimits
+
+logger = logging.getLogger("graqle.licensing.meter")
+
+__all__ = ["ENFORCE_ENV", "METER_FILENAME", "MeterStatus", "MeterReading", "UsageMeter"]
+
+# Reserved for CR-LIC-03 enforcement. This module never reads it.
+ENFORCE_ENV = "GRAQLE_ENFORCE_CAPS"
+
+METER_FILENAME = "meter.json"
+_SCHEMA_VERSION = 1
+
+
+class MeterStatus(str, Enum):
+    OK = "OK"
+    WARN = "WARN"          # >= warn threshold (80% of cap by default)
+    AT_CAP = "AT_CAP"      # >= cap (informational only in CR-LIC-01)
+
+
+@dataclass(frozen=True)
+class MeterReading:
+    status: MeterStatus
+    node_count: int
+    high_water_mark: int
+    max_nodes: int | None
+
+    @property
+    def percent_used(self) -> int | None:
+        """Whole-percent usage of the cap, or ``None`` when uncapped."""
+        if not self.max_nodes:
+            return None
+        return int(self.node_count / self.max_nodes * 100)
+
+
+class UsageMeter:
+    """High-water-mark meter persisted under a project's ``.graqle`` directory."""
+
+    def __init__(self, graqle_dir: Path | str):
+        self._path = Path(graqle_dir) / METER_FILENAME
+
+    # -- persistence -------------------------------------------------------
+
+    def _load(self) -> dict:
+        try:
+            with open(self._path, encoding="utf-8") as f:
+                data = json.load(f)
+            if not isinstance(data, dict):
+                return {}
+            return data
+        except (OSError, ValueError):
+            return {}
+
+    def _store(self, data: dict) -> None:
+        """Atomic write (tmpfile → fsync → replace). Failures are logged, not raised."""
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            fd, tmp = tempfile.mkstemp(
+                dir=str(self._path.parent), prefix=".meter-", suffix=".tmp"
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    json.dump(data, f, indent=2, sort_keys=True)
+                    f.flush()
+                    os.fsync(f.fileno())
+                os.replace(tmp, self._path)
+            finally:
+                if os.path.exists(tmp):
+                    try:
+                        os.unlink(tmp)
+                    except OSError:
+                        pass
+        except OSError as exc:
+            logger.debug("meter persistence skipped: %s", exc)
+
+    # -- public API --------------------------------------------------------
+
+    @property
+    def high_water_mark(self) -> int:
+        raw = self._load().get("high_water_mark", 0)
+        return raw if isinstance(raw, int) and raw >= 0 else 0
+
+    def record(self, node_count: int, limits: EffectiveLimits) -> MeterReading:
+        """Record ``node_count``, advance the high-water mark, classify status.
+
+        Never raises. Warn-only: callers may print the status but nothing in
+        this CR blocks on it.
+        """
+        try:
+            count = max(0, int(node_count))
+        except (TypeError, ValueError):
+            count = 0
+
+        hwm = max(self.high_water_mark, count)
+        self._store(
+            {
+                "schema_version": _SCHEMA_VERSION,
+                "high_water_mark": hwm,
+                "last_node_count": count,
+                "limit_source": limits.source,
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+
+        if limits.unlimited:
+            status = MeterStatus.OK
+        elif count >= (limits.max_nodes or 0):
+            status = MeterStatus.AT_CAP
+        else:
+            warn_at = limits.warn_threshold()
+            status = (
+                MeterStatus.WARN
+                if warn_at is not None and count >= warn_at
+                else MeterStatus.OK
+            )
+        return MeterReading(
+            status=status,
+            node_count=count,
+            high_water_mark=hwm,
+            max_nodes=limits.max_nodes,
+        )

--- a/tests/test_licensing/test_limits_meter.py
+++ b/tests/test_licensing/test_limits_meter.py
@@ -151,6 +151,30 @@ def test_unlimited_license_always_ok(tmp_path):
     assert reading.percent_used is None
 
 
+def test_meter_skips_rewrite_when_hwm_unchanged(tmp_path):
+    # Shared-repo diff churn guard: a scan that doesn't advance the HWM must
+    # not touch the file (pre-merge debate point 3).
+    meter = UsageMeter(tmp_path)
+    meter.record(400, _anon())
+    before = (tmp_path / METER_FILENAME).read_bytes()
+    meter.record(400, _anon())
+    meter.record(120, _anon())
+    assert (tmp_path / METER_FILENAME).read_bytes() == before
+
+
+def test_meter_self_gitignores(tmp_path):
+    UsageMeter(tmp_path).record(10, _anon())
+    gi = tmp_path / ".gitignore"
+    assert gi.exists()
+    assert "meter.json" in gi.read_text(encoding="utf-8")
+
+
+def test_meter_leaves_existing_gitignore_alone(tmp_path):
+    (tmp_path / ".gitignore").write_text("custom\n", encoding="utf-8")
+    UsageMeter(tmp_path).record(10, _anon())
+    assert (tmp_path / ".gitignore").read_text(encoding="utf-8") == "custom\n"
+
+
 def test_meter_tolerates_bad_node_count(tmp_path):
     reading = UsageMeter(tmp_path).record("garbage", _anon())  # type: ignore[arg-type]
     assert reading.status is MeterStatus.OK

--- a/tests/test_licensing/test_limits_meter.py
+++ b/tests/test_licensing/test_limits_meter.py
@@ -1,0 +1,157 @@
+"""CR-LIC-01 — tier-derived limits resolution + warn-only high-water-mark meter."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from graqle.licensing.limits import (
+    ANONYMOUS_MAX_NODES,
+    TIER_MAX_NODES,
+    EffectiveLimits,
+    resolve_limits,
+)
+from graqle.licensing.manager import LicenseTier
+from graqle.licensing.meter import METER_FILENAME, MeterStatus, UsageMeter
+
+
+# ---------------------------------------------------------------------------
+# resolve_limits
+# ---------------------------------------------------------------------------
+
+
+def test_anonymous_gets_500():
+    limits = resolve_limits(None)
+    assert limits.max_nodes == ANONYMOUS_MAX_NODES == 500
+    assert limits.source == "anonymous"
+    assert not limits.unlimited
+
+
+def test_registered_free_key_gets_1000():
+    lic = SimpleNamespace(tier=LicenseTier.FREE, features=set())
+    limits = resolve_limits(lic)
+    assert limits.max_nodes == 1_000
+    assert limits.source == "tier:free"
+
+
+@pytest.mark.parametrize(
+    "tier", [LicenseTier.PRO, LicenseTier.TEAM, LicenseTier.ENTERPRISE]
+)
+def test_paid_tiers_uncapped(tier):
+    limits = resolve_limits(SimpleNamespace(tier=tier, features=set()))
+    assert limits.unlimited
+    assert limits.max_nodes is None
+    assert limits.warn_threshold() is None
+
+
+def test_tier_accepts_string_values():
+    limits = resolve_limits(SimpleNamespace(tier="free", features=set()))
+    assert limits.max_nodes == TIER_MAX_NODES[LicenseTier.FREE]
+
+
+def test_unknown_tier_fails_to_free_cap_not_unlimited():
+    limits = resolve_limits(SimpleNamespace(tier="platinum", features=set()))
+    assert limits.max_nodes == TIER_MAX_NODES[LicenseTier.FREE]
+    assert limits.source == "tier:unknown"
+
+
+def test_signed_feature_override_wins():
+    lic = SimpleNamespace(tier=LicenseTier.FREE, features={"max_nodes:5000"})
+    limits = resolve_limits(lic)
+    assert limits.max_nodes == 5_000
+    assert limits.source == "override"
+
+
+def test_largest_override_wins():
+    lic = SimpleNamespace(
+        tier=LicenseTier.FREE, features={"max_nodes:2000", "max_nodes:800"}
+    )
+    assert resolve_limits(lic).max_nodes == 2_000
+
+
+@pytest.mark.parametrize(
+    "bad", ["max_nodes:", "max_nodes:abc", "max_nodes:-5", "max_nodes:0", 42]
+)
+def test_malformed_overrides_ignored(bad):
+    lic = SimpleNamespace(tier=LicenseTier.FREE, features={bad} if isinstance(bad, str) else {bad})
+    limits = resolve_limits(lic)
+    assert limits.max_nodes == TIER_MAX_NODES[LicenseTier.FREE]
+    assert limits.source == "tier:free"
+
+
+def test_warn_threshold_is_80_percent():
+    assert EffectiveLimits(max_nodes=500, source="anonymous").warn_threshold() == 400
+
+
+# ---------------------------------------------------------------------------
+# UsageMeter
+# ---------------------------------------------------------------------------
+
+
+def _anon() -> EffectiveLimits:
+    return resolve_limits(None)
+
+
+def test_meter_ok_below_warn(tmp_path):
+    reading = UsageMeter(tmp_path).record(100, _anon())
+    assert reading.status is MeterStatus.OK
+    assert reading.high_water_mark == 100
+    assert reading.percent_used == 20
+
+
+def test_meter_warns_at_80_percent(tmp_path):
+    reading = UsageMeter(tmp_path).record(400, _anon())
+    assert reading.status is MeterStatus.WARN
+
+
+def test_meter_at_cap(tmp_path):
+    reading = UsageMeter(tmp_path).record(500, _anon())
+    assert reading.status is MeterStatus.AT_CAP
+    assert reading.percent_used == 100
+
+
+def test_meter_never_blocks_above_cap(tmp_path):
+    # Warn-only phase: recording far beyond the cap still succeeds.
+    reading = UsageMeter(tmp_path).record(15_453, _anon())
+    assert reading.status is MeterStatus.AT_CAP
+    assert reading.high_water_mark == 15_453
+
+
+def test_high_water_mark_never_decreases(tmp_path):
+    meter = UsageMeter(tmp_path)
+    meter.record(450, _anon())
+    reading = meter.record(50, _anon())
+    assert reading.node_count == 50
+    assert reading.high_water_mark == 450
+
+
+def test_meter_persists_across_instances(tmp_path):
+    UsageMeter(tmp_path).record(321, _anon())
+    assert UsageMeter(tmp_path).high_water_mark == 321
+    data = json.loads((tmp_path / METER_FILENAME).read_text(encoding="utf-8"))
+    assert data["high_water_mark"] == 321
+    assert data["schema_version"] == 1
+
+
+def test_corrupt_meter_file_treated_as_empty(tmp_path):
+    (tmp_path / METER_FILENAME).write_text("{not json", encoding="utf-8")
+    meter = UsageMeter(tmp_path)
+    assert meter.high_water_mark == 0
+    reading = meter.record(10, _anon())
+    assert reading.status is MeterStatus.OK
+    assert reading.high_water_mark == 10
+
+
+def test_unlimited_license_always_ok(tmp_path):
+    limits = resolve_limits(SimpleNamespace(tier=LicenseTier.PRO, features=set()))
+    reading = UsageMeter(tmp_path).record(1_000_000, limits)
+    assert reading.status is MeterStatus.OK
+    assert reading.percent_used is None
+
+
+def test_meter_tolerates_bad_node_count(tmp_path):
+    reading = UsageMeter(tmp_path).record("garbage", _anon())  # type: ignore[arg-type]
+    assert reading.status is MeterStatus.OK
+    assert reading.node_count == 0

--- a/tests/test_licensing/test_manager.py
+++ b/tests/test_licensing/test_manager.py
@@ -126,10 +126,20 @@ class TestTierFeatures:
         assert "ontology_generator" in free
         assert "mcp_learn" in free
 
-    def test_pro_tier_is_empty(self):
-        """PRO tier reserved for future team-adjacent features (v0.7.5)."""
+    def test_pro_tier_governance_surface(self):
+        """PRO tier carries the professional governance surface (ADR-244, CR-LIC-01).
+
+        Replaces test_pro_tier_is_empty: the v0.7.5 'PRO is reserved/empty'
+        policy is deliberately reversed — PRO is the paid professional tier.
+        These are feature constants only; gating call sites land in CR-LIC-03.
+        """
         pro = TIER_FEATURES[LicenseTier.PRO]
-        assert len(pro) == 0
+        assert "governance_suite" in pro
+        assert "ci_mode" in pro
+        assert "multi_backend_debate" in pro
+        assert "unlimited_learn" in pro
+        # Solo features stay FREE — PRO must not claw back the v0.7.5 grants.
+        assert not (pro & TIER_FEATURES[LicenseTier.FREE])
 
     def test_team_tier_features(self):
         team = TIER_FEATURES[LicenseTier.TEAM]


### PR DESCRIPTION
Community release of the node-limit ladder and usage meter (warn-only — nothing is enforced or blocked).

- `graqle/licensing/limits.py` — tier-derived node caps: anonymous 500 / registered-free 1,000 / paid uncapped; signed `max_nodes:<int>` licence feature overrides; unknown tiers fail closed
- `graqle/licensing/meter.py` — local, tamper-evident high-water-mark usage meter; writes only when the HWM advances; self-gitignores; never blocks any operation
- `graq scan` prints a single advisory line when a graph exceeds the tier cap (informational only)
- Restores the PRO feature set definition (governance suite, CI mode, multi-backend debate, unlimited learn)

Enforcement remains OFF (`GRAQLE_ENFORCE_CAPS` gate, default disabled) — this release only surfaces information. Reads are never gated.

Verification: 81/81 targeted licensing tests pass on this branch; two-round internal review completed at the original merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)