### PR TITLE
fix(monetisation): dead upgrade link graqle.dev -> graqle.com

### DIFF
--- a/graqle/activation/providers.py
+++ b/graqle/activation/providers.py
@@ -181,7 +181,7 @@ class ActivationVerdict:
             "message": (
                 f"This turn scored {self.safety.score:.2f} (DRACE). Pro mode "
                 "would block this automatically. Upgrade to enforce "
-                "governance in your workflow: https://graqle.dev/pricing"
+                "governance in your workflow: https://graqle.com/pricing"
             ),
         }
 

--- a/tests/test_activation/test_activation_layer.py
+++ b/tests/test_activation/test_activation_layer.py
@@ -59,7 +59,7 @@ def test_advisory_blocked_worthy_shows_upgrade_chip():
     chip = v.advisory_chip
     assert chip is not None
     assert chip["kind"] == "upgrade_to_enforce"
-    assert "graqle.dev/pricing" in chip["message"]
+    assert "graqle.com/pricing" in chip["message"]
     assert chip["drace_score"] == 0.2
 
 


### PR DESCRIPTION
Public cherry-pick of private #306, branched off **current** master (supersedes #233, which fell BEHIND after #231/#232 landed and showed a stale-base conflict in the UI).

The Free-tier advisory upgrade chip (`graqle/activation/providers.py:184`) pointed at the dead host `graqle.dev/pricing` while every other CTA uses `graqle.com/pricing` — a broken link in the live upgrade funnel = **lost conversions**. Fix the URL + the test that asserted it. `test_advisory_blocked_worthy_shows_upgrade_chip` passes.

Up-to-date with master, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)