### PR TITLE
chore(release): 0.82.0 — Enterprise R1 proof spec + conformance suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## 0.82.0 (2026-07-28) — [Enterprise: frozen proof spec + conformance suite]
+
+> Publishes GraQle's tamper-evidence proof format as an independently versioned, third-party-implementable
+> specification. Purely additive: no signing or verification logic changed, and every previously-issued
+> proof bundle continues to verify unchanged.
+
+### Enterprise (CR-010 Enterprise Enhancement Program)
+
+- **Frozen proof spec + conformance suite (R1)** — the proof-bundle envelope, the trusted-key manifest and
+  the verify-result contract are now published as versioned JSON Schemas plus prose at
+  `graqle/pct/schema/proof-spec/v1.0/` (`bundle`, `keyring`, `verify-result`, and `SPEC.md`). The spec
+  version (`graqle.pct.schema.SPEC_VERSION`) is **decoupled from the SDK version**: pinning to
+  `proof-spec/v1.0` does not pin you to a release. Schemas ship in the wheel and load through
+  `importlib.resources` via the new `load_proof_schema()` / `proof_schema_text()` helpers.
+- **Conformance corpus** — a declarative corpus at `graqle/pct/schema/conformance/` (manifest plus static,
+  reproducible golden vectors) covering every `VerifyFailure` classification plus the usage-error path.
+  Each case pins the typed failure, the process exit code, and the distinction between a check that did
+  not run (absent) and one that ran and failed (present and `false`). The corpus is consumed over a
+  subprocess/JSON boundary, so a third-party verifier can self-certify without importing GraQle — verified
+  by running the full corpus from an installed wheel.
+- **`graq attest verify` exit codes are now normative**: `0` verified, `1` did not verify, `2` usage error.
+  A usage error emits `{"ok": false, "error": ...}` and deliberately does not conform to the
+  verify-result schema, since no verification was attempted.
+- **Note for integrators** — `proof_format_version` is published as an **opaque, signature-covered**
+  string. It is covered by the signature and by the leaf hash, so a verifier must never rewrite or
+  normalize it; doing so invalidates an otherwise-valid signature. See `SPEC.md` §3.1 and §8.2.
+
+### Monetisation
+
+- **Tier-trust hardening (CR-LIC-03b)** — an unverified tier hint no longer grants entitlement. Tier
+  resolution consults the verified licence state first; the environment variable selects governance mode
+  only and is not an entitlement source.
+
+---
+
 ## 0.81.0 (2026-07-26) — [Enterprise: secrets providers + gateway backend]
 
 > First two P0 requirements of the Enterprise Enhancement Program (CR-010). Both are additive and

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.81.0"
+__version__ = "0.82.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ name = "graqle"
 # (first-to-finish/best-of-N) + CostAwareRouter (auto cost/latency selection) —
 # dual-provider autonomy. 0.77.0 = ADR-239 Stage 2
 # (CheckpointProtocol + run_tests). 0.76.0 = ADR-225 G1 multi-tenant memory.
-version = "0.81.0"
+version = "0.82.0"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Release 0.82.0 (public bump)

Cherry-pick of the **bump commit** `b51704d5` from private PR #320 (merged 2026-07-28T19:27:59Z, merge `35f2ccca`), applied onto public master `2821feb6` as `cd16bce5`.

**Version files only** — exactly 3: `pyproject.toml`, `graqle/__version__.py`, `CHANGELOG.md`. No code.

### What 0.82.0 ships

Everything already on public master since `v0.81.0`:

| Commit | Lane | Content |
|---|---|---|
| `eb5c41d7` | Enterprise (CR-010.R1) | Frozen proof spec v1.0 + conformance corpus |
| `426db271` | Monetisation (CR-LIC-03b) | Tier-trust hardening |

Owner approved this two-lane payload explicitly. CR-B10.5 (private #319) merged to *private* master after the bump but has **not** reached public, so it is correctly excluded from this release.

### Headline: R1 becomes usable

R1's whole value is in being installable. Until now the frozen proof spec existed only on master; after this release a third party can `pip install graqle==0.82.0` and implement a conformant verifier from the published schemas, `SPEC.md`, and golden vectors — no GraQle source required. `SPEC_VERSION` stays `1.0`, decoupled from the SDK version, so pinning to the spec does not pin to a release.

### Verified on this public base

- Diff is exactly the 3 version files; `pyproject.toml` and `__version__.py` both read `0.82.0`
- `SPEC_VERSION` still `1.0` across the bump (R1's acceptance criterion holds)
- **187 tests pass** in `tests/test_pct/`, including the full conformance corpus
- TS-1..TS-4 screen: **0 hits**

### After merge

Owner go-ahead required before tagging — `v0.82.0` triggers CI Trusted Publishing and a PyPI version can never be reused. Then verified from a neutral cwd in a clean venv.

⚠️ `Release Gate (PyPI)` fails with `release_gate prediction provider failed: FileNotFoundError` (exit 2) on content-only PRs — seen on #232, #241, and expected here. Gate tooling, not content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
