### PR TITLE
Release 0.83.0 — free-tier reasoning cap (W3) + scheduler contract (R6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,52 @@ All notable changes to GraQle are documented in this file.
 
 ---
 
+## 0.83.0 (2026-07-30) — [Enterprise: scheduler contract + free-tier reasoning cap]
+
+> ### ⚠️ BREAKING CHANGE — free tier only
+>
+> **Graph reasoning on the FREE tier is now capped per calendar month.** Once the cap is reached,
+> calls that previously succeeded raise **`ReasoningQuotaExceeded`**
+> (`from graqle.licensing.reasoning_quota import ReasoningQuotaExceeded`). This affects
+> `graph.reason()` / `areason()` and every CLI path built on them.
+> **Paid tiers are unaffected and see no behaviour change.**
+>
+> **If you are on the free tier, before upgrading:** either handle the exception at your reasoning
+> call sites, or move to a paid tier. To inspect usage without consuming quota,
+> `ReasoningQuota(graqle_dir).peek()` returns a `QuotaReading(used, limit, month, allowed)`
+> (`limit == -1` means unlimited). Unattended jobs are the exposed case — an uncaught
+> `ReasoningQuotaExceeded` will fail the run rather than degrade quietly.
+
+> The other half of this release is additive: it makes the CLI drivable by a scheduler rather than
+> only by a human. That part is **opt-in** — bare `graq rebuild` is unchanged from 0.82.0.
+
+### Enterprise (CR-010 Enterprise Enhancement Program)
+
+- **Scheduler-grade pipeline contract (R6)** — `graq rebuild` and `graq govern serve --once` can now be
+  driven unattended by cron, Airflow or GitHub Actions. New `--headless`, `--json`, `--report-json` and
+  `--incremental` flags on `graq rebuild`, and `--json` / `--report-json` on `govern serve --once`.
+  Runs are idempotent, non-interactive and exit-coded: `0` success, `1` failure, `2` usage error,
+  `3` empty delta (nothing to rebuild). `--report-json` writes a frozen `RunReport` atomically, so a
+  scheduler never observes a half-written report. Incremental rebuilds skip unchanged content by hash.
+- **Root defect fixed (opt-in)** — `graq rebuild` previously exited `0` even when the graph file was not
+  found, because Typer discards command return values. The corrected exit codes apply on the **machine
+  paths only** (`--headless` / `--json` / `--report-json`). Bare `graq rebuild` keeps its existing exit
+  behaviour and emits a stderr `DeprecationWarning`; whether it adopts the corrected codes is deferred
+  to a future release.
+
+### Monetisation
+
+- **⚠️ Reasoning-quota wall (ADR-245 Decision 8)** — the **free tier now has a monthly cap on graph
+  reasoning**. Existing free-tier users who exceed the cap will see `ReasoningQuotaExceeded` where calls
+  previously succeeded. Paid tiers are unaffected. The counter is per-month and self-pruning (13 months
+  retained).
+- The quota meter is deliberately **not** relocatable from the environment. `GRAQLE_QUOTA_DIR` is honoured
+  only inside a real pytest process (detected via `sys.modules`, not a self-attested environment
+  variable), so it cannot be used as a paywall bypass. This follows the same rule that makes
+  `quota_exempt()` refuse `CI=true`: self-attested environment exemptions are not entitlement.
+
+---
+
 ## 0.82.0 (2026-07-28) — [Enterprise: frozen proof spec + conformance suite]
 
 > Publishes GraQle's tamper-evidence proof format as an independently versioned, third-party-implementable

--- a/graqle/__version__.py
+++ b/graqle/__version__.py
@@ -5,4 +5,4 @@
 # constraints: none
 # ── /graqle:intelligence ──
 
-__version__ = "0.82.0"
+__version__ = "0.83.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,16 @@ build-backend = "hatchling.build"
 [project]
 name = "graqle"
 # V-ADR240-DELTA: native version bump (G4 config, CG-14 native-edit precedent).
-# 0.79.0 = ADR-242-A1 CR-SEED-02: graqle.workflow.seed — seed a project graph
+# 0.83.0 = CR-010 R6 scheduler contract (--headless/--json/--report-json,
+# exit codes 0/1/2/3) + ADR-245 W3 reasoning-quota wall (free monthly cap on
+# graph reasoning). 0.79.0 = ADR-242-A1 CR-SEED-02: graqle.workflow.seed — seed a project graph
 # from goal + build profile + source chunks before any code exists, and the
 # flat-scanner-shape serializer for raw-dict graph consumers; additive,
 # backward-compatible, no IP concern. 0.78.0 = ADR-240 D1+D2: BackendRaceChain
 # (first-to-finish/best-of-N) + CostAwareRouter (auto cost/latency selection) —
 # dual-provider autonomy. 0.77.0 = ADR-239 Stage 2
 # (CheckpointProtocol + run_tests). 0.76.0 = ADR-225 G1 multi-tenant memory.
-version = "0.82.0"
+version = "0.83.0"
 description = "Give your AI tools architecture-aware reasoning. Build a knowledge graph from any codebase — dependency analysis, impact analysis, governed AI answers with confidence scores. Works with Claude Code, Cursor, VS Code Copilot. 14 LLM backends, fully offline capable."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Release 0.83.0 — free-tier reasoning cap (W3) + scheduler contract (R6)

Public port of private **#326** (`28398970`), merged 2026-07-31. Version files are
**byte-identical to `private/master`**. 3 files: `pyproject.toml`, `graqle/__version__.py`,
`CHANGELOG.md`. No code changes — the code already landed in **#245**.

### ⚠️ Contains a BREAKING CHANGE for the free tier

Reasoning on the free tier is now capped per calendar month; over the cap, calls that
previously succeeded raise `ReasoningQuotaExceeded`. **Paid tiers are unaffected.** The
CHANGELOG leads with the notice, names the exception and its import path, and gives the
upgrade path — this is the first release where a previously-working call can fail, so it
is called out at the top rather than buried in a feature list.

### What ships

| | |
|---|---|
| **W3 reasoning-quota wall** (ADR-245 Decision 8) | free monthly cap; gate at the SDK primitive so CLI, MCP, chat and server API are all covered; `areason_stream` and `graq debate` carry their own gates (they never reach `areason`) |
| **CR-010.R6 scheduler contract** | `--headless` / `--json`, normative exit codes, content-hash incremental `rebuild` |

### Verified from the built wheel — not source

Built `graqle-0.83.0-py3-none-any.whl`, installed it into a **clean venv**, and exercised
the wall end-to-end:

```
1) free user at cap, enforcement default ON   → BLOCKED  (quota reached: 30/30)
2) old bypass: GRAQLE_QUOTA_DIR repointed to a
   fresh dir + PYTEST_CURRENT_TEST forged      → STILL BLOCKED, resolves .graqle
3) internal=True (sanctioned tooling)          → ALLOWED
```

Wheel contents confirmed: `reasoning_gate.py` + `reasoning_quota.py` **ship**; the
`sys.modules` guard is **present**; the unconditional `GRAQLE_QUOTA_DIR` override is
**gone**; month-pruning is in; `graqle/cloud/*` and `graqle/server/*` are **stripped**
(0 entries each).

> This closes the one verification gap I had flagged as outstanding: previously only the
> wheel's *contents* were checked, never an actual install.

### Ordering

`private #325` (back-port of the paywall-bypass fix) was merged **before** `#326`, so the
release is cut from a private master that no longer contains the vulnerable
`resolve_quota_dir()`. Confirmed on `private/master`: unconditional override **gone**,
`sys.modules` guard present, version `0.83.0`.

### Rule #0

`git remote -v` run before push. Public cherry-pick authorised **only** because private
#326 is merged (`2026-07-31T12:28:52`, base advanced to `9fee93ac`). Sequential gate
satisfied.

### After merge

Tag `v0.83.0` → PyPI publishes → MCP Registry auto-follows.

**Known red:** `Release Gate (PyPI)` — documented repo-wide infra flake (`FileNotFoundError`,
exit 2) that also failed on #243, #244 and #245, all of which merged. Needs an
owner-approved infra fix (empty `GRAQLE_LICENSE` secret); unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
