### PR TITLE
CR-DIST: bump plugin manifests to 0.80.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -13,7 +13,7 @@
       "name": "graqle",
       "source": "./plugins/codex/graqle",
       "description": "Graph-powered codebase reasoning, impact analysis, and governed edits via the GraQle MCP server, plus governed-workflow skills.",
-      "version": "0.79.0",
+      "version": "0.80.0",
       "author": {
         "name": "Quantamix Solutions",
         "url": "https://graqle.com"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "graqle",
       "source": "./plugins/claude-code/graqle",
       "description": "Graph-powered codebase reasoning, impact analysis, and governed edits via the GraQle MCP server, plus governed-workflow skills and an optional governance gate hook.",
-      "version": "0.79.0",
+      "version": "0.80.0",
       "author": {
         "name": "Quantamix Solutions",
         "url": "https://graqle.com"

--- a/plugins/claude-code/graqle/.claude-plugin/plugin.json
+++ b/plugins/claude-code/graqle/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "graqle",
-  "version": "0.79.0",
+  "version": "0.80.0",
   "description": "GraQle dev intelligence layer: graph-powered codebase reasoning, impact analysis, and governed edits via MCP, plus governed-workflow skills and an optional governance gate hook.",
   "author": {
     "name": "Quantamix Solutions",

--- a/plugins/codex/graqle/.codex-plugin/plugin.json
+++ b/plugins/codex/graqle/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "graqle",
-  "version": "0.79.0",
+  "version": "0.80.0",
   "description": "GraQle dev intelligence layer: graph-powered codebase reasoning, impact analysis, and governed edits via MCP, plus governed-workflow skills.",
   "interface": {
     "displayName": "GraQle",


### PR DESCRIPTION
## Public version bump — plugin manifests to 0.80.0

Public cherry-pick of the functional version bumps from private PR #304 (merged). Aligns the Claude Code + Codex plugin manifests with the 0.80.0 PyPI/MCP-registry release so the community/directory listing shows the current version.

### Changed (4 functional manifests only)
- `.claude-plugin/marketplace.json` — plugin version 0.79.0 → 0.80.0
- `.agents/plugins/marketplace.json` — plugin version 0.79.0 → 0.80.0
- `plugins/claude-code/graqle/.claude-plugin/plugin.json` — 0.79.0 → 0.80.0
- `plugins/codex/graqle/.codex-plugin/plugin.json` — 0.79.0 → 0.80.0

### Deliberately NOT included
- Internal submission notes (`SUBMISSION.md`) stay private — only what the plugins need to resolve goes public.

### Validation
- `claude plugin validate` PASSES.

### Why
The Anthropic claude-community submission form clones this public repo; this makes the listed version match the shipped release before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)