### PR TITLE
Release 0.80.0: version bump + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## 0.80.0 (2026-07-18) — [Plugin bundles + node-limit visibility (warn-only)]
+
+> Distribution: repo-scoped plugin bundles for Claude Code
+> (`/plugin marketplace add quantamixsol/graqle`) and the Codex CLI, plus a
+> refreshed MCP Registry manifest. Licensing: tier-derived node limits and a
+> local warn-only usage meter — **nothing is enforced or blocked**; reads are
+> never gated.
+
+- **Claude Code plugin bundle** — `.claude-plugin/marketplace.json` +
+  `plugins/claude-code/graqle/` (stdio MCP server, `governed-bug-fix` +
+  `graph-onboard` skills, optional governance gate hook — advisory by default,
+  `GRAQLE_GATE_MODE=enforce` opts into fail-closed).
+- **Codex plugin bundle** — `.agents/plugins/marketplace.json` +
+  `plugins/codex/graqle/` (interface manifest, same skills).
+- **MCP Registry** — `server.json` refreshed (0.80.0, description, websiteUrl).
+- **`graqle.licensing.limits`** — tier-derived node caps (anonymous 500 /
+  registered-free 1,000 / paid uncapped) with signed `max_nodes:<int>` licence
+  feature overrides; unknown tiers fail closed. Informational in this release.
+- **`graqle.licensing.meter`** — local, tamper-evident high-water-mark usage
+  meter; writes only when the high-water mark advances; self-gitignores; never
+  blocks any operation.
+- **`graq scan`** — single advisory line when a graph exceeds the tier cap.
+- PRO feature-set definition restored (governance suite, CI mode,
+  multi-backend debate, unlimited learn).
+
+---
+
 ## 0.76.0 (2026-06-26) — [G1 multi-tenant memory isolation + WS-F trade-secret wheel gate]
 
 > ADR-225 G1 isolation layer 3: per-tenant `ReasoningMemory` registry with

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.79.0"
+__version__ = "0.80.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ name = "graqle"
 # (first-to-finish/best-of-N) + CostAwareRouter (auto cost/latency selection) —
 # dual-provider autonomy. 0.77.0 = ADR-239 Stage 2
 # (CheckpointProtocol + run_tests). 0.76.0 = ADR-225 G1 multi-tenant memory.
-version = "0.79.0"
+version = "0.80.0"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/quantamixsol/graqle",
     "source": "github"
   },
-  "version": "0.79.0",
+  "version": "0.80.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "graqle",
-      "version": "0.79.0",
+      "version": "0.80.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Version bump 0.79.0 -> 0.80.0 (pyproject.toml, __version__.py, server.json, CHANGELOG) for the 0.80.0 release: plugin bundles (Claude Code + Codex), MCP Registry manifest refresh, and warn-only tier limits + usage meter (nothing enforced; reads never gated). All features already merged on master (#227, #228).

After merge: verify CI green -> tag v0.80.0 -> CI publishes to PyPI (trusted publishing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)