### PR TITLE
CR-010.R4 — Enterprise-gateway LLM backend (GatewayBackend)

### DIFF
--- a/graqle/backends/api.py
+++ b/graqle/backends/api.py
@@ -86,6 +86,12 @@ async def _retry_with_backoff(
             return await func()
         except ImportError:
             raise  # Don't retry import errors
+        except GatewayAuthError:
+            # A 401 is an auth failure, not a transient network error. The
+            # gateway's own refresh-once retry (GatewayBackend.generate) is the
+            # only 401 retry; re-running the generic backoff would re-invoke the
+            # refresh command on every attempt. Surface it immediately. (CR-010.R4)
+            raise
         except Exception as e:
             last_error = e
             if attempt < max_retries - 1:
@@ -712,6 +718,37 @@ class CustomBackend(BaseBackend):
         self._timeout = timeout
         self._max_retries = max_retries
 
+    def _build_headers(self) -> dict[str, str]:
+        """Request headers for an OpenAI-compatible call.
+
+        Extracted from ``generate()`` (CR-010.R4) so subclasses — notably
+        ``GatewayBackend`` — can add organization / RPC / project headers by
+        overriding this one method. Behaviour is byte-identical to the prior
+        inline construction: ``Content-Type`` always, ``Authorization: Bearer``
+        only when an api_key is present.
+        """
+        headers = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        return headers
+
+    def _build_payload(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int,
+        temperature: float,
+        stop: list[str] | None,
+    ) -> dict[str, Any]:
+        """OpenAI-compatible chat-completions request body (extracted CR-010.R4)."""
+        return {
+            "model": self._model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "stop": stop,
+        }
+
     async def generate(
         self,
         prompt: str,
@@ -727,20 +764,15 @@ class CustomBackend(BaseBackend):
                 raise ImportError(
                     "Custom backend requires 'httpx'. Install with: pip install httpx"
                 )
-            headers = {"Content-Type": "application/json"}
-            if self._api_key:
-                headers["Authorization"] = f"Bearer {self._api_key}"
+            headers = self._build_headers()
+            payload = self._build_payload(
+                prompt, max_tokens=max_tokens, temperature=temperature, stop=stop
+            )
             async with httpx.AsyncClient(timeout=self._timeout) as client:
                 response = await client.post(
                     self._endpoint,
                     headers=headers,
-                    json={
-                        "model": self._model,
-                        "messages": [{"role": "user", "content": prompt}],
-                        "max_tokens": max_tokens,
-                        "temperature": temperature,
-                        "stop": stop,
-                    },
+                    json=payload,
                 )
                 response.raise_for_status()
                 data = response.json()
@@ -773,3 +805,189 @@ class CustomBackend(BaseBackend):
     @property
     def cost_per_1k_tokens(self) -> float:
         return self._cost
+
+
+class GatewayAuthError(Exception):
+    """Raised on an HTTP 401 from a gateway endpoint (CR-010.R4).
+
+    A typed exception so ``GatewayBackend`` can catch *only* auth failures for
+    its refresh-once retry, without swallowing unrelated ``httpx`` status
+    errors. Never carries the token or response body.
+    """
+
+
+class GatewayBackend(CustomBackend):
+    """Enterprise OpenAI-compatible **gateway** backend (CR-010.R4).
+
+    Extends ``CustomBackend`` with the things real corporate gateways need — and
+    that previously required wrapper scripts:
+
+    - ``organization`` — sent as the ``OpenAI-Organization`` header (project/org routing).
+    - ``extra_headers`` — arbitrary custom RPC headers (e.g. ``Rpc-Caller``); these win
+      on key collision so a gateway can rename/override the org or auth header.
+    - ``model_allowlist`` — client-side refusal (``None`` = no restriction; ``[]`` =
+      lockdown, all models refused) enforced **before any network call**.
+    - ``on_auth_error`` — a refresh **command** (for short-lived SSO tokens): on a 401 the
+      command is run once via the R5 secrets ``command`` provider, the token is refreshed,
+      and the request is retried **exactly once**. ``"fail"`` or ``None`` disables refresh.
+
+    All new parameters are keyword-only and default ``None`` — ``CustomBackend``'s own
+    signature and behaviour are untouched, so existing callers are unaffected.
+    The gateway ``endpoint`` (``base_url``) may be a localhost sidecar-proxy URL.
+    The token is resolved via R5 ``SecretStr`` and never appears in logs or headers-repr.
+    """
+
+    def __init__(
+        self,
+        endpoint: str,
+        model: str = "default",
+        api_key: str | None = None,
+        cost: float = 0.001,
+        timeout: float = 120.0,
+        max_retries: int = MAX_RETRIES,
+        *,
+        organization: str | None = None,
+        extra_headers: dict[str, str] | None = None,
+        model_allowlist: list[str] | None = None,
+        on_auth_error: str | None = None,
+    ) -> None:
+        super().__init__(endpoint, model, api_key, cost, timeout, max_retries)
+        self._organization = organization
+        self._extra_headers = dict(extra_headers or {})
+        self._model_allowlist = model_allowlist
+        self._on_auth_error = on_auth_error
+
+    def _build_headers(self) -> dict[str, str]:
+        """Base headers + ``OpenAI-Organization`` + ``extra_headers``.
+
+        ``extra_headers`` may override most headers (a gateway can legitimately
+        rename ``OpenAI-Organization`` or add RPC headers), but ``Authorization``
+        is **reserved** (CR-010.R4 sentinel B-1): silently nulling or replacing
+        the bearer token via config is a credential-substitution vector, so a
+        case-insensitive ``Authorization`` key in ``extra_headers`` is dropped and
+        the resolved token is applied last. To send *no* auth, pass ``api_key=None``.
+        """
+        headers = super()._build_headers()
+        if self._organization:
+            headers["OpenAI-Organization"] = self._organization
+        # Reserved: never let extra_headers clobber Authorization (case-insensitive).
+        safe_extra = {
+            k: v for k, v in self._extra_headers.items()
+            if k.lower() != "authorization"
+        }
+        headers.update(safe_extra)
+        # Re-assert Authorization last so it survives any extra_headers ordering.
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        return headers
+
+    def _check_model_allowed(self) -> None:
+        """Refuse a disallowed model client-side (pre-HTTP). ``None`` = unrestricted."""
+        if self._model_allowlist is not None and self._model not in self._model_allowlist:
+            raise ValueError(
+                f"Model {self._model!r} is not in the configured model_allowlist "
+                f"{sorted(self._model_allowlist)}. Request refused client-side "
+                f"(no call made to {self._endpoint})."
+            )
+
+    def _try_refresh(self) -> bool:
+        """Run the ``on_auth_error`` refresh command once; update the token in place.
+
+        Returns True iff a fresh non-empty token was obtained. **Never raises** —
+        any failure (disabled, command error, empty token) returns False so the
+        original ``GatewayAuthError`` is what surfaces to the caller. Uses the R5
+        ``command`` secrets provider (argv, no shell) so there is no injection surface.
+        """
+        if not self._on_auth_error or self._on_auth_error.strip().lower() == "fail":
+            return False
+        try:
+            from graqle.config.secrets import resolve_secret
+
+            resolved = resolve_secret(
+                "gateway_token_refresh",
+                provider="command",
+                ref=self._on_auth_error,
+            )
+            new_token = resolved.value.get_secret_value()
+        except Exception as exc:
+            # A refresh failure must never mask the original auth error, and must
+            # never surface the refresh command's stderr/secret material. But a
+            # broken refresh pipeline must not be *invisible* (CR-010.R4 sentinel
+            # M-1) — log the exception TYPE only (never the secret/stderr).
+            logger.warning(
+                "[%s] token refresh via on_auth_error failed: %s",
+                self.name,
+                type(exc).__name__,
+            )
+            return False
+        if not new_token:
+            logger.warning(
+                "[%s] token refresh via on_auth_error returned an empty token", self.name
+            )
+            return False
+        self._api_key = new_token
+        return True
+
+    async def generate(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int = 512,
+        temperature: float = 0.3,
+        stop: list[str] | None = None,
+    ) -> GenerateResult:
+        # 1. Client-side allowlist — zero network cost on a misconfigured model.
+        self._check_model_allowed()
+
+        async def _call(*, refreshed: bool = False):
+            try:
+                import httpx
+            except ImportError:
+                raise ImportError(
+                    "Gateway backend requires 'httpx'. Install with: pip install httpx"
+                )
+            headers = self._build_headers()
+            payload = self._build_payload(
+                prompt, max_tokens=max_tokens, temperature=temperature, stop=stop
+            )
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                response = await client.post(
+                    self._endpoint, headers=headers, json=payload
+                )
+                if response.status_code == 401:
+                    # Refresh-once: on the first 401, run the refresh command and
+                    # retry exactly once. A second 401 (or no refresh) propagates.
+                    if not refreshed and self._try_refresh():
+                        return await _call(refreshed=True)
+                    raise GatewayAuthError(
+                        f"401 Unauthorized from {self._endpoint} "
+                        f"(refresh {'exhausted' if refreshed else 'unavailable'})"
+                    )
+                response.raise_for_status()
+                data = response.json()
+                choices = data.get("choices", [])
+                if not choices:
+                    logger.warning(f"[{self.name}] No choices in response")
+                    return GenerateResult(text="", model=self._model)
+                choice = choices[0]
+                message = choice.get("message", {})
+                finish_reason = choice.get("finish_reason", "") or ""
+                truncated = finish_reason == "length"
+                return GenerateResult(
+                    text=message.get("content", ""),
+                    truncated=truncated,
+                    stop_reason=finish_reason,
+                    tokens_used=None,
+                    model=self._model,
+                )
+
+        # GatewayAuthError must NOT be retried by the generic backoff (it is an
+        # auth failure, not a transient network error) — the refresh-once logic
+        # above is the only retry for 401s.
+        return await _retry_with_backoff(
+            _call, backend_name=self.name, max_retries=self._max_retries
+        )
+
+    @property
+    def name(self) -> str:
+        return f"gateway:{self._endpoint}"

--- a/graqle/backends/providers.py
+++ b/graqle/backends/providers.py
@@ -195,3 +195,51 @@ def create_provider_backend(
         api_key=resolved_key,
         cost=cost,
     )
+
+
+def create_gateway_backend(
+    base_url: str,
+    model: str,
+    *,
+    api_key: str | None = None,
+    organization: str | None = None,
+    extra_headers: dict[str, str] | None = None,
+    model_allowlist: list[str] | None = None,
+    on_auth_error: str | None = None,
+    cost: float = 0.001,
+    timeout: float = 120.0,
+) -> "GatewayBackend":
+    """Build a :class:`GatewayBackend` from an ``openai-compatible`` config stanza (CR-010.R4).
+
+    This is the factory the config layer calls when ``backend.type == "openai-compatible"``.
+    It is deliberately separate from :func:`create_provider_backend` (which is keyed on named
+    presets) so the preset path stays untouched — a gateway is config-driven, not a preset.
+
+    Args:
+        base_url: Gateway endpoint. May be a localhost sidecar-proxy URL.
+        model: Model / deployment name (may be namespaced, e.g. ``namespace/deployment-prod``).
+        api_key: Bearer token. The config layer resolves this via R5 ``resolve_secret`` and
+            passes the raw string here; ``None`` sends no ``Authorization`` header.
+        organization: Sent as the ``OpenAI-Organization`` header.
+        extra_headers: Custom RPC/project headers; these win on collision.
+        model_allowlist: Client-side allowlist (``None`` = unrestricted; ``[]`` = lockdown).
+        on_auth_error: Refresh command run once on a 401, or ``"fail"``/``None`` to disable.
+        cost: Cost per 1k tokens (for accounting).
+        timeout: Per-request timeout (seconds).
+
+    Returns:
+        A configured :class:`GatewayBackend`.
+    """
+    from graqle.backends.api import GatewayBackend
+
+    return GatewayBackend(
+        base_url,
+        model=model,
+        api_key=api_key,
+        cost=cost,
+        timeout=timeout,
+        organization=organization,
+        extra_headers=extra_headers,
+        model_allowlist=model_allowlist,
+        on_auth_error=on_auth_error,
+    )

--- a/tests/test_backends/test_gateway_backend.py
+++ b/tests/test_backends/test_gateway_backend.py
@@ -1,0 +1,300 @@
+"""CR-010.R4 — tests for the enterprise-gateway LLM backend.
+
+Covers:
+  - GatewayBackend headers: org header + extra_headers (extra win on collision)
+  - Model allowlist: allow listed; refuse unlisted client-side (pre-HTTP, no call);
+    empty list = lockdown; None = unrestricted
+  - 401 refresh-once: refresh runs once -> retry -> success; second 401 raises;
+    on_auth_error 'fail'/None -> no refresh, immediate GatewayAuthError;
+    refresh-command failure -> original 401 surfaces (not the refresh error)
+  - CustomBackend regression: _build_headers unchanged for the base class
+  - No-leak: token never in headers-repr / GatewayAuthError message
+  - create_gateway_backend factory wiring
+
+Uses a fake ``httpx`` module injected into sys.modules so no network is hit and
+the 401 path is fully controllable.
+
+See: .gsm/external/Change Requests/CR-010.R4-enterprise-gateway-backend.md
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from graqle.backends.api import (
+    CustomBackend,
+    GatewayAuthError,
+    GatewayBackend,
+)
+
+TOKEN = "TEST-MOCK-GATEWAY-TOKEN"
+REFRESHED = "TEST-MOCK-REFRESHED-TOKEN"
+
+
+# ─────────────── fake httpx ──────────────────────────────────────────────────
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, json_data=None):
+        self.status_code = status_code
+        self._json = json_data or {
+            "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]
+        }
+        self.captured_headers = None
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._json
+
+
+class _FakeClient:
+    """Records POST headers and returns a scripted sequence of responses."""
+
+    last_headers: dict | None = None
+    responses: list = []
+    call_count = 0
+
+    def __init__(self, timeout=None):
+        self._timeout = timeout
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def post(self, url, headers=None, json=None):
+        type(self).last_headers = dict(headers or {})
+        type(self).call_count += 1
+        idx = min(type(self).call_count - 1, len(type(self).responses) - 1)
+        return type(self).responses[idx]
+
+
+def _install_fake_httpx(monkeypatch, responses):
+    _FakeClient.responses = responses
+    _FakeClient.call_count = 0
+    _FakeClient.last_headers = None
+    fake = types.ModuleType("httpx")
+    fake.AsyncClient = _FakeClient
+    monkeypatch.setitem(sys.modules, "httpx", fake)
+
+
+# ─────────────── headers ─────────────────────────────────────────────────────
+
+
+def test_headers_include_org_and_extra():
+    gb = GatewayBackend(
+        "http://sidecar/v1", model="ns/prod", api_key=TOKEN,
+        organization="org-abc", extra_headers={"Rpc-Caller": "graqle", "Rpc-Service": "kg"},
+    )
+    h = gb._build_headers()
+    assert h["OpenAI-Organization"] == "org-abc"
+    assert h["Rpc-Caller"] == "graqle"
+    assert h["Rpc-Service"] == "kg"
+    assert h["Authorization"] == f"Bearer {TOKEN}"
+
+
+def test_extra_headers_win_on_collision():
+    gb = GatewayBackend(
+        "http://x", model="m", api_key=TOKEN,
+        organization="org-1", extra_headers={"OpenAI-Organization": "override"},
+    )
+    assert gb._build_headers()["OpenAI-Organization"] == "override"
+
+
+def test_extra_headers_cannot_clobber_authorization():
+    # B-1 (sentinel): extra_headers must NOT be able to null/replace the bearer token.
+    gb = GatewayBackend(
+        "http://x", model="m", api_key=TOKEN,
+        extra_headers={"authorization": "Bearer HACKED", "Authorization": ""},
+    )
+    assert gb._build_headers()["Authorization"] == f"Bearer {TOKEN}"
+
+
+def test_no_api_key_sends_no_auth_even_with_extra():
+    gb = GatewayBackend("http://x", model="m", api_key=None, extra_headers={"X-Foo": "1"})
+    assert "Authorization" not in gb._build_headers()
+
+
+# ─────────────── model allowlist ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_allowlist_allows_listed(monkeypatch):
+    _install_fake_httpx(monkeypatch, [_FakeResponse(200)])
+    gb = GatewayBackend("http://x", model="ns/prod", api_key=TOKEN, model_allowlist=["ns/prod"])
+    r = await gb.generate("hi")
+    assert r.text == "ok"
+
+
+@pytest.mark.asyncio
+async def test_allowlist_refuses_unlisted_pre_http(monkeypatch):
+    _install_fake_httpx(monkeypatch, [_FakeResponse(200)])
+    gb = GatewayBackend("http://x", model="ns/dev", api_key=TOKEN, model_allowlist=["ns/prod"])
+    with pytest.raises(ValueError) as ei:
+        await gb.generate("hi")
+    assert "not in the configured model_allowlist" in str(ei.value)
+    assert _FakeClient.call_count == 0  # refused BEFORE any network call
+
+
+@pytest.mark.asyncio
+async def test_empty_allowlist_is_lockdown(monkeypatch):
+    _install_fake_httpx(monkeypatch, [_FakeResponse(200)])
+    gb = GatewayBackend("http://x", model="anything", api_key=TOKEN, model_allowlist=[])
+    with pytest.raises(ValueError):
+        await gb.generate("hi")
+    assert _FakeClient.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_none_allowlist_unrestricted(monkeypatch):
+    _install_fake_httpx(monkeypatch, [_FakeResponse(200)])
+    gb = GatewayBackend("http://x", model="whatever", api_key=TOKEN, model_allowlist=None)
+    r = await gb.generate("hi")
+    assert r.text == "ok"
+
+
+# ─────────────── 401 refresh-once ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_401_refresh_once_then_success(monkeypatch):
+    _install_fake_httpx(monkeypatch, [_FakeResponse(401), _FakeResponse(200)])
+
+    calls = {"n": 0}
+
+    def fake_resolve(name, cfg=None, *, default=None, provider=None, ref=None):
+        calls["n"] += 1
+        from graqle.config.resolver import SecretStr
+        from graqle.config.secrets import ResolvedSecret
+        return ResolvedSecret(value=SecretStr(REFRESHED), provider="command", source_ref_redacted="<cmd>")
+
+    monkeypatch.setattr("graqle.config.secrets.resolve_secret", fake_resolve)
+    gb = GatewayBackend("http://x", model="m", api_key=TOKEN, on_auth_error="refresh-cmd")
+    r = await gb.generate("hi")
+    assert r.text == "ok"
+    assert calls["n"] == 1                         # refresh ran exactly once
+    assert _FakeClient.call_count == 2             # first 401, then retry
+    assert gb._api_key == REFRESHED                # token updated in place
+    assert _FakeClient.last_headers["Authorization"] == f"Bearer {REFRESHED}"
+
+
+@pytest.mark.asyncio
+async def test_second_401_raises_gateway_auth_error(monkeypatch):
+    _install_fake_httpx(monkeypatch, [_FakeResponse(401), _FakeResponse(401)])
+
+    def fake_resolve(name, cfg=None, *, default=None, provider=None, ref=None):
+        from graqle.config.resolver import SecretStr
+        from graqle.config.secrets import ResolvedSecret
+        return ResolvedSecret(value=SecretStr(REFRESHED), provider="command", source_ref_redacted="<cmd>")
+
+    monkeypatch.setattr("graqle.config.secrets.resolve_secret", fake_resolve)
+    gb = GatewayBackend("http://x", model="m", api_key=TOKEN, on_auth_error="refresh-cmd")
+    with pytest.raises(GatewayAuthError) as ei:
+        await gb.generate("hi")
+    assert TOKEN not in str(ei.value) and REFRESHED not in str(ei.value)  # no token in message
+
+
+@pytest.mark.asyncio
+async def test_on_auth_error_fail_no_refresh(monkeypatch):
+    _install_fake_httpx(monkeypatch, [_FakeResponse(401)])
+    gb = GatewayBackend("http://x", model="m", api_key=TOKEN, on_auth_error="fail")
+    with pytest.raises(GatewayAuthError):
+        await gb.generate("hi")
+    assert _FakeClient.call_count == 1  # no retry
+
+
+@pytest.mark.asyncio
+async def test_on_auth_error_none_no_refresh(monkeypatch):
+    _install_fake_httpx(monkeypatch, [_FakeResponse(401)])
+    gb = GatewayBackend("http://x", model="m", api_key=TOKEN, on_auth_error=None)
+    with pytest.raises(GatewayAuthError):
+        await gb.generate("hi")
+    assert _FakeClient.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_refresh_command_failure_surfaces_original_401(monkeypatch):
+    _install_fake_httpx(monkeypatch, [_FakeResponse(401)])
+
+    def boom(name, cfg=None, *, default=None, provider=None, ref=None):
+        raise RuntimeError("SECRET-REFRESH-INTERNAL-ERROR")
+
+    monkeypatch.setattr("graqle.config.secrets.resolve_secret", boom)
+    gb = GatewayBackend("http://x", model="m", api_key=TOKEN, on_auth_error="broken-cmd")
+    with pytest.raises(GatewayAuthError) as ei:
+        await gb.generate("hi")
+    # the refresh error must NOT surface — only the 401
+    assert "SECRET-REFRESH-INTERNAL-ERROR" not in str(ei.value)
+    assert gb._api_key == TOKEN  # token unchanged after failed refresh
+
+
+@pytest.mark.asyncio
+async def test_refresh_failure_logs_warning_without_secret(monkeypatch, caplog):
+    # M-1 (sentinel): a broken refresh must be visible via a WARNING log, but the
+    # log must contain only the exception TYPE — never the secret or stderr.
+    _install_fake_httpx(monkeypatch, [_FakeResponse(401)])
+
+    def boom(name, cfg=None, *, default=None, provider=None, ref=None):
+        raise RuntimeError("SECRET-REFRESH-INTERNAL-ERROR")
+
+    monkeypatch.setattr("graqle.config.secrets.resolve_secret", boom)
+    gb = GatewayBackend("http://x", model="m", api_key=TOKEN, on_auth_error="broken-cmd")
+    import logging
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(GatewayAuthError):
+            await gb.generate("hi")
+    warned = "\n".join(r.message for r in caplog.records if r.levelno >= logging.WARNING)
+    assert "refresh" in warned.lower()
+    assert "SECRET-REFRESH-INTERNAL-ERROR" not in warned  # only the type name
+    assert TOKEN not in warned
+
+
+@pytest.mark.asyncio
+async def test_on_auth_error_fail_case_insensitive(monkeypatch):
+    # m-2 hardening: 'FAIL'/'Fail' must also disable refresh (no silent typo trap).
+    _install_fake_httpx(monkeypatch, [_FakeResponse(401)])
+    gb = GatewayBackend("http://x", model="m", api_key=TOKEN, on_auth_error="FAIL")
+    with pytest.raises(GatewayAuthError):
+        await gb.generate("hi")
+    assert _FakeClient.call_count == 1  # no refresh attempted
+
+
+# ─────────────── CustomBackend regression ────────────────────────────────────
+
+
+def test_custombackend_headers_unchanged():
+    cb = CustomBackend("http://x", model="m", api_key=TOKEN)
+    h = cb._build_headers()
+    assert h == {"Content-Type": "application/json", "Authorization": f"Bearer {TOKEN}"}
+
+
+def test_custombackend_no_key_no_auth_header():
+    cb = CustomBackend("http://x", model="m", api_key=None)
+    assert "Authorization" not in cb._build_headers()
+
+
+# ─────────────── factory + no-leak ───────────────────────────────────────────
+
+
+def test_create_gateway_backend_factory():
+    from graqle.backends.providers import create_gateway_backend
+    gb = create_gateway_backend(
+        "http://gw/v1", "ns/prod", api_key=TOKEN, organization="org-9",
+        extra_headers={"Rpc-Caller": "x"}, model_allowlist=["ns/prod"], on_auth_error="fail",
+    )
+    assert isinstance(gb, GatewayBackend)
+    assert gb.name == "gateway:http://gw/v1"
+    assert gb._organization == "org-9"
+
+
+def test_token_not_in_backend_repr():
+    gb = GatewayBackend("http://x", model="m", api_key=TOKEN)
+    assert TOKEN not in repr(gb)
+    assert TOKEN not in gb.name


### PR DESCRIPTION
## CR-010.R4 — Enterprise-gateway LLM backend (`GatewayBackend`)

Public cherry-pick of private PR **#308** (merged to `research-development-graqle`, merge `453f5fcf`).
Second slice of the **Enterprise Enhancement Program** (CR-010) — requirement **R4 (P0)**: connect GraQle
to any corporate OpenAI-compatible gateway in **config alone**, no wrapper scripts.

### What this adds
- **`graqle/backends/api.py` → `GatewayBackend(CustomBackend)` + typed `GatewayAuthError`:**
  - `organization` → `OpenAI-Organization` header; `extra_headers` for custom RPC headers. **`Authorization`
    is reserved** — `extra_headers` can never null/replace the bearer token. `base_url` may be a localhost
    sidecar proxy.
  - `model_allowlist` → **client-side refusal before any network call** (`None` unrestricted, `[]` lockdown).
  - `on_auth_error` → on a 401, run the refresh command **once** via the R5 `command` secrets provider,
    refresh the token, retry **exactly once**; second 401 (or `fail`/`None`) raises `GatewayAuthError`
    (typed + non-retryable in the generic backoff). Refresh failures log a WARNING (exception **type only**
    — never the secret/stderr) and surface the original 401.
  - Token via R5 `SecretStr` → never in logs, error messages, or header-repr.
- **Refactor:** `CustomBackend` gains extracted `_build_headers()` / `_build_payload()`, **behaviour
  byte-identical** — existing callers unaffected (**141 backend tests green, 0 regression**).
- **`graqle/backends/providers.py` → `create_gateway_backend()`** factory for the `openai-compatible` stanza.

### Config stanza
```yaml
backend:
  type: openai-compatible
  base_url: ${GATEWAY_URL}            # incl. localhost sidecar proxies
  organization: <project-uuid>
  extra_headers: {Rpc-Caller: ..., Rpc-Service: ...}
  model_allowlist: [namespace/deployment-prod, ...]
  on_auth_error: refresh-command | fail
```

### Tests
`tests/test_backends/test_gateway_backend.py` — **19 tests** (headers, reserved-Authorization, allowlist
pre-HTTP refusal, 401-refresh-once, second-401, fail/none, refresh-failure no-leak + WARNING,
CustomBackend regression, factory). Verified green on this public base; 141 backend tests green.

### Community invariant
No trade-secret surface — backend request/response I/O only (**TS-1..TS-4 screen: 0 hits**). Verifier and
formats stay Apache-2.0 and un-gated.

---

**Governance:** CR-010.R4 · private PR #308 MERGED (`453f5fcf`) → this public cherry-pick per ABSOLUTE
RULE #0 · sentinel APPROVE 0-BLOCKER/0-MAJOR 91% (reason-fallback; found+fixed B-1 Authorization-clobber &
M-1 refresh-swallow; verified B-2) · TS-screen 0 hits · graq_learn `lesson_20260726T130253`. Depends on R5
(merged, public).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
