### PR TITLE
Release 0.81.0 (public) — Enterprise: secrets (R5) + gateway backend (R4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## 0.81.0 (2026-07-26) — [Enterprise: secrets providers + gateway backend]
+
+> First two P0 requirements of the Enterprise Enhancement Program (CR-010). Both are additive and
+> backward-compatible — existing configs and credential handling are unchanged.
+
+### Enterprise (CR-010 Enterprise Enhancement Program)
+
+- **Secrets provider abstraction (R5)** — new `secrets:` config resolution supporting
+  `env | file | keychain | command` providers via `graqle.config.secrets.resolve_secret`. The `file`
+  provider natively reads `$SECRETS_PATH/<name>`-style mounted secret stores, so moving from a developer
+  laptop (keychain) to a hosted environment (mounted file) is a one-line config change. Resolved values
+  are wrapped in `SecretStr` (never logged, printed, or embedded in errors); resolution is fail-closed
+  (a present-but-empty mounted secret file raises rather than silently returning empty). Behind
+  `GRAQLE_USE_SECRETS_RESOLVER` (default off) — no change to existing environment-variable behaviour.
+- **Enterprise-gateway LLM backend (R4)** — new `GatewayBackend` for any corporate OpenAI-compatible
+  gateway: an `organization` header, custom RPC `extra_headers` (the `Authorization` header is reserved
+  and cannot be overridden by config), a localhost sidecar `base_url`, a client-side `model_allowlist`
+  (disallowed models are refused before any network call), and an `on_auth_error` hook that on a 401
+  refreshes the token once via the R5 `command` provider and retries exactly once. `CustomBackend` gains
+  extracted `_build_headers()` / `_build_payload()` (behaviour unchanged for existing callers). New
+  `graqle.backends.providers.create_gateway_backend()` factory for the
+  `backend: {type: openai-compatible, ...}` config stanza.
+
+---
+
 ## 0.80.0 (2026-07-18) — [Plugin bundles + node-limit visibility (warn-only)]
 
 > Distribution: repo-scoped plugin bundles for Claude Code

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.80.0"
+__version__ = "0.81.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ name = "graqle"
 # (first-to-finish/best-of-N) + CostAwareRouter (auto cost/latency selection) —
 # dual-provider autonomy. 0.77.0 = ADR-239 Stage 2
 # (CheckpointProtocol + run_tests). 0.76.0 = ADR-225 G1 multi-tenant memory.
-version = "0.80.0"
+version = "0.81.0"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Release 0.81.0 (public) — Enterprise: secrets providers (R5) + gateway backend (R4)

Public cherry-pick of the version bump merged privately in PR #312 (`cd6ed7e8`). Puts **R4 + R5**
(already on public master) onto PyPI.

### Changes (version bump ONLY — 3 files)
- `pyproject.toml` + `graqle/__version__.py`: **0.80.0 → 0.81.0**
- `CHANGELOG.md`: 0.81.0 section (R5 secrets provider + R4 gateway backend)

### No mix-up guarantee
Cherry-picked **only** the bump commit `f55643df` (not the merge commit). Verified the diff is exactly the
3 files above and contains **none** of the concurrently-merged monetisation PR #313 files
(`scan.py`/`meter.py`/`test_limits_meter.py`) — that work is the monetisation session's, shipping on its
own version lane (NOT 0.81.0). TS-1..TS-4 screen: 0 hits.

### What ships in 0.81.0
- **R5** — `secrets:` resolver (`env|file|keychain|command`; `$SECRETS_PATH/<name>` mounts; `SecretStr`;
  fail-closed; behind `GRAQLE_USE_SECRETS_RESOLVER`, default off).
- **R4** — `GatewayBackend` for corporate OpenAI-compatible gateways (org/RPC headers, reserved
  `Authorization`, sidecar `base_url`, client-side `model_allowlist`, 401→refresh-once via R5 command
  provider) + `create_gateway_backend()` factory.

### After merge → release
Push `v0.81.0` tag → CI publishes to PyPI via Trusted Publishing (`ci.yml` `publish` job, `refs/tags/v*`).
`Release Gate (PyPI)` CI check infra-fails (`prediction provider FileNotFoundError`) — unrelated to this
change, not a publish blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
